### PR TITLE
feat(ai): add OpenAI API compatible provider support

### DIFF
--- a/.trae/specs/add-openai-compatible-provider/checklist.md
+++ b/.trae/specs/add-openai-compatible-provider/checklist.md
@@ -1,0 +1,7 @@
+- [x] 成功创建 `infrastructure/ai/providers/openai_provider.py` 并实现 `OpenAIProvider` 类。
+- [x] `OpenAIProvider.generate` 方法可以正确组装 Prompt 并返回 `GenerationResult`，且带 `TokenUsage` 统计。
+- [x] `OpenAIProvider.stream_generate` 能够异步产生文本块 (SSE event handling 或使用 `AsyncOpenAI` 的 stream 模式)。
+- [x] `interfaces/api/dependencies.py` 内部引入了获取 OpenAI Settings 的辅助函数。
+- [x] 所有 `interfaces/api/dependencies.py` 内原来硬编码 `AnthropicProvider` 的逻辑（如 `get_auto_workflow`、`get_auto_knowledge_generator` 等）全部改为统一获取当前生效的 Provider（根据环境变量 `LLM_PROVIDER`）。
+- [x] 项目中已引入必要的依赖（如 `openai` 库）并在 `requirements.txt` 中。
+- [x] 测试运行应用（或者模拟调用 `dependencies.get_llm_service()`），确认能根据配置实例化 `OpenAIProvider` 或 `AnthropicProvider` 并且无语法错误。

--- a/.trae/specs/add-openai-compatible-provider/spec.md
+++ b/.trae/specs/add-openai-compatible-provider/spec.md
@@ -1,0 +1,28 @@
+# 兼容 OpenAI 的大模型提供商支持 Spec
+
+## Why
+目前系统默认强绑定 Anthropic (Claude) 作为大语言模型提供商，在 `interfaces/api/dependencies.py` 等多处硬编码了 `AnthropicProvider`。为了让系统兼容更多的大模型（如 GPT-4, DeepSeek, 豆包等），我们需要引入兼容 OpenAI API 标准的 `OpenAIProvider`，并通过环境变量支持在不同模型提供商之间切换。
+
+## What Changes
+- **新增** `OpenAIProvider`：在 `infrastructure/ai/providers/openai_provider.py` 中实现，继承 `BaseProvider`，并使用 `openai` SDK 或 `httpx` 实现 `generate` 和 `stream_generate` 方法。
+- **修改** 依赖注入 `interfaces/api/dependencies.py`：引入 `LLM_PROVIDER` 环境变量（可选值为 `openai` 或 `anthropic`），并根据配置动态返回对应的 Provider。
+- **修改** 获取环境配置的逻辑：新增获取 `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL` 的相关函数。
+- **兼容性**：确保原有的 `AnthropicProvider` 功能不受影响，并在没有配置时依然可以降级为 `MockProvider`。
+
+## Impact
+- Affected specs: 系统的核心 AI 调用链路、各业务模块的依赖注入流程。
+- Affected code: 
+  - `infrastructure/ai/providers/openai_provider.py` (新增)
+  - `interfaces/api/dependencies.py`
+
+## ADDED Requirements
+### Requirement: 兼容 OpenAI API 的 LLM 服务
+系统应当能够通过配置使用符合 OpenAI 接口标准的大模型服务。
+
+#### Scenario: Success case
+- **WHEN** 用户在环境变量中设置 `LLM_PROVIDER=openai`, 并且配置了 `OPENAI_API_KEY`（以及可选的 `OPENAI_BASE_URL`）
+- **THEN** 系统在获取 LLM 服务时应返回 `OpenAIProvider` 实例，所有大模型调用（文本生成、流式生成）将路由至对应的 OpenAI 兼容接口。
+
+## MODIFIED Requirements
+### Requirement: 动态模型提供商选择
+原系统只检测 Anthropic 的 API Key，现在应根据 `LLM_PROVIDER` 选择对应的初始化逻辑，并在指定服务未配置时优雅降级为 `MockProvider`。

--- a/.trae/specs/add-openai-compatible-provider/tasks.md
+++ b/.trae/specs/add-openai-compatible-provider/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+- [x] Task 1: 实现 `OpenAIProvider` 核心逻辑
+  - [x] SubTask 1.1: 在 `infrastructure/ai/providers/openai_provider.py` 中创建 `OpenAIProvider`，继承 `BaseProvider`。
+  - [x] SubTask 1.2: 使用 `openai.AsyncOpenAI` 或 `httpx` 实现异步 `generate` 方法，接收 `Prompt` 和 `GenerationConfig`，返回 `GenerationResult`，并处理 token usage。
+  - [x] SubTask 1.3: 实现异步流式 `stream_generate` 方法，处理 SSE 流返回文本数据。
+- [x] Task 2: 修改依赖注入配置 `interfaces/api/dependencies.py`
+  - [x] SubTask 2.1: 增加对 `OPENAI_API_KEY`、`OPENAI_BASE_URL` 和 `OPENAI_MODEL` 的环境变量读取和验证逻辑 (`_openai_settings`)。
+  - [x] SubTask 2.2: 根据 `LLM_PROVIDER`（默认 `openai` 或 `anthropic`）动态返回对应的 `Provider` 实例（在 `get_llm_service`, `get_auto_workflow`, `get_auto_bible_generator` 等相关所有直接使用 `AnthropicProvider` 的地方进行替换或抽象）。
+
+# Task Dependencies
+- [Task 2] depends on [Task 1]

--- a/infrastructure/ai/providers/__init__.py
+++ b/infrastructure/ai/providers/__init__.py
@@ -1,5 +1,6 @@
 """Infrastructure AI providers module"""
 from .base import BaseProvider
 from .anthropic_provider import AnthropicProvider
+from .openai_provider import OpenAIProvider
 
-__all__ = ["BaseProvider", "AnthropicProvider"]
+__all__ = ["BaseProvider", "AnthropicProvider", "OpenAIProvider"]

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -1,0 +1,135 @@
+"""OpenAI LLM 提供商实现"""
+import logging
+import os
+from typing import AsyncIterator
+
+from openai import AsyncOpenAI
+
+from domain.ai.services.llm_service import GenerationConfig, GenerationResult
+from domain.ai.value_objects.prompt import Prompt
+from domain.ai.value_objects.token_usage import TokenUsage
+from infrastructure.ai.config.settings import Settings
+from .base import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+# 从环境变量读取模型配置，默认使用 gpt-4o
+DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+
+class OpenAIProvider(BaseProvider):
+    """OpenAI LLM 提供商实现
+    
+    使用 OpenAI API 实现 LLM 服务。
+    """
+
+    def __init__(self, settings: Settings):
+        """初始化 OpenAI 提供商
+        
+        Args:
+            settings: AI 配置设置
+            
+        Raises:
+            ValueError: 如果 API key 未设置
+        """
+        super().__init__(settings)
+        
+        if not settings.api_key:
+            raise ValueError("API key is required for OpenAIProvider")
+            
+        # 初始化 AsyncOpenAI 客户端
+        client_kwargs = {
+            "api_key": settings.api_key,
+        }
+        if settings.base_url:
+            client_kwargs["base_url"] = settings.base_url
+            
+        self.async_client = AsyncOpenAI(**client_kwargs)
+
+    async def generate(
+        self,
+        prompt: Prompt,
+        config: GenerationConfig
+    ) -> GenerationResult:
+        """生成文本
+        
+        Args:
+            prompt: 提示词
+            config: 生成配置
+            
+        Returns:
+            生成结果
+            
+        Raises:
+            RuntimeError: 当 API 调用失败或返回空内容时
+        """
+        try:
+            messages = [
+                {"role": "system", "content": prompt.system},
+                {"role": "user", "content": prompt.user}
+            ]
+            
+            response = await self.async_client.chat.completions.create(
+                model=config.model or DEFAULT_MODEL,
+                messages=messages,
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
+            )
+            
+            if not response.choices or not response.choices[0].message.content:
+                raise RuntimeError("API returned empty content")
+                
+            content = response.choices[0].message.content
+            
+            input_tokens = response.usage.prompt_tokens if response.usage else 0
+            output_tokens = response.usage.completion_tokens if response.usage else 0
+            token_usage = TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens
+            )
+            
+            return GenerationResult(content=content, token_usage=token_usage)
+            
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate text: {str(e)}") from e
+
+    async def stream_generate(
+        self,
+        prompt: Prompt,
+        config: GenerationConfig
+    ) -> AsyncIterator[str]:
+        """流式生成内容
+        
+        Args:
+            prompt: 提示词
+            config: 生成配置
+            
+        Yields:
+            生成的文本片段
+            
+        Raises:
+            RuntimeError: 当流式生成失败时
+        """
+        try:
+            messages = [
+                {"role": "system", "content": prompt.system},
+                {"role": "user", "content": prompt.user}
+            ]
+            
+            stream = await self.async_client.chat.completions.create(
+                model=config.model or DEFAULT_MODEL,
+                messages=messages,
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
+                stream=True,
+            )
+            
+            async for chunk in stream:
+                if chunk.choices and chunk.choices[0].delta.content:
+                    yield chunk.choices[0].delta.content
+                    
+        except Exception as e:
+            logger.error(f"[Stream] Failed: {e}")
+            raise RuntimeError(f"Failed to stream text: {str(e)}") from e

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -88,6 +88,31 @@ def _anthropic_settings(require_key: bool = True) -> Optional[Settings]:
     return Settings(api_key=key, base_url=_anthropic_base_url())
 
 
+def _openai_api_key() -> Optional[str]:
+    raw = os.getenv("OPENAI_API_KEY")
+    if raw is None:
+        return None
+    key = raw.strip()
+    return key or None
+
+
+def _openai_base_url() -> Optional[str]:
+    u = os.getenv("OPENAI_BASE_URL")
+    return u.strip() if u and u.strip() else None
+
+
+def _openai_settings(require_key: bool = True) -> Optional[Settings]:
+    """构建 OpenAI Settings；require_key=False 时无密钥返回 None。"""
+    key = _openai_api_key()
+    if not key:
+        if require_key:
+            raise ValueError(
+                "Set OPENAI_API_KEY (optional: OPENAI_BASE_URL)"
+            )
+        return None
+    return Settings(api_key=key, base_url=_openai_base_url())
+
+
 def get_storage() -> FileStorage:
     """获取存储后端实例
 
@@ -286,12 +311,20 @@ def get_hosted_write_service() -> HostedWriteService:
 
 
 def get_llm_service():
-    """获取 LLM 服务实例（有 API Key 用 Anthropic，否则 Mock）。供多模块复用。"""
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        return AnthropicProvider(settings)
+    """获取 LLM 服务实例（根据 LLM_PROVIDER 决定使用 OpenAI 或 Anthropic，无配置用 Mock）。供多模块复用。"""
+    provider = os.getenv("LLM_PROVIDER", "anthropic").lower()
+    
+    if provider == "openai":
+        settings = _openai_settings(require_key=False)
+        if settings:
+            from infrastructure.ai.providers.openai_provider import OpenAIProvider
+            return OpenAIProvider(settings)
+    else:
+        settings = _anthropic_settings(require_key=False)
+        if settings:
+            return AnthropicProvider(settings)
+            
     from infrastructure.ai.providers.mock_provider import MockProvider
-
     return MockProvider()
 
 
@@ -525,14 +558,12 @@ def get_auto_workflow() -> AutoNovelGenerationWorkflow:
     Returns:
         AutoNovelGenerationWorkflow 实例
     """
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for workflow")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
+    llm_service = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_service, MockProvider):
         logger.warning("No API key found, using MockProvider for workflow")
+    else:
+        logger.info(f"Using {llm_service.__class__.__name__} for workflow")
 
     return build_auto_workflow(llm_service)
 
@@ -543,15 +574,12 @@ def get_auto_bible_generator() -> AutoBibleGenerator:
     Returns:
         AutoBibleGenerator 实例
     """
-    # Try to get Anthropic settings, fall back to mock if no API key
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for Bible generation")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
+    llm_service = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_service, MockProvider):
         logger.warning("No API key found, using MockProvider for Bible generation")
+    else:
+        logger.info(f"Using {llm_service.__class__.__name__} for Bible generation")
 
     # 导入 WorldbuildingService 和 TripleRepository
     from application.world.services.worldbuilding_service import WorldbuildingService
@@ -578,13 +606,7 @@ def get_state_extractor() -> StateExtractor:
     Returns:
         StateExtractor 实例
     """
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
-    return StateExtractor(llm_service=llm_service)
+    return StateExtractor(llm_service=get_llm_service())
 
 
 def get_auto_knowledge_generator() -> AutoKnowledgeGenerator:
@@ -593,14 +615,8 @@ def get_auto_knowledge_generator() -> AutoKnowledgeGenerator:
     Returns:
         AutoKnowledgeGenerator 实例
     """
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
     return AutoKnowledgeGenerator(
-        llm_service=llm_service,
+        llm_service=get_llm_service(),
         knowledge_service=get_knowledge_service()
     )
 
@@ -628,14 +644,12 @@ def get_beat_sheet_service():
     """
     from application.blueprint.services.beat_sheet_service import BeatSheetService
 
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for beat sheet generation")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
+    llm_service = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_service, MockProvider):
         logger.warning("No API key found, using MockProvider for beat sheet generation")
+    else:
+        logger.info(f"Using {llm_service.__class__.__name__} for beat sheet generation")
 
     return BeatSheetService(
         beat_sheet_repo=get_beat_sheet_repository(),
@@ -655,14 +669,12 @@ def get_scene_generation_service():
     """
     from application.core.services.scene_generation_service import SceneGenerationService
 
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for scene generation")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
+    llm_service = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_service, MockProvider):
         logger.warning("No API key found, using MockProvider for scene generation")
+    else:
+        logger.info(f"Using {llm_service.__class__.__name__} for scene generation")
 
     return SceneGenerationService(
         llm_service=llm_service,
@@ -680,14 +692,13 @@ def get_scene_director_service() -> "SceneDirectorService":
     """
     from application.engine.services.scene_director_service import SceneDirectorService
 
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for scene director")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
+    llm_service = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_service, MockProvider):
         logger.warning("No API key found, using MockProvider for scene director")
+    else:
+        logger.info(f"Using {llm_service.__class__.__name__} for scene director")
+        
     return SceneDirectorService(llm_service=llm_service)
 
 
@@ -779,14 +790,12 @@ def get_macro_refactor_proposal_service():
     """
     from application.audit.services.macro_refactor_proposal_service import MacroRefactorProposalService
 
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_service = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for macro refactor proposals")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_service = MockProvider()
+    llm_service = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_service, MockProvider):
         logger.warning("No API key found, using MockProvider for macro refactor proposals")
+    else:
+        logger.info(f"Using {llm_service.__class__.__name__} for macro refactor proposals")
 
     return MacroRefactorProposalService(llm_service)
 
@@ -830,14 +839,12 @@ def get_tension_analyzer():
     from infrastructure.persistence.database.sqlite_narrative_event_repository import SqliteNarrativeEventRepository
     from infrastructure.ai.llm_client import LLMClient
 
-    settings = _anthropic_settings(require_key=False)
-    if settings:
-        llm_provider = AnthropicProvider(settings)
-        logger.info("Using AnthropicProvider for tension analyzer")
-    else:
-        from infrastructure.ai.providers.mock_provider import MockProvider
-        llm_provider = MockProvider()
+    llm_provider = get_llm_service()
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    if isinstance(llm_provider, MockProvider):
         logger.warning("No API key found, using MockProvider for tension analyzer")
+    else:
+        logger.info(f"Using {llm_provider.__class__.__name__} for tension analyzer")
 
     llm_client = LLMClient(provider=llm_provider)
     narrative_event_repo = SqliteNarrativeEventRepository(get_database())


### PR DESCRIPTION
## Why
The current system strictly binds to Anthropic (Claude) as the LLM provider, with `AnthropicProvider` hardcoded in `interfaces/api/dependencies.py` and other modules. To support a broader range of LLMs (such as GPT-4, DeepSeek, etc.) that comply with the OpenAI API standard, we need to introduce an `OpenAIProvider` and enable dynamic switching via environment variables.

## What Changes
- **Added `OpenAIProvider`**: Implemented in `infrastructure/ai/providers/openai_provider.py`, using `openai.AsyncOpenAI` for both standard and streaming text generation.
- **Refactored Dependency Injection**: Updated `interfaces/api/dependencies.py` to decouple hardcoded LLM initializations. 
- **Dynamic Provider Selection**: Introduced the `LLM_PROVIDER` environment variable (defaults to `anthropic` for backward compatibility, optionally `openai`).
- **New Configurations**: Added `OPENAI_API_KEY`, `OPENAI_BASE_URL` and `OPENAI_MODEL` reading logic. Ensures a graceful fallback to `MockProvider` if credentials are missing.

## Testing
- [x] Verified `OpenAIProvider` text generation and token usage handling.
- [x] Verified `OpenAIProvider` async SSE streaming text generation logic.
- [x] Verified successful integration with DI container across all relevant workflows and engine services.