### PR TITLE
Restore legacy stats import paths after module reorganization

### DIFF
--- a/aitext/__init__.py
+++ b/aitext/__init__.py
@@ -1,0 +1,2 @@
+"""Backward-compatible exports for the historic ``aitext`` package."""
+

--- a/aitext/web/__init__.py
+++ b/aitext/web/__init__.py
@@ -1,0 +1,2 @@
+"""Compatibility exports for the historic ``aitext.web`` package."""
+

--- a/aitext/web/models/__init__.py
+++ b/aitext/web/models/__init__.py
@@ -1,0 +1,12 @@
+"""Compatibility exports for the historic ``aitext.web.models`` package."""
+
+from .stats_models import BookStats, ChapterStats, ContentAnalysis, GlobalStats, WritingProgress
+
+__all__ = [
+    "BookStats",
+    "ChapterStats",
+    "ContentAnalysis",
+    "GlobalStats",
+    "WritingProgress",
+]
+

--- a/aitext/web/models/stats_models.py
+++ b/aitext/web/models/stats_models.py
@@ -1,0 +1,17 @@
+"""Compatibility wrapper for the historic ``aitext.web.models.stats_models`` path."""
+
+from web.models.stats_models import (
+    BookStats,
+    ChapterStats,
+    ContentAnalysis,
+    GlobalStats,
+    WritingProgress,
+)
+
+__all__ = [
+    "BookStats",
+    "ChapterStats",
+    "ContentAnalysis",
+    "GlobalStats",
+    "WritingProgress",
+]

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,2 @@
+"""Backward-compatible exports for the legacy ``web`` package."""
+

--- a/web/middleware/__init__.py
+++ b/web/middleware/__init__.py
@@ -1,0 +1,21 @@
+"""Compatibility exports for legacy web middleware."""
+
+from .error_handler import (
+    STATUS_CODE_MAP,
+    add_error_handlers,
+    generic_exception_handler,
+    http_exception_handler,
+    validation_exception_handler,
+)
+from .logging_config import get_logger, setup_logging
+
+__all__ = [
+    "STATUS_CODE_MAP",
+    "add_error_handlers",
+    "generic_exception_handler",
+    "get_logger",
+    "http_exception_handler",
+    "setup_logging",
+    "validation_exception_handler",
+]
+

--- a/web/middleware/error_handler.py
+++ b/web/middleware/error_handler.py
@@ -1,0 +1,18 @@
+"""Compatibility wrapper for the legacy error handler import path."""
+
+from interfaces.api.middleware.error_handler import (
+    STATUS_CODE_MAP,
+    add_error_handlers,
+    generic_exception_handler,
+    http_exception_handler,
+    validation_exception_handler,
+)
+
+__all__ = [
+    "STATUS_CODE_MAP",
+    "add_error_handlers",
+    "generic_exception_handler",
+    "http_exception_handler",
+    "validation_exception_handler",
+]
+

--- a/web/middleware/logging_config.py
+++ b/web/middleware/logging_config.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the legacy logging config import path."""
+
+from interfaces.api.middleware.logging_config import get_logger, setup_logging
+
+__all__ = ["get_logger", "setup_logging"]
+

--- a/web/models/__init__.py
+++ b/web/models/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility exports for legacy web models."""
+
+from .responses import ErrorResponse, PaginatedResponse, SuccessResponse
+from .stats_models import BookStats, ChapterStats, ContentAnalysis, GlobalStats, WritingProgress
+
+__all__ = [
+    "BookStats",
+    "ChapterStats",
+    "ContentAnalysis",
+    "ErrorResponse",
+    "GlobalStats",
+    "PaginatedResponse",
+    "SuccessResponse",
+    "WritingProgress",
+]
+

--- a/web/models/responses.py
+++ b/web/models/responses.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for legacy response model imports."""
+
+from interfaces.api.stats.models.responses import ErrorResponse, PaginatedResponse, SuccessResponse
+
+__all__ = ["ErrorResponse", "PaginatedResponse", "SuccessResponse"]
+

--- a/web/models/stats_models.py
+++ b/web/models/stats_models.py
@@ -1,0 +1,18 @@
+"""Compatibility wrapper for legacy statistics model imports."""
+
+from interfaces.api.stats.models.stats_models import (
+    BookStats,
+    ChapterStats,
+    ContentAnalysis,
+    GlobalStats,
+    WritingProgress,
+)
+
+__all__ = [
+    "BookStats",
+    "ChapterStats",
+    "ContentAnalysis",
+    "GlobalStats",
+    "WritingProgress",
+]
+

--- a/web/repositories/__init__.py
+++ b/web/repositories/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility exports for legacy web repositories."""
+
+from .stats_repository import StatsRepository
+from .stats_repository_adapter import StatsRepositoryAdapter
+
+__all__ = ["StatsRepository", "StatsRepositoryAdapter"]
+

--- a/web/repositories/stats_repository.py
+++ b/web/repositories/stats_repository.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the legacy stats repository import path."""
+
+from interfaces.api.stats.repositories.stats_repository import StatsRepository
+
+__all__ = ["StatsRepository"]
+

--- a/web/repositories/stats_repository_adapter.py
+++ b/web/repositories/stats_repository_adapter.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the legacy stats repository adapter import path."""
+
+from interfaces.api.stats.repositories.stats_repository_adapter import StatsRepositoryAdapter
+
+__all__ = ["StatsRepositoryAdapter"]
+

--- a/web/routers/__init__.py
+++ b/web/routers/__init__.py
@@ -1,0 +1,6 @@
+"""Compatibility exports for legacy web routers."""
+
+from .stats import create_stats_router
+
+__all__ = ["create_stats_router"]
+

--- a/web/routers/stats.py
+++ b/web/routers/stats.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the legacy stats router import path."""
+
+from interfaces.api.stats.routers.stats import create_stats_router
+
+__all__ = ["create_stats_router"]
+

--- a/web/services/__init__.py
+++ b/web/services/__init__.py
@@ -1,0 +1,6 @@
+"""Compatibility exports for legacy web services."""
+
+from .stats_service import StatsService
+
+__all__ = ["StatsService"]
+

--- a/web/services/stats_service.py
+++ b/web/services/stats_service.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for the legacy stats service import path."""
+
+from interfaces.api.stats.services.stats_service import StatsService
+
+__all__ = ["StatsService"]
+


### PR DESCRIPTION
## 变更说明
- 恢复 `web.*` 旧导入路径对 stats 模块的兼容访问
- 恢复 `aitext.web.models.stats_models` 的兼容导入入口
- 保持实际实现仍位于 `interfaces.api.*`，仅增加薄兼容层，避免重复逻辑

## 测试
- [x] 本地已跑核心用例：`pytest -q tests/web`
- [x] 兼容包可正常编译：`python -m compileall web aitext`
- [ ] 关键路径手测通过（本次未做前后端联调）

## 风险与回滚
- 风险：本次仅恢复 stats 相关历史导入路径，仓库中其他旧路径或缺失依赖问题仍可能导致全量 `pytest` 失败
- 回滚方式：删除新增的 `web/` 和 `aitext/web/` 兼容层文件即可
