### PR TITLE
fix: avoid Windows Unicode logging errors during startup

### DIFF
--- a/interfaces/api/middleware/logging_config.py
+++ b/interfaces/api/middleware/logging_config.py
@@ -14,6 +14,39 @@ VALID_LOGGING_LEVELS = [
 ]
 
 
+class SafeConsoleHandler(logging.StreamHandler):
+    """Console handler that degrades gracefully on encoding errors.
+
+    Windows terminals commonly default to legacy encodings such as GBK.
+    When log messages contain emoji or other non-representable characters,
+    the standard StreamHandler can trigger UnicodeEncodeError while writing
+    to stderr/stdout. This handler falls back to an ASCII-safe escaped
+    representation instead of crashing the log emission path.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit a record, escaping unsupported characters when needed."""
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            try:
+                stream.write(msg + self.terminator)
+            except UnicodeEncodeError:
+                safe_msg = self._escape_for_stream(msg + self.terminator, stream)
+                stream.write(safe_msg)
+            self.flush()
+        except RecursionError:
+            raise
+        except Exception:
+            self.handleError(record)
+
+    @staticmethod
+    def _escape_for_stream(text: str, stream) -> str:
+        """Convert text to a stream-safe escaped representation."""
+        encoding = getattr(stream, "encoding", None) or "utf-8"
+        return text.encode(encoding, errors="backslashreplace").decode(encoding)
+
+
 def _validate_logging_level(level: int) -> None:
     """Validate that the logging level is a valid Python logging level.
 
@@ -46,7 +79,6 @@ def _validate_log_file(log_file: str) -> None:
     if not log_file or not log_file.strip():
         raise ValueError("log_file cannot be empty or whitespace")
 
-    # Try to create parent directories if they don't exist
     try:
         log_dir = os.path.dirname(log_file)
         if log_dir and not os.path.exists(log_dir):
@@ -54,10 +86,7 @@ def _validate_log_file(log_file: str) -> None:
     except (OSError, IOError) as e:
         raise ValueError(f"Cannot create log directory: {e}")
 
-    # Check if we can write to the location
     try:
-        # Try to open the file in append mode to check writability
-        # This will fail if the path is invalid or not writable
         test_handle = open(log_file, 'a')
         test_handle.close()
     except (OSError, IOError, PermissionError) as e:
@@ -80,52 +109,41 @@ def setup_logging(
         ValueError: If logging level or log file path is invalid
         TypeError: If log_file parameter is not a string when provided
     """
-    # Validate logging level
     _validate_logging_level(level)
 
-    # Clear any existing handlers
     root_logger = logging.getLogger()
     for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
 
-    # Set the root logging level
     root_logger.setLevel(level)
 
-    # Create formatters with different date formats for console and file
     console_formatter = logging.Formatter(
         format_string,
         datefmt="%H:%M:%S"
     )
 
-    # Console handler
-    console_handler = logging.StreamHandler()
+    console_handler = SafeConsoleHandler()
     console_handler.setLevel(level)
     console_handler.setFormatter(console_formatter)
     root_logger.addHandler(console_handler)
 
-    # File handler (optional) with error handling
     if log_file is not None:
-        # Validate log file path BEFORE trying to create handler
-        # Validation errors should be raised immediately
         _validate_log_file(log_file)
 
-        # Only catch file creation errors, not validation errors
         try:
             file_formatter = logging.Formatter(
                 format_string,
                 datefmt="%Y-%m-%d %H:%M:%S"
             )
-            file_handler = logging.FileHandler(log_file)
+            file_handler = logging.FileHandler(log_file, encoding="utf-8")
             file_handler.setLevel(level)
             file_handler.setFormatter(file_formatter)
             root_logger.addHandler(file_handler)
 
         except (OSError, IOError, PermissionError) as e:
-            # Log a warning if file handler creation fails, but continue with console only
             print(f"WARNING: Failed to setup file logging: {e}")
             print("Logging will continue with console output only.")
 
-    # Uvicorn：保留默认访问日志格式（INFO: 127.0.0.1:port - "GET ..." 200 OK）
     logging.getLogger("uvicorn").setLevel(logging.WARNING)
     logging.getLogger("uvicorn.access").setLevel(logging.INFO)
     logging.getLogger("fastapi").setLevel(logging.WARNING)

--- a/tests/web/middleware/test_logging_config.py
+++ b/tests/web/middleware/test_logging_config.py
@@ -1,5 +1,6 @@
 """Tests for unified logging configuration."""
 
+import io
 import logging
 import os
 import tempfile
@@ -7,13 +8,16 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from interfaces.api.middleware.logging_config import get_logger, setup_logging
+from interfaces.api.middleware.logging_config import (
+    SafeConsoleHandler,
+    get_logger,
+    setup_logging,
+)
 
 
 @pytest.fixture
 def reset_logging():
     """Reset logging configuration before and after each test."""
-    # Clear all handlers before test
     root_logger = logging.getLogger()
     handlers = root_logger.handlers[:]
     for handler in handlers:
@@ -22,7 +26,6 @@ def reset_logging():
 
     yield
 
-    # Clear all handlers after test
     root_logger = logging.getLogger()
     handlers = root_logger.handlers[:]
     for handler in handlers:
@@ -39,16 +42,13 @@ class TestSetupLogging:
 
         root_logger = logging.getLogger()
 
-        # Verify root logger level
         assert root_logger.level == logging.DEBUG
 
-        # Verify we have a console handler
         assert len(root_logger.handlers) == 1
         handler = root_logger.handlers[0]
-        assert isinstance(handler, logging.StreamHandler)
+        assert isinstance(handler, SafeConsoleHandler)
         assert handler.level == logging.DEBUG
 
-        # Verify formatter
         formatter = handler.formatter
         assert formatter is not None
         assert "%(levelname)s" in formatter._fmt
@@ -58,71 +58,58 @@ class TestSetupLogging:
         """Test logging setup with both console and file output."""
         temp_dir = tempfile.mkdtemp()
         try:
-            log_file_path = os.path.join(temp_dir, 'test.log')
+            log_file_path = os.path.join(temp_dir, "test.log")
 
             setup_logging(level=logging.INFO, log_file=log_file_path)
 
             root_logger = logging.getLogger()
 
-            # Verify root logger level
             assert root_logger.level == logging.INFO
-
-            # Verify we have two handlers (console and file)
             assert len(root_logger.handlers) == 2
 
-            # Verify console handler
             console_handler = root_logger.handlers[0]
-            assert isinstance(console_handler, logging.StreamHandler)
+            assert isinstance(console_handler, SafeConsoleHandler)
             assert console_handler.level == logging.INFO
 
-            # Verify file handler
             file_handler = root_logger.handlers[1]
             assert isinstance(file_handler, logging.FileHandler)
             assert file_handler.level == logging.INFO
+            assert file_handler.encoding.lower() == "utf-8"
 
-            # Verify file handler has different date format
             file_formatter = file_handler.formatter
             assert file_formatter.datefmt == "%Y-%m-%d %H:%M:%S"
 
-            # Test actual file writing
             test_logger = get_logger("test")
             test_logger.info("Test message")
 
             assert os.path.exists(log_file_path)
-            with open(log_file_path, 'r') as f:
+            with open(log_file_path, "r") as f:
                 content = f.read()
                 assert "Test message" in content
                 assert "[INFO]" in content
 
-            # Close the file handler before cleanup to avoid Windows file lock issues
             file_handler.close()
             root_logger.removeHandler(file_handler)
 
         finally:
-            # Clean up temp directory and file
             import shutil
             import time
-            # Give the file system time to release the file handle
             time.sleep(0.1)
             if os.path.exists(temp_dir):
                 shutil.rmtree(temp_dir)
 
     def test_setup_logging_clears_existing_handlers(self, reset_logging):
         """Test that setup_logging clears existing handlers."""
-        # Add a dummy handler first
         root_logger = logging.getLogger()
         dummy_handler = logging.StreamHandler()
         root_logger.addHandler(dummy_handler)
 
-        # Count existing handlers (including our dummy one)
         existing_handler_count = len(root_logger.handlers)
         assert existing_handler_count >= 1
         assert dummy_handler in root_logger.handlers
 
-        # Now setup logging - it should clear the dummy handler
         setup_logging()
 
-        # Should only have 1 handler (the console handler from setup_logging)
         assert len(root_logger.handlers) == 1
         assert root_logger.handlers[0] is not dummy_handler
 
@@ -145,6 +132,35 @@ class TestSetupLogging:
         handler = root_logger.handlers[0]
 
         assert handler.formatter._fmt == custom_format
+
+    def test_safe_console_handler_escapes_unencodable_characters(self, reset_logging):
+        """Test that console logging does not crash on encoding errors."""
+
+        class GbkConsole(io.StringIO):
+            encoding = "gbk"
+
+            def write(self, text):
+                if "🚀" in text:
+                    idx = text.index("🚀")
+                    raise UnicodeEncodeError("gbk", text, idx, idx + 1, "illegal multibyte sequence")
+                return super().write(text)
+
+        stream = GbkConsole()
+        handler = SafeConsoleHandler(stream)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger("safe_console_test")
+        logger.handlers = []
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        logger.addHandler(handler)
+
+        logger.info("🚀 backend starting")
+
+        output = stream.getvalue()
+        assert "\\U0001f680 backend starting" in output
+
+        logger.removeHandler(handler)
 
 
 class TestGetLogger:
@@ -175,7 +191,6 @@ class TestGetLogger:
 
         logger = get_logger("test")
 
-        # Logger inherits root level
         assert logger.getEffectiveLevel() == logging.ERROR
 
     def test_get_logger_can_log(self, reset_logging):
@@ -184,8 +199,6 @@ class TestGetLogger:
 
         logger = get_logger("test_logger")
 
-        # Add a custom handler to capture log records
-        import io
         log_capture = io.StringIO()
         test_handler = logging.StreamHandler(log_capture)
         test_handler.setLevel(logging.INFO)
@@ -196,13 +209,11 @@ class TestGetLogger:
         logger.warning("Test warning message")
         logger.error("Test error message")
 
-        # Check that messages were logged
         log_content = log_capture.getvalue()
         assert "Test info message" in log_content
         assert "Test warning message" in log_content
         assert "Test error message" in log_content
 
-        # Clean up
         logger.removeHandler(test_handler)
 
 
@@ -211,36 +222,26 @@ class TestSetupLoggingErrorHandling:
 
     def test_invalid_logging_level_raises_error(self, reset_logging):
         """Test that invalid logging level raises ValueError."""
-        import pytest
-
         with pytest.raises(ValueError, match="Invalid logging level"):
             setup_logging(level=999)
 
     def test_invalid_logging_level_negative(self, reset_logging):
         """Test that negative logging level raises ValueError."""
-        import pytest
-
         with pytest.raises(ValueError, match="Invalid logging level"):
             setup_logging(level=-1)
 
     def test_invalid_log_file_not_string(self, reset_logging):
         """Test that non-string log_file raises TypeError."""
-        import pytest
-
         with pytest.raises(TypeError, match="log_file must be a string"):
             setup_logging(level=logging.INFO, log_file=123)
 
     def test_invalid_log_file_empty_string(self, reset_logging):
         """Test that empty string log_file raises ValueError."""
-        import pytest
-
         with pytest.raises(ValueError, match="log_file cannot be empty"):
             setup_logging(level=logging.INFO, log_file="")
 
     def test_invalid_log_file_whitespace(self, reset_logging):
         """Test that whitespace-only log_file raises ValueError."""
-        import pytest
-
         with pytest.raises(ValueError, match="log_file cannot be empty"):
             setup_logging(level=logging.INFO, log_file="   ")
 
@@ -248,34 +249,26 @@ class TestSetupLoggingErrorHandling:
         """Test that setup_logging continues with console if file setup fails."""
         import sys
         from io import StringIO
-        import tempfile
 
-        # Create a scenario where directory creation succeeds but file writing fails
-        # by using a valid directory but then making the file handle fail during creation
         temp_dir = tempfile.mkdtemp()
 
-        # Capture stdout to check for warning message
         old_stdout = sys.stdout
         captured_output = StringIO()
         sys.stdout = captured_output
 
         try:
-            # Use a valid path but we'll mock the FileHandler to fail
             valid_path = os.path.join(temp_dir, "test.log")
 
-            with patch('interfaces.api.middleware.logging_config.logging.FileHandler') as mock_file_handler:
-                # Mock FileHandler to raise an exception
+            with patch("interfaces.api.middleware.logging_config.logging.FileHandler") as mock_file_handler:
                 mock_file_handler.side_effect = PermissionError("Permission denied")
 
                 setup_logging(level=logging.INFO, log_file=valid_path)
 
-            # Verify console logging is still working
             root_logger = logging.getLogger()
             assert root_logger.level == logging.INFO
-            assert len(root_logger.handlers) == 1  # Only console handler
+            assert len(root_logger.handlers) == 1
             assert isinstance(root_logger.handlers[0], logging.StreamHandler)
 
-            # Verify warning was printed
             output = captured_output.getvalue()
             assert "WARNING: Failed to setup file logging" in output
             assert "Logging will continue with console output only" in output
@@ -288,15 +281,12 @@ class TestSetupLoggingErrorHandling:
 
     def test_valid_logging_levels(self, reset_logging):
         """Test that all valid logging levels work correctly."""
-        from itertools import product
-
-        # Test all valid logging levels
         valid_levels = [
             logging.DEBUG,
             logging.INFO,
             logging.WARNING,
             logging.ERROR,
-            logging.CRITICAL
+            logging.CRITICAL,
         ]
 
         for level in valid_levels:
@@ -304,38 +294,35 @@ class TestSetupLoggingErrorHandling:
             root_logger = logging.getLogger()
             assert root_logger.level == level
 
-            # Clear handlers for next test
             for handler in root_logger.handlers[:]:
                 root_logger.removeHandler(handler)
 
     def test_valid_log_file_creates_directory(self, reset_logging):
         """Test that valid log file path creates parent directories if needed."""
-        import tempfile
         import shutil
 
         temp_dir = tempfile.mkdtemp()
         try:
-            # Create a nested directory path that doesn't exist yet
             nested_path = os.path.join(temp_dir, "level1", "level2", "test.log")
 
-            # This should create the directories and set up the file handler
             setup_logging(level=logging.INFO, log_file=nested_path)
 
             root_logger = logging.getLogger()
             assert len(root_logger.handlers) == 2
 
-            # Verify the file was created
             assert os.path.exists(nested_path)
             assert os.path.isfile(nested_path)
 
-            # Clean up the file handler before removing directories
             file_handler = root_logger.handlers[1]
             file_handler.close()
             root_logger.removeHandler(file_handler)
 
         finally:
-            # Clean up temp directory
             import time
+            time.sleep(0.1)
+            if os.path.exists(temp_dir):
+                shutil.rmtree(temp_dir)
+
             time.sleep(0.1)  # Give time for file handles to be released
             if os.path.exists(temp_dir):
                 shutil.rmtree(temp_dir)


### PR DESCRIPTION
## Summary

This PR fixes Windows console/file logging issues when log messages contain emoji or other non-ASCII characters.

## Changes

- add a `SafeConsoleHandler` that falls back to escaped output on `UnicodeEncodeError`
- set file logging to explicit `utf-8` encoding
- add tests covering the console fallback and file handler encoding

## Why

I hit this while testing local startup on Windows.

On Windows terminals using legacy encodings such as GBK, startup logs containing emoji could raise `UnicodeEncodeError`, which made local startup noisy and confusing even when the app still worked.

This keeps the existing log messages intact while making the logging path more robust.
