### PR TITLE
fix: 修复重构后的启动与兼容性问题

### DIFF
--- a/application/audit/services/chapter_review_service.py
+++ b/application/audit/services/chapter_review_service.py
@@ -9,7 +9,7 @@
 - 改进建议生成
 """
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, TYPE_CHECKING
 from datetime import datetime
 import json
 import logging
@@ -20,10 +20,12 @@ from domain.cast.repositories.cast_repository import CastRepository
 from domain.novel.repositories.timeline_repository import TimelineRepository
 from domain.novel.repositories.storyline_repository import StorylineRepository
 from domain.novel.repositories.foreshadowing_repository import ForeshadowingRepository
-from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 from application.ai.llm_json_extract import parse_llm_json_to_dict
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
+
+if TYPE_CHECKING:
+    from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +97,7 @@ class ChapterReviewService:
         timeline_repo: TimelineRepository,
         storyline_repo: StorylineRepository,
         foreshadowing_repo: ForeshadowingRepository,
-        vector_store: ChromaDBVectorStore,
+        vector_store: "ChromaDBVectorStore",
         llm_service: LLMService,
         model: str = "claude-3-5-haiku-20241022"
     ):

--- a/application/blueprint/services/beat_sheet_service.py
+++ b/application/blueprint/services/beat_sheet_service.py
@@ -6,7 +6,7 @@
 import uuid
 import json
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 from datetime import datetime
 
 from domain.novel.entities.beat_sheet import BeatSheet
@@ -16,7 +16,9 @@ from domain.novel.repositories.chapter_repository import ChapterRepository
 from domain.novel.repositories.storyline_repository import StorylineRepository
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
-from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
+
+if TYPE_CHECKING:
+    from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +37,7 @@ class BeatSheetService:
         chapter_repo: ChapterRepository,
         storyline_repo: StorylineRepository,
         llm_service: LLMService,
-        vector_store: ChromaDBVectorStore,
+        vector_store: "ChromaDBVectorStore",
         bible_service=None,
     ):
         self.beat_sheet_repo = beat_sheet_repo

--- a/application/core/dtos/novel_dto.py
+++ b/application/core/dtos/novel_dto.py
@@ -8,6 +8,31 @@ if TYPE_CHECKING:
     from domain.novel.entities.chapter import Chapter
 
 
+def _public_stage(novel: 'Novel') -> str:
+    """内部 current_stage -> 前端/旧接口粗粒度 stage。"""
+    current_stage = getattr(novel, 'current_stage', None)
+    current_value = current_stage.value if hasattr(current_stage, 'value') else str(current_stage or '')
+
+    explicit_stage = getattr(novel, 'stage', None)
+    explicit_value = explicit_stage.value if hasattr(explicit_stage, 'value') else str(explicit_stage or '')
+
+    # 兼容旧 update_novel_stage：仅显式 stage 被改动时优先保留。
+    if explicit_value and explicit_value != 'planning' and current_value in ('', 'planning'):
+        return explicit_value
+
+    stage_map = {
+        'planning': 'planning',
+        'macro_planning': 'planning',
+        'act_planning': 'planning',
+        'writing': 'writing',
+        'auditing': 'reviewing',
+        'reviewing': 'reviewing',
+        'paused_for_review': 'reviewing',
+        'completed': 'completed',
+    }
+    return stage_map.get(current_value, explicit_value or 'planning')
+
+
 @dataclass
 class ChapterDTO:
     """章节 DTO"""
@@ -75,7 +100,7 @@ class NovelDTO:
             title=novel.title,
             author=novel.author,
             target_chapters=novel.target_chapters,
-            stage=novel.stage.value,
+            stage=_public_stage(novel),
             premise=getattr(novel, 'premise', ''),  # 兼容旧数据
             chapters=chapters,
             total_word_count=novel.get_total_word_count().value,

--- a/application/core/services/novel_service.py
+++ b/application/core/services/novel_service.py
@@ -36,6 +36,18 @@ class NovelService:
         self.chapter_repository = chapter_repository
         self.story_node_repository = story_node_repository
 
+    def _hydrate_chapters(self, novel: Novel) -> Novel:
+        """用 Chapter 仓储补齐 DTO 所需章节列表。"""
+        if self.chapter_repository is None:
+            return novel
+        try:
+            chapters = self.chapter_repository.list_by_novel(novel.novel_id)
+            if isinstance(chapters, list):
+                novel.chapters = chapters
+        except Exception:
+            pass
+        return novel
+
     def ensure_default_act_for_chapters(self, novel_id: str) -> None:
         """若无任何「幕」节点，创建默认第一幕，以便 add_chapter 能挂接章节到叙事结构树。"""
         if not self.story_node_repository:
@@ -99,7 +111,7 @@ class NovelService:
         if novel is None:
             return None
 
-        dto = NovelDTO.from_domain(novel)
+        dto = NovelDTO.from_domain(self._hydrate_chapters(novel))
 
         dto.has_bible = self._check_has_bible(novel_id)
         dto.has_outline = self._check_has_outline(novel_id)
@@ -107,6 +119,13 @@ class NovelService:
         return dto
 
     def _check_has_bible(self, novel_id: str) -> bool:
+        storage = getattr(self.novel_repository, "storage", None)
+        if storage is not None and hasattr(storage, "exists"):
+            try:
+                return bool(storage.exists(f"novels/{novel_id}/bible.json"))
+            except Exception:
+                pass
+
         try:
             from infrastructure.persistence.database.sqlite_bible_repository import SqliteBibleRepository
             from infrastructure.persistence.database.connection import get_database
@@ -133,7 +152,7 @@ class NovelService:
             NovelDTO 列表
         """
         novels = self.novel_repository.list_all()
-        return [NovelDTO.from_domain(novel) for novel in novels]
+        return [NovelDTO.from_domain(self._hydrate_chapters(novel)) for novel in novels]
 
     def delete_novel(self, novel_id: str) -> None:
         """删除小说
@@ -173,6 +192,8 @@ class NovelService:
 
         # 查询数据库中实际的章节数
         existing_chapters = self.chapter_repository.list_by_novel(NovelId(novel_id))
+        if not isinstance(existing_chapters, list):
+            existing_chapters = list(getattr(novel, "chapters", []) or [])
         expected_number = len(existing_chapters) + 1
 
         # 验证章节号是否连续
@@ -189,6 +210,9 @@ class NovelService:
 
         # 直接保存章节，不通过Novel实体
         self.chapter_repository.save(chapter)
+        if not any(getattr(c, "number", None) == chapter.number for c in novel.chapters):
+            novel.chapters.append(chapter)
+        self.novel_repository.save(novel)
 
         # 同步创建 StoryNode 章节节点，并关联到当前活跃的幕
         if self.story_node_repository:
@@ -237,8 +261,8 @@ class NovelService:
                 logger.warning(f"Failed to sync chapter to story structure: {e}")
 
         # 重新加载Novel以返回最新状态
-        novel = self.novel_repository.get_by_id(NovelId(novel_id))
-        return NovelDTO.from_domain(novel)
+        novel = self.novel_repository.get_by_id(NovelId(novel_id)) or novel
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def update_novel(self, novel_id: str, title: Optional[str] = None, author: Optional[str] = None, 
                      target_chapters: Optional[int] = None, premise: Optional[str] = None) -> NovelDTO:
@@ -272,7 +296,7 @@ class NovelService:
             novel.premise = premise
 
         self.novel_repository.save(novel)
-        return NovelDTO.from_domain(novel)
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def update_novel_stage(self, novel_id: str, stage: str) -> NovelDTO:
         """更新小说阶段
@@ -294,7 +318,7 @@ class NovelService:
         novel.stage = NovelStage(stage)
         self.novel_repository.save(novel)
 
-        return NovelDTO.from_domain(novel)
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def update_auto_approve_mode(self, novel_id: str, auto_approve_mode: bool) -> NovelDTO:
         """更新全自动模式设置
@@ -316,7 +340,7 @@ class NovelService:
         novel.auto_approve_mode = auto_approve_mode
         self.novel_repository.save(novel)
 
-        return NovelDTO.from_domain(novel)
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def get_novel_statistics(self, novel_id: str) -> Dict[str, Any]:
         """获取小说统计信息（以 Chapter 仓储落盘为准，与列表/读写 API 一致）

--- a/application/core/services/scene_generation_service.py
+++ b/application/core/services/scene_generation_service.py
@@ -4,13 +4,15 @@
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 from domain.novel.value_objects.scene import Scene
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
 from application.engine.services.scene_director_service import SceneDirectorService
-from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
+
+if TYPE_CHECKING:
+    from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ class SceneGenerationService:
         self,
         llm_service: LLMService,
         scene_director: SceneDirectorService,
-        vector_store: Optional[ChromaDBVectorStore] = None,
+        vector_store: Optional["ChromaDBVectorStore"] = None,
         embedding_service=None,
     ):
         self.llm_service = llm_service

--- a/application/dtos/__init__.py
+++ b/application/dtos/__init__.py
@@ -1,0 +1,19 @@
+"""兼容旧导入路径：application.dtos.* -> 新分层 DTO 模块。"""
+
+from importlib import import_module
+import sys
+
+
+_MODULE_ALIASES = {
+    "bible_dto": "application.world.dtos.bible_dto",
+    "generation_result": "application.engine.dtos.generation_result",
+    "ghost_annotation": "application.audit.dtos.ghost_annotation",
+    "macro_refactor_dto": "application.audit.dtos.macro_refactor_dto",
+    "novel_dto": "application.core.dtos.novel_dto",
+    "scene_director_dto": "application.engine.dtos.scene_director_dto",
+    "writer_block_dto": "application.workbench.dtos.writer_block_dto",
+}
+
+
+for _alias, _target in _MODULE_ALIASES.items():
+    sys.modules[f"{__name__}.{_alias}"] = import_module(_target)

--- a/application/services/__init__.py
+++ b/application/services/__init__.py
@@ -1,0 +1,39 @@
+"""兼容旧导入路径：application.services.* -> 新分层 service 模块。"""
+
+from importlib import import_module
+import sys
+
+
+_MODULE_ALIASES = {
+    "ai_generation_service": "application.engine.services.ai_generation_service",
+    "bible_location_triple_sync": "application.world.services.bible_location_triple_sync",
+    "bible_service": "application.world.services.bible_service",
+    "chapter_indexing_service": "application.analyst.services.chapter_indexing_service",
+    "chapter_service": "application.core.services.chapter_service",
+    "character_indexer": "application.analyst.services.character_indexer",
+    "cliche_scanner": "application.audit.services.cliche_scanner",
+    "conflict_detection_service": "application.audit.services.conflict_detection_service",
+    "context_builder": "application.engine.services.context_builder",
+    "hosted_write_service": "application.engine.services.hosted_write_service",
+    "indexing_service": "application.analyst.services.indexing_service",
+    "macro_merge_engine": "application.audit.services.macro_merge_engine",
+    "macro_refactor_proposal_service": "application.audit.services.macro_refactor_proposal_service",
+    "macro_refactor_scanner": "application.audit.services.macro_refactor_scanner",
+    "mutation_applier": "application.audit.services.mutation_applier",
+    "narrative_entity_state_service": "application.analyst.services.narrative_entity_state_service",
+    "novel_service": "application.core.services.novel_service",
+    "scene_director_service": "application.engine.services.scene_director_service",
+    "state_extractor": "application.analyst.services.state_extractor",
+    "state_updater": "application.analyst.services.state_updater",
+    "style_constraint_builder": "application.engine.services.style_constraint_builder",
+    "subtext_matching_service": "application.analyst.services.subtext_matching_service",
+    "tension_analyzer": "application.analyst.services.tension_analyzer",
+    "trigger_keyword_catalog": "application.engine.services.trigger_keyword_catalog",
+    "voice_drift_service": "application.analyst.services.voice_drift_service",
+    "voice_fingerprint_service": "application.analyst.services.voice_fingerprint_service",
+    "voice_sample_service": "application.analyst.services.voice_sample_service",
+}
+
+
+for _alias, _target in _MODULE_ALIASES.items():
+    sys.modules[f"{__name__}.{_alias}"] = import_module(_target)

--- a/domain/novel/value_objects/chapter_state.py
+++ b/domain/novel/value_objects/chapter_state.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Any
 
 
@@ -14,9 +14,9 @@ class ChapterState:
     foreshadowing_planted: List[Dict[str, Any]]  # List[{description, chapter}]
     foreshadowing_resolved: List[Dict[str, Any]]  # List[{foreshadowing_id, chapter}]
     events: List[Dict[str, Any]]  # List[{type, description, involved_characters, chapter}]
-    timeline_events: List[Dict[str, Any]]  # List[{event, timestamp, timestamp_type}]
-    advanced_storylines: List[Dict[str, Any]]  # List[{storyline_id, progress_summary}]
-    new_storylines: List[Dict[str, Any]]  # List[{name, type, description}]
+    timeline_events: List[Dict[str, Any]] = field(default_factory=list)  # List[{event, timestamp, timestamp_type}]
+    advanced_storylines: List[Dict[str, Any]] = field(default_factory=list)  # List[{storyline_id, progress_summary}]
+    new_storylines: List[Dict[str, Any]] = field(default_factory=list)  # List[{name, type, description}]
 
     def has_new_characters(self) -> bool:
         """检查是否有新角色"""

--- a/infrastructure/ai/__init__.py
+++ b/infrastructure/ai/__init__.py
@@ -1,6 +1,8 @@
-"""Infrastructure AI module"""
-from .config import Settings
-from .providers import BaseProvider, AnthropicProvider
-from .openai_embedding_service import OpenAIEmbeddingService
+"""Infrastructure AI module.
 
-__all__ = ["Settings", "BaseProvider", "AnthropicProvider", "OpenAIEmbeddingService"]
+避免包导入时强制拉起可选第三方 SDK（anthropic/openai 等）。
+"""
+
+from .config import Settings
+
+__all__ = ["Settings"]

--- a/infrastructure/ai/providers/__init__.py
+++ b/infrastructure/ai/providers/__init__.py
@@ -1,6 +1,20 @@
-"""Infrastructure AI providers module"""
-from .base import BaseProvider
-from .anthropic_provider import AnthropicProvider
-from .openai_provider import OpenAIProvider
+"""Infrastructure AI providers module.
 
-__all__ = ["BaseProvider", "AnthropicProvider", "OpenAIProvider"]
+仅强制导出基础类型；具体 Provider 在各自依赖可用时再按需导入。
+"""
+
+from .base import BaseProvider
+
+__all__ = ["BaseProvider"]
+
+try:
+    from .anthropic_provider import AnthropicProvider
+    __all__.append("AnthropicProvider")
+except ModuleNotFoundError:
+    AnthropicProvider = None
+
+try:
+    from .openai_provider import OpenAIProvider
+    __all__.append("OpenAIProvider")
+except ModuleNotFoundError:
+    OpenAIProvider = None

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -29,7 +29,6 @@ from infrastructure.persistence.database.story_node_repository import StoryNodeR
 from infrastructure.persistence.database.sqlite_cast_repository import SqliteCastRepository
 from infrastructure.persistence.database.sqlite_foreshadowing_repository import SqliteForeshadowingRepository
 from infrastructure.persistence.database.sqlite_timeline_repository import SqliteTimelineRepository
-from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
 from infrastructure.ai.config.settings import Settings
 
 from application.core.services.novel_service import NovelService
@@ -317,12 +316,19 @@ def get_llm_service():
     if provider == "openai":
         settings = _openai_settings(require_key=False)
         if settings:
-            from infrastructure.ai.providers.openai_provider import OpenAIProvider
-            return OpenAIProvider(settings)
+            try:
+                from infrastructure.ai.providers.openai_provider import OpenAIProvider
+                return OpenAIProvider(settings)
+            except ModuleNotFoundError as e:
+                logger.warning("OpenAI provider dependency missing, fallback to MockProvider: %s", e)
     else:
         settings = _anthropic_settings(require_key=False)
         if settings:
-            return AnthropicProvider(settings)
+            try:
+                from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
+                return AnthropicProvider(settings)
+            except ModuleNotFoundError as e:
+                logger.warning("Anthropic provider dependency missing, fallback to MockProvider: %s", e)
             
     from infrastructure.ai.providers.mock_provider import MockProvider
     return MockProvider()

--- a/interfaces/api/middleware/error_handler.py
+++ b/interfaces/api/middleware/error_handler.py
@@ -12,6 +12,16 @@ from ..responses import ErrorResponse
 logger = logging.getLogger("aitext.interfaces.api.middleware.error_handler")
 
 
+# Starlette/FastAPI 版本兼容：
+# - 旧版本常量名为 HTTP_422_UNPROCESSABLE_ENTITY
+# - 部分实现/文档会使用 HTTP_422_UNPROCESSABLE_CONTENT
+HTTP_422_STATUS = getattr(
+    status,
+    "HTTP_422_UNPROCESSABLE_CONTENT",
+    status.HTTP_422_UNPROCESSABLE_ENTITY,
+)
+
+
 # Status code to error code mapping
 STATUS_CODE_MAP: Dict[int, str] = {
     status.HTTP_400_BAD_REQUEST: "BAD_REQUEST",
@@ -19,7 +29,7 @@ STATUS_CODE_MAP: Dict[int, str] = {
     status.HTTP_403_FORBIDDEN: "FORBIDDEN",
     status.HTTP_404_NOT_FOUND: "NOT_FOUND",
     status.HTTP_409_CONFLICT: "CONFLICT",
-    status.HTTP_422_UNPROCESSABLE_CONTENT: "UNPROCESSABLE_ENTITY",
+    HTTP_422_STATUS: "UNPROCESSABLE_ENTITY",
     status.HTTP_500_INTERNAL_SERVER_ERROR: "INTERNAL_ERROR",
 }
 
@@ -90,7 +100,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         logger.debug(f"  - {field_error['field']}: {field_error['message']}")
 
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        status_code=HTTP_422_STATUS,
         content=error_response.model_dump()
     )
 

--- a/interfaces/api/stats/repositories/sqlite_stats_repository_adapter.py
+++ b/interfaces/api/stats/repositories/sqlite_stats_repository_adapter.py
@@ -13,6 +13,27 @@ from infrastructure.persistence.database.connection import DatabaseConnection
 logger = logging.getLogger(__name__)
 
 
+def _public_stage_from_row(row: Dict) -> str:
+    """数据库 current_stage -> 兼容旧统计接口 stage。"""
+    current_stage = row.get("current_stage") or "planning"
+    explicit_stage = row.get("stage")
+
+    if explicit_stage and explicit_stage != "planning" and current_stage == "planning":
+        return explicit_stage
+
+    stage_map = {
+        "planning": "planning",
+        "macro_planning": "planning",
+        "act_planning": "planning",
+        "writing": "writing",
+        "auditing": "reviewing",
+        "reviewing": "reviewing",
+        "paused_for_review": "reviewing",
+        "completed": "completed",
+    }
+    return stage_map.get(current_stage, explicit_stage or "planning")
+
+
 class SqliteStatsRepositoryAdapter:
     """Adapter to read statistics from SQLite database.
 
@@ -69,7 +90,7 @@ class SqliteStatsRepositoryAdapter:
                 "title": row.get("title", ""),
                 "author": row.get("author", "未知作者"),
                 "slug": slug,
-                "stage": row.get("stage", "planning"),
+                "stage": _public_stage_from_row(row),
                 "target_chapters": row.get("target_chapters", 0),
             }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=7.0,<9.0
+pytest-asyncio>=0.23,<1.0
 volcengine-python-sdk[ark]>=1.0.0
 anthropic>=0.40.0
 pydantic>=2.0.0
@@ -6,6 +7,7 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 jinja2>=3.1.0
 python-multipart>=0.0.6
+python-dotenv>=1.0.0
 httpx>=0.25.0
 faiss-cpu>=1.7.4
 numpy>=1.21.0


### PR DESCRIPTION
## 概要
- 修复当前 FastAPI / Starlette 环境下的启动兼容问题
- 避免在未安装 anthropic / faiss 等可选依赖时因顶层导入导致应用直接崩溃
- 增加 `application.dtos.*` 与 `application.services.*` 的兼容层，恢复旧导入路径可用性
- 为 `ChapterState` 提供向后兼容默认值，并统一对外暴露的 stage 映射
- 修复 `NovelService` 返回 DTO 时章节数据丢失的问题
- 补充测试/脚本实际使用但缺失的依赖声明

## 背景
近期重构后，项目出现了几类高优先级回归：

1. `interfaces.main` 在当前依赖版本下可能无法正常导入，影响服务启动
2. 部分可选 AI / 向量依赖未安装时，应用会在 import 阶段直接失败
3. 旧测试与旧调用方依赖的 `application.dtos.*`、`application.services.*` 路径失效
4. 某些 DTO / Service 返回值与重构前行为不一致，导致测试与兼容链路异常

本 PR 聚焦修复以上问题，不包含与本次主题无关的本地修改。

## 主要修改
### 1. 启动兼容修复
- 修复 422 状态码常量在不同 FastAPI / Starlette 版本中的兼容问题
- 使 `from interfaces.main import app` 可正常执行

### 2. 可选依赖降级处理
- 调整 AI provider 与部分 service 的导入方式
- 当 `anthropic`、`faiss` 等依赖缺失时，不再因为顶层 import 导致整个应用启动失败

### 3. 旧导入路径兼容层
- 新增：
  - `application/dtos/__init__.py`
  - `application/services/__init__.py`
- 保持旧代码与旧测试中的导入方式继续可用

### 4. 领域/DTO 兼容修复
- 为 `ChapterState` 新增字段补充默认值，避免旧调用方因参数缺失报错
- 统一 public/stats 对外展示的 stage 映射，降低内部 `current_stage` 与外部展示不一致的问题

### 5. NovelService 返回值修复
- 修复 `NovelService` 在 DTO 转换时章节列表未正确回填的问题
- 修复 `add_chapter()` 后返回 DTO 缺少新章节的问题

### 6. 依赖声明补齐
- 增加：
  - `pytest-asyncio`
  - `python-dotenv`

## 验证
已本地验证：

- `python -c "from interfaces.main import app; print(len(app.routes))"`
- `pytest tests/web/middleware/test_error_handler.py tests/unit/application/dtos/test_ghost_annotation.py tests/unit/application/dtos/test_scene_director_dto.py tests/unit/application/services/test_novel_service.py tests/unit/domain/novel/services/test_consistency_checker.py -q`

上述目标验证已通过。

## 备注
本 PR 有意未包含以下与当前主题无关的本地改动：
- `application/engine/services/autopilot_daemon.py`
- `application/engine/services/context_budget_allocator.py`
- `application/engine/services/streaming_bus.py`
