### PR TITLE
fix: 修复自动驾驶引擎的章节定位与流式队列运行时问题

### DIFF
--- a/application/audit/services/chapter_review_service.py
+++ b/application/audit/services/chapter_review_service.py
@@ -9,7 +9,7 @@
 - 改进建议生成
 """
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, TYPE_CHECKING
 from datetime import datetime
 import json
 import logging
@@ -20,10 +20,12 @@ from domain.cast.repositories.cast_repository import CastRepository
 from domain.novel.repositories.timeline_repository import TimelineRepository
 from domain.novel.repositories.storyline_repository import StorylineRepository
 from domain.novel.repositories.foreshadowing_repository import ForeshadowingRepository
-from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 from application.ai.llm_json_extract import parse_llm_json_to_dict
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
+
+if TYPE_CHECKING:
+    from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +97,7 @@ class ChapterReviewService:
         timeline_repo: TimelineRepository,
         storyline_repo: StorylineRepository,
         foreshadowing_repo: ForeshadowingRepository,
-        vector_store: ChromaDBVectorStore,
+        vector_store: "ChromaDBVectorStore",
         llm_service: LLMService,
         model: str = "claude-3-5-haiku-20241022"
     ):

--- a/application/blueprint/services/beat_sheet_service.py
+++ b/application/blueprint/services/beat_sheet_service.py
@@ -6,7 +6,7 @@
 import uuid
 import json
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 from datetime import datetime
 
 from domain.novel.entities.beat_sheet import BeatSheet
@@ -16,7 +16,9 @@ from domain.novel.repositories.chapter_repository import ChapterRepository
 from domain.novel.repositories.storyline_repository import StorylineRepository
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
-from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
+
+if TYPE_CHECKING:
+    from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +37,7 @@ class BeatSheetService:
         chapter_repo: ChapterRepository,
         storyline_repo: StorylineRepository,
         llm_service: LLMService,
-        vector_store: ChromaDBVectorStore,
+        vector_store: "ChromaDBVectorStore",
         bible_service=None,
     ):
         self.beat_sheet_repo = beat_sheet_repo

--- a/application/core/dtos/novel_dto.py
+++ b/application/core/dtos/novel_dto.py
@@ -8,6 +8,31 @@ if TYPE_CHECKING:
     from domain.novel.entities.chapter import Chapter
 
 
+def _public_stage(novel: 'Novel') -> str:
+    """内部 current_stage -> 前端/旧接口粗粒度 stage。"""
+    current_stage = getattr(novel, 'current_stage', None)
+    current_value = current_stage.value if hasattr(current_stage, 'value') else str(current_stage or '')
+
+    explicit_stage = getattr(novel, 'stage', None)
+    explicit_value = explicit_stage.value if hasattr(explicit_stage, 'value') else str(explicit_stage or '')
+
+    # 兼容旧 update_novel_stage：仅显式 stage 被改动时优先保留。
+    if explicit_value and explicit_value != 'planning' and current_value in ('', 'planning'):
+        return explicit_value
+
+    stage_map = {
+        'planning': 'planning',
+        'macro_planning': 'planning',
+        'act_planning': 'planning',
+        'writing': 'writing',
+        'auditing': 'reviewing',
+        'reviewing': 'reviewing',
+        'paused_for_review': 'reviewing',
+        'completed': 'completed',
+    }
+    return stage_map.get(current_value, explicit_value or 'planning')
+
+
 @dataclass
 class ChapterDTO:
     """章节 DTO"""
@@ -75,7 +100,7 @@ class NovelDTO:
             title=novel.title,
             author=novel.author,
             target_chapters=novel.target_chapters,
-            stage=novel.stage.value,
+            stage=_public_stage(novel),
             premise=getattr(novel, 'premise', ''),  # 兼容旧数据
             chapters=chapters,
             total_word_count=novel.get_total_word_count().value,

--- a/application/core/services/novel_service.py
+++ b/application/core/services/novel_service.py
@@ -36,6 +36,18 @@ class NovelService:
         self.chapter_repository = chapter_repository
         self.story_node_repository = story_node_repository
 
+    def _hydrate_chapters(self, novel: Novel) -> Novel:
+        """用 Chapter 仓储补齐 DTO 所需章节列表。"""
+        if self.chapter_repository is None:
+            return novel
+        try:
+            chapters = self.chapter_repository.list_by_novel(novel.novel_id)
+            if isinstance(chapters, list):
+                novel.chapters = chapters
+        except Exception:
+            pass
+        return novel
+
     def ensure_default_act_for_chapters(self, novel_id: str) -> None:
         """若无任何「幕」节点，创建默认第一幕，以便 add_chapter 能挂接章节到叙事结构树。"""
         if not self.story_node_repository:
@@ -99,7 +111,7 @@ class NovelService:
         if novel is None:
             return None
 
-        dto = NovelDTO.from_domain(novel)
+        dto = NovelDTO.from_domain(self._hydrate_chapters(novel))
 
         dto.has_bible = self._check_has_bible(novel_id)
         dto.has_outline = self._check_has_outline(novel_id)
@@ -107,6 +119,13 @@ class NovelService:
         return dto
 
     def _check_has_bible(self, novel_id: str) -> bool:
+        storage = getattr(self.novel_repository, "storage", None)
+        if storage is not None and hasattr(storage, "exists"):
+            try:
+                return bool(storage.exists(f"novels/{novel_id}/bible.json"))
+            except Exception:
+                pass
+
         try:
             from infrastructure.persistence.database.sqlite_bible_repository import SqliteBibleRepository
             from infrastructure.persistence.database.connection import get_database
@@ -133,7 +152,7 @@ class NovelService:
             NovelDTO 列表
         """
         novels = self.novel_repository.list_all()
-        return [NovelDTO.from_domain(novel) for novel in novels]
+        return [NovelDTO.from_domain(self._hydrate_chapters(novel)) for novel in novels]
 
     def delete_novel(self, novel_id: str) -> None:
         """删除小说
@@ -173,6 +192,8 @@ class NovelService:
 
         # 查询数据库中实际的章节数
         existing_chapters = self.chapter_repository.list_by_novel(NovelId(novel_id))
+        if not isinstance(existing_chapters, list):
+            existing_chapters = list(getattr(novel, "chapters", []) or [])
         expected_number = len(existing_chapters) + 1
 
         # 验证章节号是否连续
@@ -189,6 +210,9 @@ class NovelService:
 
         # 直接保存章节，不通过Novel实体
         self.chapter_repository.save(chapter)
+        if not any(getattr(c, "number", None) == chapter.number for c in novel.chapters):
+            novel.chapters.append(chapter)
+        self.novel_repository.save(novel)
 
         # 同步创建 StoryNode 章节节点，并关联到当前活跃的幕
         if self.story_node_repository:
@@ -237,8 +261,8 @@ class NovelService:
                 logger.warning(f"Failed to sync chapter to story structure: {e}")
 
         # 重新加载Novel以返回最新状态
-        novel = self.novel_repository.get_by_id(NovelId(novel_id))
-        return NovelDTO.from_domain(novel)
+        novel = self.novel_repository.get_by_id(NovelId(novel_id)) or novel
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def update_novel(self, novel_id: str, title: Optional[str] = None, author: Optional[str] = None, 
                      target_chapters: Optional[int] = None, premise: Optional[str] = None) -> NovelDTO:
@@ -272,7 +296,7 @@ class NovelService:
             novel.premise = premise
 
         self.novel_repository.save(novel)
-        return NovelDTO.from_domain(novel)
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def update_novel_stage(self, novel_id: str, stage: str) -> NovelDTO:
         """更新小说阶段
@@ -294,7 +318,7 @@ class NovelService:
         novel.stage = NovelStage(stage)
         self.novel_repository.save(novel)
 
-        return NovelDTO.from_domain(novel)
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def update_auto_approve_mode(self, novel_id: str, auto_approve_mode: bool) -> NovelDTO:
         """更新全自动模式设置
@@ -316,7 +340,7 @@ class NovelService:
         novel.auto_approve_mode = auto_approve_mode
         self.novel_repository.save(novel)
 
-        return NovelDTO.from_domain(novel)
+        return NovelDTO.from_domain(self._hydrate_chapters(novel))
 
     def get_novel_statistics(self, novel_id: str) -> Dict[str, Any]:
         """获取小说统计信息（以 Chapter 仓储落盘为准，与列表/读写 API 一致）

--- a/application/core/services/scene_generation_service.py
+++ b/application/core/services/scene_generation_service.py
@@ -4,13 +4,15 @@
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 from domain.novel.value_objects.scene import Scene
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
 from application.engine.services.scene_director_service import SceneDirectorService
-from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
+
+if TYPE_CHECKING:
+    from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +31,7 @@ class SceneGenerationService:
         self,
         llm_service: LLMService,
         scene_director: SceneDirectorService,
-        vector_store: Optional[ChromaDBVectorStore] = None,
+        vector_store: Optional["ChromaDBVectorStore"] = None,
         embedding_service=None,
     ):
         self.llm_service = llm_service

--- a/application/dtos/__init__.py
+++ b/application/dtos/__init__.py
@@ -1,0 +1,19 @@
+"""兼容旧导入路径：application.dtos.* -> 新分层 DTO 模块。"""
+
+from importlib import import_module
+import sys
+
+
+_MODULE_ALIASES = {
+    "bible_dto": "application.world.dtos.bible_dto",
+    "generation_result": "application.engine.dtos.generation_result",
+    "ghost_annotation": "application.audit.dtos.ghost_annotation",
+    "macro_refactor_dto": "application.audit.dtos.macro_refactor_dto",
+    "novel_dto": "application.core.dtos.novel_dto",
+    "scene_director_dto": "application.engine.dtos.scene_director_dto",
+    "writer_block_dto": "application.workbench.dtos.writer_block_dto",
+}
+
+
+for _alias, _target in _MODULE_ALIASES.items():
+    sys.modules[f"{__name__}.{_alias}"] = import_module(_target)

--- a/application/engine/services/autopilot_daemon.py
+++ b/application/engine/services/autopilot_daemon.py
@@ -707,7 +707,7 @@ class AutopilotDaemon:
         if not self._is_still_running(novel):
             return
 
-        chapter_num = novel.current_act * 10 + novel.current_chapter_in_act  # 刚写完的章节
+        chapter_num = novel.current_auto_chapters or 1  # 刚写完的章节（在 _handle_writing 末尾已递增）
 
         from domain.novel.value_objects.novel_id import NovelId
         from domain.novel.value_objects.chapter_id import ChapterId

--- a/application/engine/services/context_budget_allocator.py
+++ b/application/engine/services/context_budget_allocator.py
@@ -142,13 +142,15 @@ class ContextBudgetAllocator:
         chapter_element_repository = None,
         vector_store: Optional[VectorStore] = None,
         embedding_service: Optional[EmbeddingService] = None,
+        triple_repository = None,
     ):
         self.foreshadowing_repo = foreshadowing_repository
         self.chapter_repo = chapter_repository
         self.bible_repo = bible_repository
         self.story_node_repo = story_node_repository
         self.chapter_element_repo = chapter_element_repository
-        
+        self.triple_repo = triple_repository
+
         # 向量检索门面
         self.vector_facade = None
         if vector_store and embedding_service:

--- a/application/engine/services/streaming_bus.py
+++ b/application/engine/services/streaming_bus.py
@@ -111,11 +111,25 @@ class StreamingBus:
             try:
                 queue.put_nowait(message)
             except Full:
+                # 队列满时，只清除同一 novel_id 的旧消息，保留其他小说的消息
+                keep = []
+                removed = 0
                 for _ in range(100):
                     try:
-                        queue.get_nowait()
+                        old_msg = queue.get_nowait()
                     except Empty:
                         break
+                    if isinstance(old_msg, dict) and old_msg.get("novel_id") == novel_id:
+                        removed += 1
+                    else:
+                        keep.append(old_msg)
+                for msg in keep:
+                    try:
+                        queue.put_nowait(msg)
+                    except Full:
+                        break
+                if removed > 0:
+                    logger.debug(f"[StreamingBus] 清除 {novel_id} 的 {removed} 条旧消息以腾出空间")
                 try:
                     queue.put_nowait(message)
                 except Full:

--- a/application/services/__init__.py
+++ b/application/services/__init__.py
@@ -1,0 +1,39 @@
+"""兼容旧导入路径：application.services.* -> 新分层 service 模块。"""
+
+from importlib import import_module
+import sys
+
+
+_MODULE_ALIASES = {
+    "ai_generation_service": "application.engine.services.ai_generation_service",
+    "bible_location_triple_sync": "application.world.services.bible_location_triple_sync",
+    "bible_service": "application.world.services.bible_service",
+    "chapter_indexing_service": "application.analyst.services.chapter_indexing_service",
+    "chapter_service": "application.core.services.chapter_service",
+    "character_indexer": "application.analyst.services.character_indexer",
+    "cliche_scanner": "application.audit.services.cliche_scanner",
+    "conflict_detection_service": "application.audit.services.conflict_detection_service",
+    "context_builder": "application.engine.services.context_builder",
+    "hosted_write_service": "application.engine.services.hosted_write_service",
+    "indexing_service": "application.analyst.services.indexing_service",
+    "macro_merge_engine": "application.audit.services.macro_merge_engine",
+    "macro_refactor_proposal_service": "application.audit.services.macro_refactor_proposal_service",
+    "macro_refactor_scanner": "application.audit.services.macro_refactor_scanner",
+    "mutation_applier": "application.audit.services.mutation_applier",
+    "narrative_entity_state_service": "application.analyst.services.narrative_entity_state_service",
+    "novel_service": "application.core.services.novel_service",
+    "scene_director_service": "application.engine.services.scene_director_service",
+    "state_extractor": "application.analyst.services.state_extractor",
+    "state_updater": "application.analyst.services.state_updater",
+    "style_constraint_builder": "application.engine.services.style_constraint_builder",
+    "subtext_matching_service": "application.analyst.services.subtext_matching_service",
+    "tension_analyzer": "application.analyst.services.tension_analyzer",
+    "trigger_keyword_catalog": "application.engine.services.trigger_keyword_catalog",
+    "voice_drift_service": "application.analyst.services.voice_drift_service",
+    "voice_fingerprint_service": "application.analyst.services.voice_fingerprint_service",
+    "voice_sample_service": "application.analyst.services.voice_sample_service",
+}
+
+
+for _alias, _target in _MODULE_ALIASES.items():
+    sys.modules[f"{__name__}.{_alias}"] = import_module(_target)

--- a/domain/novel/value_objects/chapter_state.py
+++ b/domain/novel/value_objects/chapter_state.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Dict, Any
 
 
@@ -14,9 +14,9 @@ class ChapterState:
     foreshadowing_planted: List[Dict[str, Any]]  # List[{description, chapter}]
     foreshadowing_resolved: List[Dict[str, Any]]  # List[{foreshadowing_id, chapter}]
     events: List[Dict[str, Any]]  # List[{type, description, involved_characters, chapter}]
-    timeline_events: List[Dict[str, Any]]  # List[{event, timestamp, timestamp_type}]
-    advanced_storylines: List[Dict[str, Any]]  # List[{storyline_id, progress_summary}]
-    new_storylines: List[Dict[str, Any]]  # List[{name, type, description}]
+    timeline_events: List[Dict[str, Any]] = field(default_factory=list)  # List[{event, timestamp, timestamp_type}]
+    advanced_storylines: List[Dict[str, Any]] = field(default_factory=list)  # List[{storyline_id, progress_summary}]
+    new_storylines: List[Dict[str, Any]] = field(default_factory=list)  # List[{name, type, description}]
 
     def has_new_characters(self) -> bool:
         """检查是否有新角色"""

--- a/infrastructure/ai/__init__.py
+++ b/infrastructure/ai/__init__.py
@@ -1,6 +1,8 @@
-"""Infrastructure AI module"""
-from .config import Settings
-from .providers import BaseProvider, AnthropicProvider
-from .openai_embedding_service import OpenAIEmbeddingService
+"""Infrastructure AI module.
 
-__all__ = ["Settings", "BaseProvider", "AnthropicProvider", "OpenAIEmbeddingService"]
+避免包导入时强制拉起可选第三方 SDK（anthropic/openai 等）。
+"""
+
+from .config import Settings
+
+__all__ = ["Settings"]

--- a/infrastructure/ai/providers/__init__.py
+++ b/infrastructure/ai/providers/__init__.py
@@ -1,6 +1,20 @@
-"""Infrastructure AI providers module"""
-from .base import BaseProvider
-from .anthropic_provider import AnthropicProvider
-from .openai_provider import OpenAIProvider
+"""Infrastructure AI providers module.
 
-__all__ = ["BaseProvider", "AnthropicProvider", "OpenAIProvider"]
+仅强制导出基础类型；具体 Provider 在各自依赖可用时再按需导入。
+"""
+
+from .base import BaseProvider
+
+__all__ = ["BaseProvider"]
+
+try:
+    from .anthropic_provider import AnthropicProvider
+    __all__.append("AnthropicProvider")
+except ModuleNotFoundError:
+    AnthropicProvider = None
+
+try:
+    from .openai_provider import OpenAIProvider
+    __all__.append("OpenAIProvider")
+except ModuleNotFoundError:
+    OpenAIProvider = None

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -29,7 +29,6 @@ from infrastructure.persistence.database.story_node_repository import StoryNodeR
 from infrastructure.persistence.database.sqlite_cast_repository import SqliteCastRepository
 from infrastructure.persistence.database.sqlite_foreshadowing_repository import SqliteForeshadowingRepository
 from infrastructure.persistence.database.sqlite_timeline_repository import SqliteTimelineRepository
-from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
 from infrastructure.ai.config.settings import Settings
 
 from application.core.services.novel_service import NovelService
@@ -317,12 +316,19 @@ def get_llm_service():
     if provider == "openai":
         settings = _openai_settings(require_key=False)
         if settings:
-            from infrastructure.ai.providers.openai_provider import OpenAIProvider
-            return OpenAIProvider(settings)
+            try:
+                from infrastructure.ai.providers.openai_provider import OpenAIProvider
+                return OpenAIProvider(settings)
+            except ModuleNotFoundError as e:
+                logger.warning("OpenAI provider dependency missing, fallback to MockProvider: %s", e)
     else:
         settings = _anthropic_settings(require_key=False)
         if settings:
-            return AnthropicProvider(settings)
+            try:
+                from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
+                return AnthropicProvider(settings)
+            except ModuleNotFoundError as e:
+                logger.warning("Anthropic provider dependency missing, fallback to MockProvider: %s", e)
             
     from infrastructure.ai.providers.mock_provider import MockProvider
     return MockProvider()

--- a/interfaces/api/middleware/error_handler.py
+++ b/interfaces/api/middleware/error_handler.py
@@ -12,6 +12,16 @@ from ..responses import ErrorResponse
 logger = logging.getLogger("aitext.interfaces.api.middleware.error_handler")
 
 
+# Starlette/FastAPI 版本兼容：
+# - 旧版本常量名为 HTTP_422_UNPROCESSABLE_ENTITY
+# - 部分实现/文档会使用 HTTP_422_UNPROCESSABLE_CONTENT
+HTTP_422_STATUS = getattr(
+    status,
+    "HTTP_422_UNPROCESSABLE_CONTENT",
+    status.HTTP_422_UNPROCESSABLE_ENTITY,
+)
+
+
 # Status code to error code mapping
 STATUS_CODE_MAP: Dict[int, str] = {
     status.HTTP_400_BAD_REQUEST: "BAD_REQUEST",
@@ -19,7 +29,7 @@ STATUS_CODE_MAP: Dict[int, str] = {
     status.HTTP_403_FORBIDDEN: "FORBIDDEN",
     status.HTTP_404_NOT_FOUND: "NOT_FOUND",
     status.HTTP_409_CONFLICT: "CONFLICT",
-    status.HTTP_422_UNPROCESSABLE_CONTENT: "UNPROCESSABLE_ENTITY",
+    HTTP_422_STATUS: "UNPROCESSABLE_ENTITY",
     status.HTTP_500_INTERNAL_SERVER_ERROR: "INTERNAL_ERROR",
 }
 
@@ -90,7 +100,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
         logger.debug(f"  - {field_error['field']}: {field_error['message']}")
 
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        status_code=HTTP_422_STATUS,
         content=error_response.model_dump()
     )
 

--- a/interfaces/api/stats/repositories/sqlite_stats_repository_adapter.py
+++ b/interfaces/api/stats/repositories/sqlite_stats_repository_adapter.py
@@ -13,6 +13,27 @@ from infrastructure.persistence.database.connection import DatabaseConnection
 logger = logging.getLogger(__name__)
 
 
+def _public_stage_from_row(row: Dict) -> str:
+    """数据库 current_stage -> 兼容旧统计接口 stage。"""
+    current_stage = row.get("current_stage") or "planning"
+    explicit_stage = row.get("stage")
+
+    if explicit_stage and explicit_stage != "planning" and current_stage == "planning":
+        return explicit_stage
+
+    stage_map = {
+        "planning": "planning",
+        "macro_planning": "planning",
+        "act_planning": "planning",
+        "writing": "writing",
+        "auditing": "reviewing",
+        "reviewing": "reviewing",
+        "paused_for_review": "reviewing",
+        "completed": "completed",
+    }
+    return stage_map.get(current_stage, explicit_stage or "planning")
+
+
 class SqliteStatsRepositoryAdapter:
     """Adapter to read statistics from SQLite database.
 
@@ -69,7 +90,7 @@ class SqliteStatsRepositoryAdapter:
                 "title": row.get("title", ""),
                 "author": row.get("author", "未知作者"),
                 "slug": slug,
-                "stage": row.get("stage", "planning"),
+                "stage": _public_stage_from_row(row),
                 "target_chapters": row.get("target_chapters", 0),
             }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=7.0,<9.0
+pytest-asyncio>=0.23,<1.0
 volcengine-python-sdk[ark]>=1.0.0
 anthropic>=0.40.0
 pydantic>=2.0.0
@@ -6,6 +7,7 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 jinja2>=3.1.0
 python-multipart>=0.0.6
+python-dotenv>=1.0.0
 httpx>=0.25.0
 faiss-cpu>=1.7.4
 numpy>=1.21.0

--- a/tests/unit/application/services/test_autopilot_daemon.py
+++ b/tests/unit/application/services/test_autopilot_daemon.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from application.engine.services.autopilot_daemon import AutopilotDaemon
+from domain.novel.entities.novel import AutopilotStatus, NovelStage
+from domain.novel.value_objects.novel_id import NovelId
+
+
+@pytest.mark.asyncio
+async def test_handle_auditing_uses_current_auto_chapters_for_lookup(monkeypatch):
+    chapter = Mock()
+    chapter.id = "chapter-12"
+    chapter.content = "本章内容"
+    chapter.status = SimpleNamespace(value="completed")
+    chapter.update_tension_score = Mock()
+
+    chapter_repository = Mock()
+    chapter_repository.get_by_novel_and_number.return_value = chapter
+    chapter_repository.list_by_novel.return_value = [chapter]
+
+    daemon = AutopilotDaemon(
+        novel_repository=Mock(),
+        llm_service=None,
+        context_builder=None,
+        background_task_service=Mock(),
+        planning_service=Mock(),
+        story_node_repo=None,
+        chapter_repository=chapter_repository,
+    )
+
+    monkeypatch.setattr(daemon, "_is_still_running", lambda novel: True)
+    monkeypatch.setattr(
+        daemon,
+        "_legacy_auditing_tasks_and_voice",
+        lambda *args, **kwargs: {
+            "drift_alert": False,
+            "similarity_score": 0.93,
+            "narrative_sync_ok": True,
+        },
+    )
+    daemon._score_tension = AsyncMock(return_value=7)
+    daemon._auto_trigger_macro_diagnosis = AsyncMock()
+    daemon._maybe_generate_summaries = AsyncMock()
+
+    novel = SimpleNamespace(
+        novel_id=NovelId("novel-1"),
+        current_act=2,
+        current_chapter_in_act=1,
+        current_auto_chapters=12,
+        current_stage=NovelStage.AUDITING,
+        autopilot_status=AutopilotStatus.RUNNING,
+        target_chapters=99,
+    )
+
+    await daemon._handle_auditing(novel)
+
+    chapter_repository.get_by_novel_and_number.assert_called_once()
+    lookup_novel_id, lookup_chapter_number = chapter_repository.get_by_novel_and_number.call_args.args
+    assert lookup_novel_id.value == "novel-1"
+    assert lookup_chapter_number == 12
+    assert novel.last_audit_chapter_number == 12
+    chapter.update_tension_score.assert_called_once_with(70)
+    chapter_repository.save.assert_called_once_with(chapter)

--- a/tests/unit/application/services/test_context_budget_allocator.py
+++ b/tests/unit/application/services/test_context_budget_allocator.py
@@ -1,0 +1,15 @@
+from application.engine.services.context_budget_allocator import ContextBudgetAllocator
+
+
+def test_allocate_without_triple_repository_does_not_raise():
+    allocator = ContextBudgetAllocator()
+
+    allocation = allocator.allocate(
+        novel_id="novel-1",
+        chapter_number=1,
+        outline="主角第一次进入遗迹。",
+        total_budget=2000,
+    )
+
+    assert "graph_subnetwork" in allocation.slots
+    assert allocation.slots["graph_subnetwork"].content == ""

--- a/tests/unit/application/services/test_streaming_bus.py
+++ b/tests/unit/application/services/test_streaming_bus.py
@@ -1,0 +1,44 @@
+from queue import Empty, Full
+
+from application.engine.services.streaming_bus import StreamingBus
+import application.engine.services.streaming_bus as streaming_bus_module
+
+
+class _FakeQueue:
+    def __init__(self, items, capacity):
+        self.items = list(items)
+        self.capacity = capacity
+        self.fail_first_put = True
+
+    def put_nowait(self, item):
+        if self.fail_first_put:
+            self.fail_first_put = False
+            raise Full
+        if len(self.items) >= self.capacity:
+            raise Full
+        self.items.append(item)
+
+    def get_nowait(self):
+        if not self.items:
+            raise Empty
+        return self.items.pop(0)
+
+
+def test_publish_only_evicts_messages_for_same_novel(monkeypatch):
+    fake_queue = _FakeQueue(
+        items=[
+            {"novel_id": "novel-a", "chunk": "old-a-1"},
+            {"novel_id": "novel-b", "chunk": "keep-b"},
+            {"novel_id": "novel-a", "chunk": "old-a-2"},
+        ],
+        capacity=3,
+    )
+    monkeypatch.setattr(streaming_bus_module, "_get_queue", lambda: fake_queue)
+
+    bus = StreamingBus()
+    bus.publish("novel-a", "new-a")
+
+    assert fake_queue.items == [
+        {"novel_id": "novel-b", "chunk": "keep-b"},
+        {"novel_id": "novel-a", "chunk": "new-a"},
+    ]


### PR DESCRIPTION
## 说明
本 PR 聚焦自动驾驶引擎中的 3 个运行时问题修复，并补充对应回归测试。

> 说明：本 PR 依赖 #10。
> 当前 diff 会包含 #10 的变更；待 #10 合并后，本 PR 会自动收敛为本次新增的修复内容。

## 变更内容
1. 修复 `AutopilotDaemon._handle_auditing` 的章节定位逻辑  
   - 原实现通过 `current_act * 10 + current_chapter_in_act` 推导刚写完的章节号；
   - 当单幕章节数超过 10 时，会定位到错误章节；
   - 现改为直接使用 `current_auto_chapters`，与写作阶段的自增计数保持一致。

2. 修复 `ContextBudgetAllocator` 的 `triple_repo` 初始化遗漏  
   - `_get_graph_subnetwork()` 会访问 `self.triple_repo`；
   - 在未注入三元组仓储时，原实现可能触发 `AttributeError`；
   - 现为构造函数补齐初始化，保证无仓储配置时安全降级。

3. 优化 `StreamingBus.publish` 的满队列淘汰策略  
   - 原实现队列满载时会直接清空一批旧消息；
   - 在多小说并发流式输出场景下，可能误删其他小说的消息；
   - 现仅淘汰同一 `novel_id` 的旧消息，避免跨小说串扰。

## 测试
新增回归测试：
- `tests/unit/application/services/test_autopilot_daemon.py`
- `tests/unit/application/services/test_context_budget_allocator.py`
- `tests/unit/application/services/test_streaming_bus.py`

本地验证：
```bash
python -c "from interfaces.main import app; print('APP_IMPORT_OK', len(app.routes))"
pytest tests/web/middleware/test_error_handler.py tests/unit/application/dtos/test_ghost_annotation.py tests/unit/application/dtos/test_scene_director_dto.py tests/unit/application/services/test_novel_service.py tests/unit/domain/novel/services/test_consistency_checker.py tests/unit/application/services/test_context_budget_allocator.py tests/unit/application/services/test_streaming_bus.py tests/unit/application/services/test_autopilot_daemon.py -q
```

结果：
- `APP_IMPORT_OK 146`
- `65 passed`
