### PR TITLE
feat: 强化对话沙盒的角色锚定，降低错定人物问题

### DIFF
--- a/application/workbench/services/sandbox_dialogue_service.py
+++ b/application/workbench/services/sandbox_dialogue_service.py
@@ -162,6 +162,12 @@ class SandboxDialogueService:
                 text = text[len(prefix):].strip()
                 break
 
+        if len(text) >= 2:
+            for left, right in (("“", "”"), ('"', '"'), ("「", "」")):
+                if text.startswith(left) and text.endswith(right):
+                    text = text[1:-1].strip()
+                    break
+
         return text
 
     def _event_to_dialogue_entry(self, event: dict) -> Optional[DialogueEntry]:
@@ -179,7 +185,7 @@ class SandboxDialogueService:
 
         summary = self._stringify(event.get("event_summary", ""))
         content = self._strip_speaker_prefix(summary, speaker) or summary
-        context = self._extract_scene_context(tags) or summary
+        context = self._extract_scene_context(tags)
 
         return DialogueEntry(
             dialogue_id=self._stringify(event.get("event_id", "")),
@@ -277,6 +283,7 @@ class SandboxDialogueService:
     def _find_relationship_to_name(self, other_name: str, relationships: list[Any]) -> str:
         for relationship in relationships:
             if isinstance(relationship, dict):
+                relation_label = self._relationship_label(relationship)
                 haystack = " ".join(
                     self._stringify(item)
                     for item in (
@@ -295,13 +302,22 @@ class SandboxDialogueService:
                     if self._stringify(item)
                 )
                 if other_name in haystack:
-                    return self._render_relationship(relationship)
+                    return relation_label or self._render_relationship(relationship)
             else:
                 text = self._stringify(relationship)
                 if other_name in text:
                     return text
 
         return ""
+
+    def _relationship_label(self, relationship: dict[str, Any]) -> str:
+        return self._first_non_empty(
+            relationship.get("relation"),
+            relationship.get("type"),
+            relationship.get("label"),
+            relationship.get("status"),
+            relationship.get("description"),
+        )
 
     def _format_scene_related_characters(self, related_characters: list[dict[str, str]]) -> str:
         if not related_characters:
@@ -324,8 +340,10 @@ class SandboxDialogueService:
 
         lines: list[str] = []
         for entry in dialogues[:4]:
-            context = f" / {entry.context}" if entry.context else ""
-            lines.append(f"- 第{entry.chapter}章{context}：{entry.content}")
+            if entry.context:
+                lines.append(f"- 第{entry.chapter}章 / {entry.context}：{entry.content}")
+            else:
+                lines.append(f"- 第{entry.chapter}章：{entry.content}")
         return "\n".join(lines)
 
     @staticmethod

--- a/application/workbench/services/sandbox_dialogue_service.py
+++ b/application/workbench/services/sandbox_dialogue_service.py
@@ -1,13 +1,15 @@
-"""
-Sandbox dialogue service for managing dialogue whitelist.
-"""
+"""Sandbox dialogue service for managing dialogue whitelist and grounded prompts."""
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
 from application.workbench.dtos.sandbox_dto import DialogueEntry, DialogueWhitelistResponse
+from domain.ai.value_objects.prompt import Prompt
 
 
 class SandboxDialogueService:
-    """Service for managing sandbox dialogue whitelist."""
+    """Service for sandbox dialogue whitelist and grounded character dialogue prompts."""
 
     def __init__(self, narrative_event_repository):
         """
@@ -35,48 +37,301 @@ class SandboxDialogueService:
         Returns:
             DialogueWhitelistResponse containing filtered dialogues
         """
-        # Fetch all events up to the latest chapter
-        # Using a large number to get all events
         events = self.narrative_event_repository.list_up_to_chapter(
             novel_id, max_chapter_inclusive=9999
         )
 
-        dialogues = []
+        dialogues: list[DialogueEntry] = []
 
         for event in events:
-            # Extract tags, handle None case
-            tags = event.get("tags") or []
-
-            # Filter events with dialogue tags（兼容 "对话:" 和旧版 "对白:"）
-            dialogue_tags = [tag for tag in tags if tag.startswith("对话:") or tag.startswith("对白:")]
-
-            if not dialogue_tags:
+            dialogue_entry = self._event_to_dialogue_entry(event)
+            if dialogue_entry is None:
                 continue
 
-            # Extract speaker from tag (format: "对话:张三" or "对白:张三")
-            event_speaker = dialogue_tags[0].split(":", 1)[1] if ":" in dialogue_tags[0] else ""
-
-            # Apply chapter filter
-            if chapter_number is not None and event.get("chapter_number") != chapter_number:
+            if chapter_number is not None and dialogue_entry.chapter != chapter_number:
                 continue
 
-            # Apply speaker filter
-            if speaker is not None and event_speaker != speaker:
+            if speaker is not None and dialogue_entry.speaker != speaker:
                 continue
-
-            # Build DialogueEntry
-            dialogue_entry = DialogueEntry(
-                dialogue_id=event.get("event_id", ""),
-                chapter=event.get("chapter_number", 0),
-                speaker=event_speaker,
-                content=event.get("event_summary", ""),
-                context=event.get("event_summary", ""),  # Using summary as context for now
-                tags=tags
-            )
 
             dialogues.append(dialogue_entry)
 
-        return DialogueWhitelistResponse(
-            dialogues=dialogues,
-            total_count=len(dialogues)
+        return DialogueWhitelistResponse(dialogues=dialogues, total_count=len(dialogues))
+
+    def get_recent_character_dialogues(
+        self,
+        novel_id: str,
+        speaker: str,
+        limit: int = 4,
+    ) -> list[DialogueEntry]:
+        """Get the most recent dialogue samples for a character."""
+        if not speaker or limit <= 0:
+            return []
+
+        entries = self.get_dialogue_whitelist(novel_id=novel_id, speaker=speaker).dialogues
+        entries.sort(key=lambda item: (item.chapter, item.dialogue_id), reverse=True)
+        return entries[:limit]
+
+    def build_dialogue_generation_prompt(
+        self,
+        *,
+        character: Any,
+        scene_prompt: str,
+        mental_state: str,
+        verbal_tic: str,
+        idle_behavior: str,
+        all_characters: Optional[Iterable[Any]] = None,
+        recent_dialogues: Optional[Iterable[DialogueEntry]] = None,
+    ) -> Prompt:
+        """Build a grounded prompt for character dialogue generation."""
+        character_name = self._stringify(getattr(character, "name", ""))
+        description = self._stringify(getattr(character, "description", ""))
+        public_profile = self._stringify(getattr(character, "public_profile", ""))
+        relationships = list(getattr(character, "relationships", []) or [])
+        scene_related_characters = self._find_scene_related_characters(
+            scene_prompt=scene_prompt,
+            target_character=character,
+            all_characters=all_characters,
         )
+
+        system = (
+            "你是长篇小说的角色对白润色器。"
+            "你的任务是让指定角色在给定场景里说出符合其人设、关系位置、历史声线和当前心理锚点的话。"
+            "优先级：历史对白习惯 > 角色设定 > 当前心理状态/口头禅/动作 > 场景目标。"
+            "不要输出分析、设定说明、JSON、标题或额外注释。"
+            "如果场景里出现其他角色，他们只能作为陪衬，不能抢走目标角色的口吻与主导发言权。"
+        )
+
+        relationship_block = self._format_relationships(relationships)
+        history_block = self._format_recent_dialogues(recent_dialogues)
+        related_block = self._format_scene_related_characters(scene_related_characters)
+        scene_text = self._stringify(scene_prompt) or "（未提供场景）"
+
+        user = f"""目标角色：{character_name}
+
+【角色基础设定】
+- 人设描述：{description or "暂无"}
+- 公开档案：{public_profile or "暂无"}
+- 当前心理状态：{mental_state or "NORMAL"}
+- 口头禅：{verbal_tic or "无"}
+- 常见动作：{idle_behavior or "无"}
+
+【角色关系】
+{relationship_block}
+
+【场景点名的相关角色】
+{related_block}
+
+【历史对白样本（模仿语气，不要照抄）】
+{history_block}
+
+【当前场景】
+{scene_text}
+
+请直接生成这名角色在当前场景中的一小段对白，要求：
+1. 只写成品台词，可夹带极少量动作描写；
+2. 重点保持这个角色自己的语气、身份位置和情绪，不要串成别的角色；
+3. 若场景里有其他角色，可以被提及或简短回应，但不要让其他角色成为主说话人；
+4. 长度控制在 2-4 句话；
+5. 不要输出角色名标签、分析说明、引号外注释。"""
+
+        return Prompt(system=system, user=user)
+
+    def clean_generated_dialogue(self, content: str, character_name: str) -> str:
+        """Normalize generated dialogue for UI rendering."""
+        text = self._stringify(content)
+        if not text:
+            return ""
+
+        if text.startswith("```"):
+            text = text.strip("`").strip()
+            if text.lower().startswith("json"):
+                text = text[4:].strip()
+
+        for prefix in (
+            f"{character_name}：",
+            f"{character_name}:",
+            "对白：",
+            "对白:",
+            "台词：",
+            "台词:",
+            "对话：",
+            "对话:",
+        ):
+            if text.startswith(prefix):
+                text = text[len(prefix):].strip()
+                break
+
+        return text
+
+    def _event_to_dialogue_entry(self, event: dict) -> Optional[DialogueEntry]:
+        tags = event.get("tags") or []
+        dialogue_tag = next(
+            (tag for tag in tags if tag.startswith("对话:") or tag.startswith("对白:")),
+            None,
+        )
+        if not dialogue_tag:
+            return None
+
+        speaker = dialogue_tag.split(":", 1)[1].strip() if ":" in dialogue_tag else ""
+        if not speaker:
+            return None
+
+        summary = self._stringify(event.get("event_summary", ""))
+        content = self._strip_speaker_prefix(summary, speaker) or summary
+        context = self._extract_scene_context(tags) or summary
+
+        return DialogueEntry(
+            dialogue_id=self._stringify(event.get("event_id", "")),
+            chapter=int(event.get("chapter_number", 0) or 0),
+            speaker=speaker,
+            content=content,
+            context=context,
+            tags=tags,
+        )
+
+    @staticmethod
+    def _stringify(value: Any) -> str:
+        return str(value or "").strip()
+
+    def _strip_speaker_prefix(self, summary: str, speaker: str) -> str:
+        for prefix in (f"{speaker}:", f"{speaker}："):
+            if summary.startswith(prefix):
+                return summary[len(prefix):].strip()
+        return summary
+
+    def _extract_scene_context(self, tags: list[str]) -> str:
+        scene_tag = next((tag for tag in tags if tag.startswith("场景:")), "")
+        return scene_tag.split(":", 1)[1].strip() if ":" in scene_tag else ""
+
+    def _format_relationships(self, relationships: list[Any]) -> str:
+        if not relationships:
+            return "- 暂无明确关系记录"
+
+        lines: list[str] = []
+        for relationship in relationships[:6]:
+            rendered = self._render_relationship(relationship)
+            if rendered:
+                lines.append(f"- {rendered}")
+        return "\n".join(lines) if lines else "- 暂无明确关系记录"
+
+    def _render_relationship(self, relationship: Any) -> str:
+        if isinstance(relationship, dict):
+            target = self._first_non_empty(
+                relationship.get("target_name"),
+                relationship.get("target"),
+                relationship.get("character"),
+                relationship.get("name"),
+                relationship.get("to"),
+                relationship.get("other"),
+            )
+            relation = self._first_non_empty(
+                relationship.get("relation"),
+                relationship.get("type"),
+                relationship.get("label"),
+                relationship.get("status"),
+                relationship.get("description"),
+            )
+            if target and relation:
+                return f"{target}：{relation}"
+            if relation:
+                return relation
+            if target:
+                return target
+            return self._stringify(relationship)
+
+        return self._stringify(relationship)
+
+    def _find_scene_related_characters(
+        self,
+        *,
+        scene_prompt: str,
+        target_character: Any,
+        all_characters: Optional[Iterable[Any]],
+    ) -> list[dict[str, str]]:
+        prompt_text = self._stringify(scene_prompt)
+        if not prompt_text or not all_characters:
+            return []
+
+        target_name = self._stringify(getattr(target_character, "name", ""))
+        relationships = list(getattr(target_character, "relationships", []) or [])
+        related: list[dict[str, str]] = []
+
+        for other in all_characters:
+            other_name = self._stringify(getattr(other, "name", ""))
+            if not other_name or other_name == target_name:
+                continue
+            if other_name not in prompt_text:
+                continue
+
+            related.append(
+                {
+                    "name": other_name,
+                    "description": self._stringify(getattr(other, "description", "")),
+                    "relation": self._find_relationship_to_name(other_name, relationships),
+                }
+            )
+
+        return related[:3]
+
+    def _find_relationship_to_name(self, other_name: str, relationships: list[Any]) -> str:
+        for relationship in relationships:
+            if isinstance(relationship, dict):
+                haystack = " ".join(
+                    self._stringify(item)
+                    for item in (
+                        relationship.get("target_name"),
+                        relationship.get("target"),
+                        relationship.get("character"),
+                        relationship.get("name"),
+                        relationship.get("to"),
+                        relationship.get("other"),
+                        relationship.get("relation"),
+                        relationship.get("type"),
+                        relationship.get("label"),
+                        relationship.get("status"),
+                        relationship.get("description"),
+                    )
+                    if self._stringify(item)
+                )
+                if other_name in haystack:
+                    return self._render_relationship(relationship)
+            else:
+                text = self._stringify(relationship)
+                if other_name in text:
+                    return text
+
+        return ""
+
+    def _format_scene_related_characters(self, related_characters: list[dict[str, str]]) -> str:
+        if not related_characters:
+            return "- 场景描述里未点名其他已知角色"
+
+        lines: list[str] = []
+        for item in related_characters:
+            pieces = [item["name"]]
+            if item.get("relation"):
+                pieces.append(f"关系：{item['relation']}")
+            if item.get("description"):
+                pieces.append(f"描述：{item['description']}")
+            lines.append(f"- {'；'.join(pieces)}")
+        return "\n".join(lines)
+
+    def _format_recent_dialogues(self, recent_dialogues: Optional[Iterable[DialogueEntry]]) -> str:
+        dialogues = list(recent_dialogues or [])
+        if not dialogues:
+            return "- 暂无历史对白样本"
+
+        lines: list[str] = []
+        for entry in dialogues[:4]:
+            context = f" / {entry.context}" if entry.context else ""
+            lines.append(f"- 第{entry.chapter}章{context}：{entry.content}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _first_non_empty(*values: Any) -> str:
+        for value in values:
+            text = str(value or "").strip()
+            if text:
+                return text
+        return ""

--- a/frontend/src/api/book.ts
+++ b/frontend/src/api/book.ts
@@ -57,56 +57,56 @@ const request = axios.create({
 request.interceptors.response.use(response => response.data)
 
 export const bookApi = {
-  getList: () => request.get<BookListItem[]>('/books') as Promise<BookListItem[]>,
-  create: (data: unknown) => request.post<SlugResponse>('/jobs/create-book', data) as Promise<SlugResponse>,
-  deleteBook: (slug: string) => request.delete<SimpleResponse>(`/book/${slug}`) as Promise<SimpleResponse>,
-  getCast: (slug: string) => request.get<CastGraph>(`/book/${slug}/cast`) as Promise<CastGraph>,
+  getList: () => request.get<BookListItem[]>('/books') as unknown as Promise<BookListItem[]>,
+  create: (data: unknown) => request.post<SlugResponse>('/jobs/create-book', data) as unknown as Promise<SlugResponse>,
+  deleteBook: (slug: string) => request.delete<SimpleResponse>(`/book/${slug}`) as unknown as Promise<SimpleResponse>,
+  getCast: (slug: string) => request.get<CastGraph>(`/book/${slug}/cast`) as unknown as Promise<CastGraph>,
   putCast: (slug: string, data: unknown) => request.put(`/book/${slug}/cast`, data),
   searchCast: (slug: string, q: string) =>
-    request.get<CastSearchResponse>(`/book/${slug}/cast/search`, { params: { q } }) as Promise<CastSearchResponse>,
+    request.get<CastSearchResponse>(`/book/${slug}/cast/search`, { params: { q } }) as unknown as Promise<CastSearchResponse>,
   /** 正文与关系图对照：章节出现、设定未入库、书名号未匹配等 */
   getCastCoverage: (slug: string) =>
-    request.get<CastCoverage>(`/book/${slug}/cast/coverage`) as Promise<CastCoverage>,
+    request.get<CastCoverage>(`/book/${slug}/cast/coverage`) as unknown as Promise<CastCoverage>,
   getKnowledge: (slug: string) =>
-    request.get<StoryKnowledge>(`/book/${slug}/knowledge`) as Promise<StoryKnowledge>,
+    request.get<StoryKnowledge>(`/book/${slug}/knowledge`) as unknown as Promise<StoryKnowledge>,
   putKnowledge: (slug: string, data: unknown) => request.put(`/book/${slug}/knowledge`, data),
   knowledgeSearch: (slug: string, q: string, k = 6) =>
-    request.get<KnowledgeSearchResponse>(`/book/${slug}/knowledge/search`, { params: { q, k } }) as Promise<KnowledgeSearchResponse>,
+    request.get<KnowledgeSearchResponse>(`/book/${slug}/knowledge/search`, { params: { q, k } }) as unknown as Promise<KnowledgeSearchResponse>,
   getDesk: (slug: string) =>
-    request.get<BookDeskResponse>(`/book/${slug}/desk`) as Promise<BookDeskResponse>,
+    request.get<BookDeskResponse>(`/book/${slug}/desk`) as unknown as Promise<BookDeskResponse>,
   /** @deprecated Use bibleApi.getBible() - Note: New API has different structure, needs bulk update endpoint */
-  getBible: (slug: string) => request.get<Bible>(`/book/${slug}/bible`) as Promise<Bible>,
+  getBible: (slug: string) => request.get<Bible>(`/book/${slug}/bible`) as unknown as Promise<Bible>,
   /** @deprecated Use bibleApi - Note: New API has different structure, needs bulk update endpoint */
   saveBible: (slug: string, data: unknown) => request.put(`/book/${slug}/bible`, data),
   /** @deprecated Use chapterApi.getChapter() instead */
   getChapterBody: (slug: string, chapterId: number) =>
-    request.get<ChapterBody>(`/book/${slug}/chapter/${chapterId}/body`) as Promise<ChapterBody>,
+    request.get<ChapterBody>(`/book/${slug}/chapter/${chapterId}/body`) as unknown as Promise<ChapterBody>,
   /** @deprecated Use chapterApi.updateChapter() instead */
   saveChapterBody: (slug: string, chapterId: number, content: string) =>
     request.put(`/book/${slug}/chapter/${chapterId}/body`, { content }),
   /** @deprecated Use chapterApi.getChapterReview() instead */
   getChapterReview: (slug: string, chapterId: number) =>
-    request.get<ChapterReview>(`/book/${slug}/chapter/${chapterId}/review`) as Promise<ChapterReview>,
+    request.get<ChapterReview>(`/book/${slug}/chapter/${chapterId}/review`) as unknown as Promise<ChapterReview>,
   /** @deprecated Use chapterApi.saveChapterReview() instead */
   saveChapterReview: (slug: string, chapterId: number, status: string, memo: string) =>
     request.put(`/book/${slug}/chapter/${chapterId}/review`, { status, memo }),
   /** @deprecated Use chapterApi.reviewChapterAi() instead - 自动审读：返回 status/memo；save=true 时写入 editorial */
   reviewChapterAi: (slug: string, chapterId: number, save = false) =>
-    request.post<ChapterReviewAiResponse>(`/book/${slug}/chapter/${chapterId}/review-ai`, { save }) as Promise<ChapterReviewAiResponse>,
+    request.post<ChapterReviewAiResponse>(`/book/${slug}/chapter/${chapterId}/review-ai`, { save }) as unknown as Promise<ChapterReviewAiResponse>,
   /** @deprecated Use chapterApi.getChapterStructure() instead */
   getChapterStructure: (slug: string, chapterId: number) =>
-    request.get<ChapterStructure>(`/book/${slug}/chapter/${chapterId}/structure`) as Promise<ChapterStructure>,
+    request.get<ChapterStructure>(`/book/${slug}/chapter/${chapterId}/structure`) as unknown as Promise<ChapterStructure>,
 }
 
 export const jobApi = {
   startPlan: (slug: string, dryRun = false, mode: 'initial' | 'revise' = 'initial') =>
-    request.post<JobCreateResponse>(`/jobs/${slug}/plan`, { dry_run: dryRun, mode }) as Promise<JobCreateResponse>,
+    request.post<JobCreateResponse>(`/jobs/${slug}/plan`, { dry_run: dryRun, mode }) as unknown as Promise<JobCreateResponse>,
   startWrite: (slug: string, from: number, to?: number, dryRun = false, continuity = false) =>
-    request.post<JobCreateResponse>(`/jobs/${slug}/write`, { from_chapter: from, to_chapter: to, dry_run: dryRun, continuity }) as Promise<JobCreateResponse>,
+    request.post<JobCreateResponse>(`/jobs/${slug}/write`, { from_chapter: from, to_chapter: to, dry_run: dryRun, continuity }) as unknown as Promise<JobCreateResponse>,
   startRun: (slug: string, dryRun = false, continuity = false) =>
-    request.post<JobCreateResponse>(`/jobs/${slug}/run`, { dry_run: dryRun, continuity }) as Promise<JobCreateResponse>,
+    request.post<JobCreateResponse>(`/jobs/${slug}/run`, { dry_run: dryRun, continuity }) as unknown as Promise<JobCreateResponse>,
   startExport: (slug: string) => request.post(`/jobs/${slug}/export`, {}),
-  cancelJob: (jobId: string) => request.post<SimpleResponse>(`/jobs/${jobId}/cancel`, {}) as Promise<SimpleResponse>,
+  cancelJob: (jobId: string) => request.post<SimpleResponse>(`/jobs/${jobId}/cancel`, {}) as unknown as Promise<SimpleResponse>,
   getStatus: (jobId: string) =>
-    request.get<JobStatusResponse>(`/jobs/${jobId}`) as Promise<JobStatusResponse>,
+    request.get<JobStatusResponse>(`/jobs/${jobId}`) as unknown as Promise<JobStatusResponse>,
 }

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,7 +1,13 @@
 // New RESTful API exports (v1)
 export * from './config'
 export * from './novel'
-export * from './chapter'
+export { chapterApi } from './chapter'
+export type {
+  UpdateChapterRequest,
+  ChapterReviewDTO,
+  ChapterStructureDTO,
+  ChapterReviewAiResponse,
+} from './chapter'
 export * from './bible'
 export * from './workflow'
 export * from './chronicles'

--- a/frontend/src/api/knowledge.ts
+++ b/frontend/src/api/knowledge.ts
@@ -15,6 +15,11 @@ export interface ChapterSummary {
   open_threads: string
   consistency_note: string
   beat_sections: string[]
+  micro_beats?: Array<{
+    description: string
+    target_words: number
+    focus: string
+  }>
   sync_status: string
 }
 
@@ -101,5 +106,5 @@ export const knowledgeApi = {
       `/novels/${novelId}/knowledge/generate`,
       {},
       { timeout: 120_000 }
-    ) as Promise<{ success: boolean; message: string; facts_count: number; premise_lock: string }>,
+    ) as unknown as Promise<{ success: boolean; message: string; facts_count: number; premise_lock: string }>,
 }

--- a/frontend/src/api/stats.ts
+++ b/frontend/src/api/stats.ts
@@ -31,14 +31,14 @@ export const statsApi = {
    * Get global statistics across all books
    * GET /stats/global
    */
-  getGlobal: () => request.get<GlobalStats>('/stats/global') as Promise<GlobalStats>,
+  getGlobal: () => request.get<GlobalStats>('/stats/global') as unknown as Promise<GlobalStats>,
 
   /**
    * Get statistics for a specific chapter
    * GET /stats/book/{slug}/chapter/{chapterId}
    */
   getChapter: (slug: string, chapterId: number) =>
-    request.get<ChapterStats>(`/stats/book/${enc(slug)}/chapter/${chapterId}`) as Promise<ChapterStats>,
+    request.get<ChapterStats>(`/stats/book/${enc(slug)}/chapter/${chapterId}`) as unknown as Promise<ChapterStats>,
 
   /**
    * Get writing progress over time
@@ -47,7 +47,7 @@ export const statsApi = {
   getProgress: (slug: string, days = 30) =>
     request.get<WritingProgress[]>(`/stats/book/${enc(slug)}/progress`, {
       params: { days },
-    }) as Promise<WritingProgress[]>,
+    }) as unknown as Promise<WritingProgress[]>,
 
   /**
    * 书目统计（v1 novel statistics）+ 写作进度（legacy /api/stats）

--- a/frontend/src/api/structure.ts
+++ b/frontend/src/api/structure.ts
@@ -4,7 +4,7 @@
 
 import { apiClient } from './config'
 
-export type NodeType = 'part' | 'volume' | 'act'
+export type NodeType = 'part' | 'volume' | 'act' | 'chapter'
 
 export interface StoryNode {
   id: string
@@ -24,12 +24,14 @@ export interface StoryNode {
   level: number
   icon: string
   display_name: string
+  word_count?: number
+  status?: string
   children?: StoryNode[]
 }
 
 export interface StoryTree {
   novel_id: string
-  tree: StoryNode[]
+  tree: StoryNode[] | { nodes: StoryNode[] }
 }
 
 export interface CreateNodeRequest {

--- a/frontend/src/components/StoryStructureTree.vue
+++ b/frontend/src/components/StoryStructureTree.vue
@@ -112,7 +112,7 @@ const structureEmptyDescription = computed(() => {
   }
   return '暂无叙事结构'
 })
-const treeData = ref<StoryNode[]>([])
+const treeData = ref<any[]>([])
 const selectedKeys = ref<string[]>([])
 const expandedKeys = ref<string[]>([])
 
@@ -260,7 +260,7 @@ const loadTree = async () => {
   loading.value = true
   try {
     const res = await structureApi.getTree(props.slug)
-    const nodes = res.tree?.nodes || []
+    const nodes = Array.isArray(res.tree) ? res.tree : (res.tree?.nodes ?? [])
     treeData.value = nodes.length > 0 ? nodes.map(convertToTreeNode) : []
 
     // 自动展开所有非章节节点
@@ -404,7 +404,7 @@ const doAddChild = async () => {
 }
 
 // 渲染节点标签
-const renderLabel = ({ option }: { option: StoryNode }) => {
+const renderLabel = ({ option }: { option: any }) => {
   const elements: any[] = [
     h('span', { class: 'node-icon' }, option.icon),
     h('span', { class: 'node-title' }, option.display_name),
@@ -426,7 +426,7 @@ const renderLabel = ({ option }: { option: StoryNode }) => {
 }
 
 // 渲染节点后缀
-const renderSuffix = ({ option }: { option: StoryNode }) => {
+const renderSuffix = ({ option }: { option: any }) => {
   const elements: any[] = []
   if (option.description && ['part', 'volume', 'act'].includes(option.node_type)) {
     elements.push(
@@ -448,7 +448,7 @@ const renderSuffix = ({ option }: { option: StoryNode }) => {
 }
 
 // 节点属性（右键绑定）
-const nodeProps = ({ option }: { option: StoryNode }) => ({
+const nodeProps = ({ option }: { option: any }) => ({
   class: `node-level-${option.level}`,
   onContextmenu: (e: MouseEvent) => handleContextMenu(e, option),
 })

--- a/frontend/src/components/charts/GraphChart.vue
+++ b/frontend/src/components/charts/GraphChart.vue
@@ -19,9 +19,9 @@ interface GraphLink {
   value?: number
 }
 
-interface EChartsEventParams {
-  dataType: 'node' | 'edge'
-  data: GraphNode | GraphLink
+interface GraphEventParams {
+  dataType?: 'node' | 'edge'
+  data?: GraphNode | GraphLink
 }
 
 const props = withDefaults(defineProps<{
@@ -39,14 +39,25 @@ const emit = defineEmits<{
   edgeClick: [link: GraphLink]
 }>()
 
-const chartOption = computed<EChartsOption>(() => ({
+const tooltip = {
+  formatter: (params: any) => {
+    const eventParams = params as unknown as GraphEventParams
+    if (eventParams.dataType === 'node') {
+      return `${(eventParams.data as GraphNode)?.name ?? ''}`
+    }
+    const link = eventParams.data as GraphLink | undefined
+    return `${link?.source ?? ''} → ${link?.target ?? ''}`
+  }
+}
+
+const chartOption = computed(() => ({
   series: [
     {
       type: 'graph',
       layout: 'force',
       data: props.nodes,
       links: props.links,
-      categories: props.categories.map((name, index) => ({ name })),
+      categories: props.categories.map(name => ({ name })),
       roam: true,
       label: {
         show: true,
@@ -64,17 +75,10 @@ const chartOption = computed<EChartsOption>(() => ({
       }
     }
   ],
-  tooltip: {
-    formatter: (params: EChartsEventParams) => {
-      if (params.dataType === 'node') {
-        return `${(params.data as GraphNode).name}`
-      }
-      return `${(params.data as GraphLink).source} → ${(params.data as GraphLink).target}`
-    }
-  }
-}))
+  tooltip
+}) as EChartsOption)
 
-const handleNodeClick = (params: EChartsEventParams) => {
+const handleNodeClick = (params: GraphEventParams) => {
   if (params.dataType === 'node') {
     emit('nodeClick', params.data as GraphNode)
   } else if (params.dataType === 'edge') {

--- a/frontend/src/components/graphs/CastGraphCompact.vue
+++ b/frontend/src/components/graphs/CastGraphCompact.vue
@@ -24,7 +24,7 @@ import { useRouter } from 'vue-router'
 import { knowledgeApi } from '../../api/knowledge'
 import GraphChart from '../charts/GraphChart.vue'
 import { convertGraph, type VisNode, type VisEdge } from '../../utils/visToEcharts'
-import type { EChartsNode, EChartsLink } from '../../utils/visToEcharts'
+import type { EChartsNode } from '../../utils/visToEcharts'
 import {
   tripleStringAttrs,
   characterImportanceZh,
@@ -38,7 +38,7 @@ interface KnowledgeTriple {
   subject: string
   predicate: string
   object: string
-  chapter_id?: number
+  chapter_id?: number | null
   note?: string
   entity_type?: string
   importance?: string

--- a/frontend/src/components/graphs/LocationGraphCompact.vue
+++ b/frontend/src/components/graphs/LocationGraphCompact.vue
@@ -24,7 +24,7 @@ import { useRouter } from 'vue-router'
 import { knowledgeApi } from '../../api/knowledge'
 import GraphChart from '../charts/GraphChart.vue'
 import { convertGraph, type VisNode, type VisEdge } from '../../utils/visToEcharts'
-import type { EChartsNode, EChartsLink } from '../../utils/visToEcharts'
+import type { EChartsNode } from '../../utils/visToEcharts'
 import {
   tripleStringAttrs,
   locationImportanceZh,
@@ -39,7 +39,7 @@ interface KnowledgeTriple {
   subject: string
   predicate: string
   object: string
-  chapter_id?: number
+  chapter_id?: number | null
   note?: string
   entity_type?: string
   importance?: string

--- a/frontend/src/components/knowledge/KnowledgeBase.vue
+++ b/frontend/src/components/knowledge/KnowledgeBase.vue
@@ -53,7 +53,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, nextTick } from 'vue'
 import { useMessage } from 'naive-ui'
-import { knowledgeApi, type ChapterSummary } from '../../api/knowledge'
+import { knowledgeApi, type ChapterSummary, type KnowledgeTriple } from '../../api/knowledge'
 import GraphChart from '../charts/GraphChart.vue'
 import KnowledgeTriplesTableEditor from './KnowledgeTriplesTableEditor.vue'
 import { convertGraph, type VisNode, type VisEdge, type EChartsGraphData } from '../../utils/visToEcharts'
@@ -63,21 +63,11 @@ const message = useMessage()
 
 const drawerWidth = 920
 
-interface Fact {
-  id: string
-  subject: string
-  predicate: string
-  object: string
-  chapter_id?: number | null
-  note?: string
-  entity_type?: 'character' | 'location' | null
-}
-
 const viewMode = ref<'graph' | 'json'>('graph')
 const tableDrawerOpen = ref(false)
 const loading = ref(false)
 const saving = ref(false)
-const facts = ref<Fact[]>([])
+const facts = ref<KnowledgeTriple[]>([])
 const storyVersion = ref(1)
 const premiseLock = ref('')
 const chaptersSnapshot = ref<ChapterSummary[]>([])

--- a/frontend/src/components/onboarding/NovelSetupGuide.vue
+++ b/frontend/src/components/onboarding/NovelSetupGuide.vue
@@ -140,7 +140,7 @@
               <n-list-item v-for="loc in bibleData.locations" :key="loc.id || loc.name">
                 <n-thing :title="loc.name" :description="loc.description">
                   <template #header-extra>
-                    <n-tag size="small" type="info">{{ loc.location_type || loc.type || '地点' }}</n-tag>
+                    <n-tag size="small" type="info">{{ loc.location_type || '地点' }}</n-tag>
                   </template>
                 </n-thing>
               </n-list-item>
@@ -309,6 +309,18 @@ function emptyWorldbuildingShape(): Record<(typeof WB_DIMS)[number], Record<stri
   }
 }
 
+function createEmptyBible(): BibleDTO {
+  return {
+    id: '',
+    novel_id: '',
+    characters: [],
+    world_settings: [],
+    locations: [],
+    timeline_notes: [],
+    style_notes: [],
+  }
+}
+
 /** 从 Bible.world_settings 名如 core_rules.power_system 还原为五维对象 */
 function worldbuildingFromWorldSettings(
   settings: { name: string; description?: string }[] | undefined
@@ -351,7 +363,7 @@ function mergeWorldbuildingDisplay(
   return out
 }
 
-function styleConventionFromBible(bible: BibleDTO | Record<string, unknown>): string {
+function styleConventionFromBible(bible: BibleDTO): string {
   const b = bible as BibleDTO & { style?: string }
   if (b.style && String(b.style).trim()) return String(b.style).trim()
   const notes: StyleNoteDTO[] = b.style_notes || []
@@ -454,10 +466,10 @@ const generatingBible = ref(false)
 const bibleGenerated = ref(false)
 const bibleStatusText = ref('正在生成世界观...')
 const bibleError = ref('')
-const bibleData = ref<BibleDTO | Record<string, unknown>>({ style_notes: [] } as BibleDTO)
+const bibleData = ref<BibleDTO>(createEmptyBible())
 const worldbuildingData = ref<ReturnType<typeof emptyWorldbuildingShape>>(emptyWorldbuildingShape())
 
-const styleConventionDisplay = computed(() => styleConventionFromBible(bibleData.value as BibleDTO))
+const styleConventionDisplay = computed(() => styleConventionFromBible(bibleData.value))
 
 // 第2步：生成人物和地点
 const generatingCharacters = ref(false)

--- a/frontend/src/components/workbench/ChapterList.vue
+++ b/frontend/src/components/workbench/ChapterList.vue
@@ -51,9 +51,9 @@
           :slug="slug"
           :current-chapter-id="currentChapterId"
           @select-chapter="handleChapterClick"
-          @plan-act="(id, title) => emit('planAct', id, title)"
+          @plan-act="handlePlanAct"
           @open-plan-modal="showMacroPlan = true"
-          @tree-loaded="(hasData) => hasStructure = hasData"
+          @tree-loaded="handleTreeLoaded"
         />
       </div>
     </n-scrollbar>
@@ -132,6 +132,14 @@ const handleChapterClick = (id: number, title = '') => {
 
 const handleBack = () => {
   emit('back')
+}
+
+const handlePlanAct = (id: string, title: string) => {
+  emit('planAct', id, title)
+}
+
+const handleTreeLoaded = (hasData: boolean) => {
+  hasStructure.value = hasData
 }
 
 </script>

--- a/frontend/src/components/workbench/DialogueGeneratorModal.vue
+++ b/frontend/src/components/workbench/DialogueGeneratorModal.vue
@@ -86,7 +86,7 @@
 import { ref, computed, watch } from 'vue'
 import { useMessage } from 'naive-ui'
 import { sandboxApi, type CharacterAnchor } from '@/api/sandbox'
-import { bibleApi } from '@/api/bible'
+import { bibleApi, type CharacterDTO } from '@/api/bible'
 
 const props = defineProps<{
   novelId: string
@@ -102,13 +102,13 @@ const scenePrompt = ref('')
 const generating = ref(false)
 const generatedDialogue = ref('')
 const loadingCharacters = ref(false)
-const characters = ref<any[]>([])
+const characters = ref<CharacterDTO[]>([])
 
 // 角色选项
 const characterOptions = computed(() => {
   return characters.value.map(char => ({
-    label: char.name || char.character_id,
-    value: char.character_id
+    label: char.name || char.id,
+    value: char.id
   }))
 })
 
@@ -118,8 +118,7 @@ async function loadCharacters() {
 
   loadingCharacters.value = true
   try {
-    const cast = await bibleApi.getCast(props.novelId)
-    characters.value = cast.characters || []
+    characters.value = await bibleApi.listCharacters(props.novelId)
   } catch (error) {
     console.error('Failed to load characters:', error)
     message.error('加载角色列表失败')

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  interface Window {
+    $message?: {
+      success: (content: string) => void
+      error: (content: string) => void
+      warning: (content: string) => void
+      info: (content: string) => void
+    }
+  }
+}
+
+export {}

--- a/frontend/src/views/Chapter.vue
+++ b/frontend/src/views/Chapter.vue
@@ -335,7 +335,8 @@ const saveStatusText = computed(() => {
 const contentDirty = computed(() => saveStatus.value === 'unsaved')
 
 const currentChapterIndex = computed(() => {
-  return chapterIds.value.indexOf(chapterId.value)
+  const cid = chapterId.value
+  return cid == null ? -1 : chapterIds.value.indexOf(cid)
 })
 
 const canPrev = computed(() => {
@@ -380,12 +381,13 @@ const onInput = () => {
 }
 
 const saveContent = async () => {
-  if (saving.value) return
+  const cid = chapterId.value
+  if (cid == null || saving.value) return
   saving.value = true
   saveStatus.value = 'saving'
 
   try {
-    await chapterApi.updateChapter(slug, chapterId.value, {
+    await chapterApi.updateChapter(slug, cid, {
       content: content.value
     })
     saveStatus.value = 'saved'
@@ -393,7 +395,7 @@ const saveContent = async () => {
     updateTime.value = new Date().toLocaleString('zh-CN', { hour12: false })
     message.success('已保存')
     // Refresh book stats after successful save
-    statsStore.onChapterSaved(slug, chapterId.value)
+    statsStore.onChapterSaved(slug, cid)
   } catch (error) {
     console.error('Failed to save content:', error)
     saveStatus.value = 'unsaved'
@@ -404,13 +406,15 @@ const saveContent = async () => {
 }
 
 const saveReview = async () => {
+  const cid = chapterId.value
+  if (cid == null) return
   savingReview.value = true
   try {
     const newStatus = statusToNew(reviewStatus.value)
-    await chapterApi.saveChapterReview(slug, chapterId.value, newStatus, reviewMemo.value)
+    await chapterApi.saveChapterReview(slug, cid, newStatus, reviewMemo.value)
     message.success('审定已保存')
     // Refresh book stats after successful save
-    statsStore.onChapterSaved(slug, chapterId.value)
+    statsStore.onChapterSaved(slug, cid)
   } catch (error) {
     console.error('Failed to save review:', error)
     message.error('保存失败，请稍后重试')
@@ -420,9 +424,11 @@ const saveReview = async () => {
 }
 
 const runAiReview = async (save: boolean) => {
+  const cid = chapterId.value
+  if (cid == null) return
   savingAiReview.value = true
   try {
-    const r = await chapterApi.reviewChapterAi(slug, chapterId.value, save)
+    const r = await chapterApi.reviewChapterAi(slug, cid, save)
     reviewStatus.value = statusToOld(r.status)
     reviewMemo.value = r.memo
     message.success(save ? '已写入审定意见' : '已填入审读意见')
@@ -443,7 +449,8 @@ const goBack = () => {
 }
 
 const goCastGraph = () => {
-  router.push({ path: `/book/${slug}/cast`, query: { chapter: String(chapterId.value) } })
+  const cid = chapterId.value
+  router.push({ path: `/book/${slug}/cast`, query: cid == null ? {} : { chapter: String(cid) } })
 }
 
 const prevChapter = () => {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -3,11 +3,15 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true

--- a/interfaces/api/v1/workbench/sandbox.py
+++ b/interfaces/api/v1/workbench/sandbox.py
@@ -1,9 +1,10 @@
 """Sandbox API endpoints for dialogue whitelist and simulation."""
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from domain.ai.services.llm_service import GenerationConfig
 from application.workbench.services.sandbox_dialogue_service import SandboxDialogueService
 from application.workbench.dtos.sandbox_dto import DialogueWhitelistResponse
 from interfaces.api.dependencies import get_sandbox_dialogue_service, get_bible_service, get_llm_service
@@ -163,12 +164,13 @@ async def patch_character_anchor(
 async def generate_dialogue(
     request: GenerateDialogueRequest,
     bible_service = Depends(get_bible_service),
-    llm_service = Depends(get_llm_service)
+    llm_service = Depends(get_llm_service),
+    sandbox_service: SandboxDialogueService = Depends(get_sandbox_dialogue_service),
 ):
     """
     AI 生成对话
 
-    根据角色锚点和场景描述，生成符合角色特征的对话
+    根据角色锚点、Bible 关系和历史对白样本，生成更贴近角色的对话
     """
     try:
         bible = bible_service.get_bible_by_novel(request.novel_id)
@@ -194,26 +196,26 @@ async def generate_dialogue(
             else (getattr(ch, "idle_behavior", None) or "")
         )
 
-        prompt = f"""你是一位专业的对话编剧。请根据以下信息生成一段对话：
+        recent_dialogues = sandbox_service.get_recent_character_dialogues(
+            request.novel_id,
+            speaker=character_name,
+            limit=4,
+        )
+        prompt = sandbox_service.build_dialogue_generation_prompt(
+            character=ch,
+            scene_prompt=request.scene_prompt,
+            mental_state=mental_state,
+            verbal_tic=verbal_tic,
+            idle_behavior=idle_behavior,
+            all_characters=bible.characters,
+            recent_dialogues=recent_dialogues,
+        )
+        config = GenerationConfig(max_tokens=240, temperature=0.85)
 
-角色：{character_name}
-心理状态：{mental_state}
-口头禅：{verbal_tic}
-待机动作/小动作：{idle_behavior}
-场景：{request.scene_prompt}
-
-要求：
-1. 对话要符合角色的心理状态和性格特征
-2. 自然融入口头禅（如果有）
-3. 必要时可描写待机动作/肢体语言（若有）
-4. 对话长度控制在 2-4 句话
-5. 只返回对话内容，不要加任何说明
-
-对话："""
-
-        # 调用 LLM 生成
-        response = await llm_service.generate(prompt, max_tokens=200)
-        dialogue = response.strip()
+        result = await llm_service.generate(prompt, config)
+        dialogue = sandbox_service.clean_generated_dialogue(result.content, character_name)
+        if not dialogue:
+            raise RuntimeError("LLM returned empty dialogue content")
 
         return GenerateDialogueResponse(
             dialogue=dialogue,

--- a/tests/integration/interfaces/api/v1/test_sandbox_api.py
+++ b/tests/integration/interfaces/api/v1/test_sandbox_api.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from application.workbench.services.sandbox_dialogue_service import SandboxDialogueService
+from application.world.dtos.bible_dto import CharacterDTO
+from domain.ai.services.llm_service import GenerationResult
+from domain.ai.value_objects.token_usage import TokenUsage
+from interfaces.api.dependencies import (
+    get_bible_service,
+    get_llm_service,
+    get_sandbox_dialogue_service,
+)
+from interfaces.main import app
+
+
+class FakeNarrativeEventRepository:
+    def __init__(self, events):
+        self._events = events
+
+    def list_up_to_chapter(self, novel_id: str, max_chapter_inclusive: int):
+        return list(self._events)
+
+
+class FakeBibleService:
+    def __init__(self):
+        self._bible = SimpleNamespace(
+            characters=[
+                CharacterDTO(
+                    id="shenji",
+                    name="沈霁",
+                    description="冷静克制的剑修",
+                    relationships=[{"target_name": "柳月", "relation": "师徒"}],
+                    public_profile="外冷内热，出手极稳",
+                    mental_state="压着火气",
+                    verbal_tic="少废话",
+                    idle_behavior="指腹轻敲剑鞘",
+                ),
+                CharacterDTO(
+                    id="liuyue",
+                    name="柳月",
+                    description="沈霁的师父，处事周全",
+                    relationships=[],
+                ),
+                CharacterDTO(
+                    id="guhan",
+                    name="顾寒",
+                    description="沈霁的旧敌",
+                    relationships=[],
+                ),
+            ]
+        )
+
+    def get_bible_by_novel(self, novel_id: str):
+        return self._bible
+
+
+class FakeLLMService:
+    def __init__(self):
+        self.prompt = None
+        self.config = None
+
+    async def generate(self, prompt, config):
+        self.prompt = prompt
+        self.config = config
+        return GenerationResult(
+            content="沈霁：少废话，让柳月退后，这里轮不到顾寒逞强。",
+            token_usage=TokenUsage(input_tokens=12, output_tokens=8),
+        )
+
+
+@pytest.fixture
+def client():
+    test_client = TestClient(app)
+    yield test_client
+    app.dependency_overrides.clear()
+
+
+def test_generate_dialogue_uses_grounded_prompt_and_strips_character_prefix(client):
+    fake_llm = FakeLLMService()
+    sandbox_service = SandboxDialogueService(
+        FakeNarrativeEventRepository(
+            [
+                {
+                    "event_id": "evt-1",
+                    "chapter_number": 12,
+                    "event_summary": "沈霁：我从不做没把握的事。",
+                    "tags": ["对话:沈霁", "场景:祠堂夜谈"],
+                },
+                {
+                    "event_id": "evt-2",
+                    "chapter_number": 15,
+                    "event_summary": "沈霁：柳月若插手，局势只会更乱。",
+                    "tags": ["对白:沈霁", "场景:雨夜巷战"],
+                },
+            ]
+        )
+    )
+
+    app.dependency_overrides[get_bible_service] = lambda: FakeBibleService()
+    app.dependency_overrides[get_llm_service] = lambda: fake_llm
+    app.dependency_overrides[get_sandbox_dialogue_service] = lambda: sandbox_service
+
+    response = client.post(
+        "/api/v1/novels/sandbox/generate-dialogue",
+        json={
+            "novel_id": "novel-1",
+            "character_id": "shenji",
+            "scene_prompt": "顾寒步步紧逼，柳月想上前挡在沈霁面前。",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "dialogue": "少废话，让柳月退后，这里轮不到顾寒逞强。",
+        "character_name": "沈霁",
+    }
+    assert fake_llm.prompt is not None
+    assert "历史对白样本" in fake_llm.prompt.user
+    assert "第15章 / 雨夜巷战：柳月若插手，局势只会更乱。" in fake_llm.prompt.user
+    assert "柳月：师徒" in fake_llm.prompt.user
+    assert "顾寒" in fake_llm.prompt.user
+    assert fake_llm.config.max_tokens == 240

--- a/tests/unit/application/services/test_sandbox_dialogue_service.py
+++ b/tests/unit/application/services/test_sandbox_dialogue_service.py
@@ -88,3 +88,11 @@ def test_build_dialogue_generation_prompt_includes_relationships_history_and_sce
     assert "场景点名的相关角色" in prompt.user
     assert "柳月" in prompt.user
     assert "少废话" in prompt.user
+
+
+def test_clean_generated_dialogue_strips_prefix_and_wrapping_quotes():
+    service = SandboxDialogueService(FakeNarrativeEventRepository([]))
+
+    cleaned = service.clean_generated_dialogue("沈霁：“少废话，退后。”", "沈霁")
+
+    assert cleaned == "少废话，退后。"

--- a/tests/unit/application/services/test_sandbox_dialogue_service.py
+++ b/tests/unit/application/services/test_sandbox_dialogue_service.py
@@ -1,0 +1,90 @@
+from application.workbench.dtos.sandbox_dto import DialogueEntry
+from application.workbench.services.sandbox_dialogue_service import SandboxDialogueService
+from application.world.dtos.bible_dto import CharacterDTO
+
+
+class FakeNarrativeEventRepository:
+    def __init__(self, events):
+        self._events = events
+
+    def list_up_to_chapter(self, novel_id: str, max_chapter_inclusive: int):
+        return list(self._events)
+
+
+def test_get_recent_character_dialogues_extracts_content_and_scene_context():
+    repo = FakeNarrativeEventRepository(
+        [
+            {
+                "event_id": "evt-1",
+                "chapter_number": 2,
+                "event_summary": "沈霁：我从不做没把握的事。",
+                "tags": ["对话:沈霁", "场景:祠堂夜谈"],
+            },
+            {
+                "event_id": "evt-2",
+                "chapter_number": 5,
+                "event_summary": "沈霁: 柳月若插手，局势只会更乱。",
+                "tags": ["对白:沈霁", "场景:雨夜巷战"],
+            },
+            {
+                "event_id": "evt-3",
+                "chapter_number": 6,
+                "event_summary": "顾寒：你还是一样嘴硬。",
+                "tags": ["对话:顾寒", "场景:城门对峙"],
+            },
+        ]
+    )
+    service = SandboxDialogueService(repo)
+
+    dialogues = service.get_recent_character_dialogues("novel-1", "沈霁", limit=2)
+
+    assert [item.chapter for item in dialogues] == [5, 2]
+    assert dialogues[0].content == "柳月若插手，局势只会更乱。"
+    assert dialogues[0].context == "雨夜巷战"
+    assert dialogues[1].content == "我从不做没把握的事。"
+
+
+def test_build_dialogue_generation_prompt_includes_relationships_history_and_scene_characters():
+    service = SandboxDialogueService(FakeNarrativeEventRepository([]))
+    character = CharacterDTO(
+        id="shenji",
+        name="沈霁",
+        description="冷静克制的剑修",
+        relationships=[{"target_name": "柳月", "relation": "师徒"}],
+        public_profile="行事果决，不喜废话",
+        mental_state="压着火气",
+        verbal_tic="少废话",
+        idle_behavior="指腹轻敲剑鞘",
+    )
+    other_character = CharacterDTO(
+        id="liuyue",
+        name="柳月",
+        description="沈霁的师父，处事周全",
+        relationships=[],
+    )
+    prompt = service.build_dialogue_generation_prompt(
+        character=character,
+        scene_prompt="顾寒逼近时，柳月想上前阻止。",
+        mental_state="压着火气",
+        verbal_tic="少废话",
+        idle_behavior="指腹轻敲剑鞘",
+        all_characters=[character, other_character],
+        recent_dialogues=[
+            DialogueEntry(
+                dialogue_id="evt-1",
+                chapter=8,
+                speaker="沈霁",
+                content="我说过，别替我做决定。",
+                context="山门争执",
+                tags=["对话:沈霁"],
+            )
+        ],
+    )
+
+    assert "角色关系" in prompt.user
+    assert "柳月：师徒" in prompt.user
+    assert "历史对白样本" in prompt.user
+    assert "第8章 / 山门争执：我说过，别替我做决定。" in prompt.user
+    assert "场景点名的相关角色" in prompt.user
+    assert "柳月" in prompt.user
+    assert "少废话" in prompt.user


### PR DESCRIPTION
## 变更摘要
当前对话沙盒在生成对白时，只使用了角色名与三项锚点信息，未充分利用 Bible 中的角色设定、角色关系与历史对白样本，容易出现口吻漂移、主说话人错位、误用其他角色语气等问题。

本 PR 对该链路做了有界增强：
- 接入目标角色最近的历史对白样本，作为声线参考
- 接入 Bible 中的人设描述、公开档案与角色关系
- 根据场景文本识别被点名的已知角色，并补充其与目标角色的关系/描述
- 修复 `/api/v1/novels/sandbox/generate-dialogue` 的调用方式，统一使用 `Prompt + GenerationConfig`
- 对生成结果做轻量清洗，避免重复输出角色名前缀
- 补充单元测试与集成测试，覆盖角色 grounding 的关键路径

## 问题背景
- 目标角色缺少历史语气约束，生成结果容易“说成别人”
- 场景中出现其他角色时，模型容易让其他角色抢走主导发言权
- 现有接口直接调用 `llm_service.generate(prompt, max_tokens=200)`，与项目统一 LLM 接口不一致

## 具体改动
### 1. 对话白名单与历史样本提取增强
- 统一从 `narrative_events` 中抽取对白事件
- 解析对白内容与场景标签，供 prompt 组装复用
- 新增目标角色最近对白样本提取能力

### 2. 对话生成 prompt grounding 增强
- 注入目标角色的人设描述、公开档案、心理状态、口头禅、常见动作
- 注入角色关系信息
- 识别场景中提到的其他已知角色，并补充其描述与关系线索
- 明确约束“目标角色必须保持主说话人地位，不能串成其他角色”

### 3. API 链路修复
- 将生成接口改为使用 `Prompt + GenerationConfig`
- 对返回文本做轻量清理，去除角色名前缀等冗余输出

## 验证
- 新增单元测试：覆盖对白提取、场景标签解析、prompt grounding 组装
- 新增集成测试：覆盖 `generate-dialogue` 接口的关键链路与返回清洗
- 本地通过依赖覆盖脚本验证：
  - 历史对白样本会被注入 prompt
  - 场景相关角色与关系信息会被注入 prompt
  - API 返回会正确去除重复角色名前缀

## 影响范围
- 仅影响对话沙盒的对白生成链路
- 不改动现有 Bible/章节数据结构
- 不改变对白白名单接口的返回结构
