### PR TITLE
支持自定义 LLM 设置与 Codex Responses 协议

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { NConfigProvider, NMessageProvider, NDialogProvider, zhCN, dateZhCN } from 'naive-ui'
 import type { GlobalThemeOverrides } from 'naive-ui'
+import LLMSettingsFab from './components/workbench/LLMSettingsFab.vue'
 
 const themeOverrides: GlobalThemeOverrides = {
   common: {
@@ -42,6 +43,7 @@ const themeOverrides: GlobalThemeOverrides = {
             <component :is="Component" />
           </transition>
         </router-view>
+        <LLMSettingsFab />
       </n-dialog-provider>
     </n-message-provider>
   </n-config-provider>

--- a/frontend/src/api/llmSettings.ts
+++ b/frontend/src/api/llmSettings.ts
@@ -1,0 +1,71 @@
+import { apiClient } from './config'
+
+export type LLMVendor = 'claude' | 'openai' | 'codex'
+export type LLMApiFormat = 'anthropic_messages' | 'openai_chat_completions' | 'openai_responses'
+
+export interface LLMSettings {
+  vendor: LLMVendor | string
+  api_format: LLMApiFormat | string
+  base_url: string
+  api_key: string
+  api_key_masked?: string
+  model: string
+  fast_model: string
+  review_model: string
+  scene_director_model: string
+  state_extractor_model: string
+  temperature: number
+  max_tokens: number
+  timeout_ms: number
+}
+
+export interface LLMPreset extends LLMSettings {
+  id: string
+  name: string
+  updated_at: string
+}
+
+export interface LLMSettingsResponse extends LLMSettings {
+  active_preset_id?: string | null
+  presets: LLMPreset[]
+}
+
+export interface LLMTestPayload extends LLMSettings {
+  prompt?: string
+}
+
+export interface LLMTestResult {
+  success: boolean
+  vendor: string
+  api_format: string
+  model: string
+  message: string
+}
+
+export interface ModelOption {
+  label: string
+  value: string
+}
+
+export interface ModelListResult {
+  success: boolean
+  items: ModelOption[]
+  count: number
+}
+
+export interface SavePresetPayload {
+  preset_id?: string | null
+  name: string
+  set_active: boolean
+  settings: LLMSettings
+}
+
+export const llmSettingsApi = {
+  get: () => apiClient.get<LLMSettingsResponse>('/settings/llm') as Promise<LLMSettingsResponse>,
+  save: (payload: LLMSettings) => apiClient.put<LLMSettingsResponse>('/settings/llm', payload) as Promise<LLMSettingsResponse>,
+  test: (payload: LLMTestPayload) => apiClient.post<LLMTestResult>('/settings/llm/test', payload) as Promise<LLMTestResult>,
+  listModels: (payload: LLMSettings) => apiClient.post<ModelListResult>('/settings/llm/models', payload) as Promise<ModelListResult>,
+  savePreset: (payload: SavePresetPayload) => apiClient.post<LLMSettingsResponse>('/settings/llm/presets', payload) as Promise<LLMSettingsResponse>,
+  activatePreset: (presetId: string) => apiClient.post<LLMSettingsResponse>(`/settings/llm/presets/${presetId}/activate`, {}) as Promise<LLMSettingsResponse>,
+  deletePreset: (presetId: string) => apiClient.delete<LLMSettingsResponse>(`/settings/llm/presets/${presetId}`) as Promise<LLMSettingsResponse>,
+}

--- a/frontend/src/components/workbench/LLMSettingsFab.vue
+++ b/frontend/src/components/workbench/LLMSettingsFab.vue
@@ -1,0 +1,817 @@
+<template>
+  <div class="llm-fab-wrap" :style="fabStyle">
+    <n-button
+      class="llm-fab"
+      circle
+      type="primary"
+      size="large"
+      @pointerdown="handlePointerDown"
+      @click="handleFabClick"
+    >
+      <template #icon>
+        <n-icon><SettingsOutline /></n-icon>
+      </template>
+    </n-button>
+
+    <n-modal
+      v-model:show="showModal"
+      preset="card"
+      title="模型接入配置"
+      class="llm-settings-modal"
+      style="width: min(840px, 96vw)"
+      :bordered="false"
+      :segmented="{ content: true, footer: 'soft' }"
+      @after-enter="handleOpen"
+    >
+      <template #header-extra>
+        <n-space :size="8" align="center">
+          <n-tag size="small" round :bordered="false">{{ vendorLabel }}</n-tag>
+          <n-tag size="small" round type="success" :bordered="false">{{ formatLabel }}</n-tag>
+          <n-tag v-if="activePresetName" size="small" round type="warning" :bordered="false">
+            {{ activePresetName }}
+          </n-tag>
+        </n-space>
+      </template>
+
+      <div class="llm-settings-body">
+        <n-alert type="info" :show-icon="true" class="llm-tip">
+          支持首页和工作台统一配置。你可以直接填入自定义 API Key，也可以把当前配置保存成预设，后续一键切换。
+        </n-alert>
+
+        <n-card size="small" :bordered="false" class="llm-section-card">
+          <template #header>
+            <n-space justify="space-between" align="center" style="width: 100%">
+              <span>预设管理</span>
+              <n-space :size="8">
+                <n-button size="small" secondary :disabled="!selectedPresetId" @click="handleApplyPreset">
+                  应用预设
+                </n-button>
+                <n-button size="small" secondary :disabled="!selectedPresetId" @click="handleDeletePreset">
+                  删除预设
+                </n-button>
+              </n-space>
+            </n-space>
+          </template>
+
+          <n-grid :cols="24" :x-gap="12">
+            <n-gi :span="10">
+              <n-form-item label="已保存预设">
+                <n-select
+                  v-model:value="selectedPresetId"
+                  clearable
+                  filterable
+                  :options="presetOptions"
+                  placeholder="选择一个预设"
+                />
+              </n-form-item>
+            </n-gi>
+            <n-gi :span="9">
+              <n-form-item label="预设名称">
+                <n-input v-model:value="presetName" placeholder="例如 我的 Grok / Claude 正式环境" />
+              </n-form-item>
+            </n-gi>
+            <n-gi :span="5">
+              <n-form-item label="保存当前">
+                <n-button block type="primary" secondary :loading="presetSaving" @click="handleSavePreset">
+                  保存为预设
+                </n-button>
+              </n-form-item>
+            </n-gi>
+          </n-grid>
+        </n-card>
+
+        <div class="preset-grid">
+          <button
+            v-for="preset in vendorPresets"
+            :key="preset.id"
+            type="button"
+            class="preset-card"
+            :class="{ 'preset-card--active': form.vendor === preset.id }"
+            @click="applyVendorPreset(preset.id)"
+          >
+            <span class="preset-title">{{ preset.label }}</span>
+            <span class="preset-sub">{{ preset.description }}</span>
+          </button>
+        </div>
+
+        <n-grid :cols="24" :x-gap="12">
+          <n-form label-placement="top" class="llm-form">
+            <n-gi :span="12">
+              <n-form-item label="协议格式">
+                <n-select v-model:value="form.api_format" :options="formatOptions" />
+              </n-form-item>
+            </n-gi>
+            <n-gi :span="12">
+              <n-form-item label="模型名">
+                <n-space vertical :size="8" style="width: 100%">
+                  <n-text depth="3" style="font-size: 12px">主模型</n-text>
+                  <n-auto-complete
+                    v-model:value="form.model"
+                    :options="modelOptions"
+                    placeholder="例如 grok-4.20-0309 / claude-sonnet-4-5 / gpt-5.2-codex"
+                  />
+                </n-space>
+              </n-form-item>
+            </n-gi>
+          </n-form>
+        </n-grid>
+
+        <n-card size="small" :bordered="false" class="llm-section-card endpoint-card">
+          <template #header>
+            <span>自定义 API 地址</span>
+          </template>
+
+          <n-space vertical :size="10">
+            <n-text depth="3" style="font-size: 12px">
+              {{ resolvedBaseUrlHelpText }}
+            </n-text>
+            <n-input
+              v-model:value="form.base_url"
+              :placeholder="resolvedBaseUrlPlaceholder"
+            />
+            <n-tag size="small" round type="info" :bordered="false">
+              当前协议：{{ formatLabel }}
+            </n-tag>
+          </n-space>
+        </n-card>
+
+        <n-card size="small" :bordered="false" class="llm-section-card api-key-card">
+          <template #header>
+            <n-space justify="space-between" align="center" style="width: 100%">
+              <span>自定义 API Key</span>
+              <n-text depth="3" style="font-size: 12px">
+                当前：{{ form.api_key ? '本次已输入' : (maskedApiKey || '未设置') }}
+              </n-text>
+            </n-space>
+          </template>
+
+          <n-space vertical :size="10">
+            <n-text depth="3" style="font-size: 12px">
+              可以直接填入新的 key。留空保存时不会覆盖已经保存的密钥。
+            </n-text>
+            <n-input
+              v-model:value="form.api_key"
+              type="password"
+              show-password-on="click"
+              :placeholder="apiKeyPlaceholder"
+            />
+            <n-space justify="space-between" align="center" style="width: 100%">
+              <n-text depth="3" style="font-size: 12px">
+                先确认地址和 Key 正确，再拉取可用模型；拉取后主模型和高级模型都可直接下拉选择。
+              </n-text>
+              <n-button type="primary" secondary :loading="modelsLoading" @click="handleLoadModels">
+                拉取模型列表
+              </n-button>
+            </n-space>
+          </n-space>
+        </n-card>
+
+        <n-collapse :default-expanded-names="['advanced-models']">
+          <n-collapse-item title="高级模型覆盖" name="advanced-models">
+            <n-grid :cols="24" :x-gap="12">
+              <n-gi :span="12">
+                <n-form-item label="快速模型">
+                  <n-select
+                    v-model:value="form.fast_model"
+                    filterable
+                    tag
+                    :options="modelOptions"
+                    placeholder="留空则跟随主模型，也可手动输入"
+                  />
+                </n-form-item>
+              </n-gi>
+              <n-gi :span="12">
+                <n-form-item label="审阅模型">
+                  <n-select
+                    v-model:value="form.review_model"
+                    filterable
+                    tag
+                    :options="modelOptions"
+                    placeholder="留空则跟随快速模型，也可手动输入"
+                  />
+                </n-form-item>
+              </n-gi>
+              <n-gi :span="12">
+                <n-form-item label="场景分析模型">
+                  <n-select
+                    v-model:value="form.scene_director_model"
+                    filterable
+                    tag
+                    :options="modelOptions"
+                    placeholder="留空则跟随快速模型，也可手动输入"
+                  />
+                </n-form-item>
+              </n-gi>
+              <n-gi :span="12">
+                <n-form-item label="状态提取模型">
+                  <n-select
+                    v-model:value="form.state_extractor_model"
+                    filterable
+                    tag
+                    :options="modelOptions"
+                    placeholder="留空则跟随主模型，也可手动输入"
+                  />
+                </n-form-item>
+              </n-gi>
+              <n-gi :span="8">
+                <n-form-item label="Temperature">
+                  <n-input-number v-model:value="form.temperature" :min="0" :max="2" :step="0.1" style="width: 100%" />
+                </n-form-item>
+              </n-gi>
+              <n-gi :span="8">
+                <n-form-item label="Max Tokens">
+                  <n-input-number v-model:value="form.max_tokens" :min="1" :step="256" style="width: 100%" />
+                </n-form-item>
+              </n-gi>
+              <n-gi :span="8">
+                <n-form-item label="超时(ms)">
+                  <n-input-number v-model:value="form.timeout_ms" :min="1000" :step="1000" style="width: 100%" />
+                </n-form-item>
+              </n-gi>
+            </n-grid>
+          </n-collapse-item>
+        </n-collapse>
+
+        <n-alert v-if="testResult" :type="testResult.success ? 'success' : 'warning'" :show-icon="true" class="llm-test-result">
+          {{ testResult.message }}
+        </n-alert>
+      </div>
+
+      <template #footer>
+        <n-space justify="space-between" style="width: 100%">
+          <n-text depth="3" style="font-size: 12px">
+            保存后立即生效；预设用于快速切换不同供应商和模型配置。
+          </n-text>
+          <n-space :size="10">
+            <n-button @click="showModal = false">关闭</n-button>
+            <n-button :loading="testing" @click="handleTest">测试连接</n-button>
+            <n-button type="primary" :loading="saving" @click="handleSave">保存当前配置</n-button>
+          </n-space>
+        </n-space>
+      </template>
+    </n-modal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { NIcon, useDialog, useMessage } from 'naive-ui'
+import { SettingsOutline } from '@vicons/ionicons5'
+import {
+  llmSettingsApi,
+  type LLMSettings,
+  type LLMSettingsResponse,
+  type ModelOption,
+  type LLMPreset,
+} from '../../api/llmSettings'
+
+const message = useMessage()
+const dialog = useDialog()
+
+const showModal = ref(false)
+const loading = ref(false)
+const saving = ref(false)
+const testing = ref(false)
+const modelsLoading = ref(false)
+const presetSaving = ref(false)
+const maskedApiKey = ref('')
+const testResult = ref<{ success: boolean; message: string } | null>(null)
+const modelOptions = ref<ModelOption[]>([])
+const presets = ref<LLMPreset[]>([])
+const selectedPresetId = ref<string | null>(null)
+const activePresetId = ref<string | null>(null)
+const presetName = ref('')
+const FAB_SIZE = 56
+const FAB_MARGIN = 22
+const FAB_STORAGE_KEY = 'plotpilot.llm-settings-fab-position'
+const fabPosition = reactive({ x: 0, y: 0 })
+const dragState = reactive({
+  active: false,
+  pointerId: -1,
+  startX: 0,
+  startY: 0,
+  originX: 0,
+  originY: 0,
+  moved: false,
+})
+const suppressNextClick = ref(false)
+
+const vendorPresets = [
+  { id: 'claude', label: 'Claude', description: 'Anthropic 原生 Messages 格式' },
+  { id: 'openai', label: 'OpenAI', description: 'OpenAI 兼容 Chat Completions' },
+  { id: 'codex', label: 'Codex', description: '适合 OpenAI/Codex 兼容接口' },
+]
+
+const form = reactive<LLMSettings>({
+  vendor: 'openai',
+  api_format: 'openai_chat_completions',
+  base_url: '',
+  api_key: '',
+  model: '',
+  fast_model: '',
+  review_model: '',
+  scene_director_model: '',
+  state_extractor_model: '',
+  temperature: 0.7,
+  max_tokens: 4096,
+  timeout_ms: 300000,
+})
+
+const formatOptions = [
+  { label: 'Anthropic Messages', value: 'anthropic_messages' },
+  { label: 'OpenAI Chat Completions', value: 'openai_chat_completions' },
+  { label: 'OpenAI Responses / Codex', value: 'openai_responses' },
+]
+
+const presetOptions = computed(() => (
+  presets.value.map(item => ({
+    label: activePresetId.value === item.id ? `${item.name} (当前)` : item.name,
+    value: item.id,
+  }))
+))
+
+const activePresetName = computed(() => (
+  presets.value.find(item => item.id === activePresetId.value)?.name || ''
+))
+
+const vendorLabel = computed(() => {
+  const found = vendorPresets.find(item => item.id === form.vendor)
+  return found?.label || String(form.vendor)
+})
+
+const formatLabel = computed(() => {
+  if (form.api_format === 'anthropic_messages') return 'Anthropic'
+  if (form.api_format === 'openai_responses') return 'OpenAI Responses / Codex'
+  return 'OpenAI Compatible'
+})
+
+const baseUrlPlaceholder = computed(() => (
+  form.api_format === 'anthropic_messages'
+    ? '例如 https://your-anthropic-endpoint'
+    : '例如 https://your-openai-compatible-endpoint/v1'
+))
+
+const baseUrlHelpText = computed(() => (
+  form.api_format === 'anthropic_messages'
+    ? '这里可以填写自定义的 Anthropic 兼容地址。通常填写根地址即可，不需要手动补 /v1/messages。'
+    : '这里可以填写你自己的 OpenAI 兼容 API 地址。多数第三方网关建议填写到 /v1。'
+))
+
+const resolvedBaseUrlPlaceholder = computed(() => {
+  if (form.api_format === 'anthropic_messages') return baseUrlPlaceholder.value
+  if (form.api_format === 'openai_responses') return '例如 https://your-openai-compatible-endpoint/v1'
+  return baseUrlPlaceholder.value
+})
+
+const resolvedBaseUrlHelpText = computed(() => {
+  if (form.api_format === 'anthropic_messages') return baseUrlHelpText.value
+  if (form.api_format === 'openai_responses') {
+    return '这里填写支持 OpenAI Responses / Codex Responses 协议的根地址，通常填到 /v1，系统会自动拼接 /responses。'
+  }
+  return baseUrlHelpText.value
+})
+
+const apiKeyPlaceholder = computed(() => (
+  maskedApiKey.value ? `当前已保存：${maskedApiKey.value}；留空则不覆盖` : '输入 API Key'
+))
+
+const fabStyle = computed(() => ({
+  left: `${fabPosition.x}px`,
+  top: `${fabPosition.y}px`,
+}))
+
+function mergeModelOptions(base: ModelOption[], values: Array<string | undefined>): ModelOption[] {
+  const map = new Map<string, ModelOption>()
+  for (const item of base) {
+    if (!item?.value) continue
+    map.set(item.value, item)
+  }
+  for (const raw of values) {
+    const value = String(raw || '').trim()
+    if (!value || map.has(value)) continue
+    map.set(value, { label: value, value })
+  }
+  return Array.from(map.values()).sort((a, b) => a.value.localeCompare(b.value))
+}
+
+function syncCurrentModelsIntoOptions(base: ModelOption[] = modelOptions.value) {
+  modelOptions.value = mergeModelOptions(base, [
+    form.model,
+    form.fast_model,
+    form.review_model,
+    form.scene_director_model,
+    form.state_extractor_model,
+  ])
+}
+
+function assignSettings(data: LLMSettings) {
+  form.vendor = data.vendor || 'openai'
+  form.api_format = data.api_format || 'openai_chat_completions'
+  form.base_url = data.base_url || ''
+  form.api_key = ''
+  form.model = data.model || ''
+  form.fast_model = data.fast_model || ''
+  form.review_model = data.review_model || ''
+  form.scene_director_model = data.scene_director_model || ''
+  form.state_extractor_model = data.state_extractor_model || ''
+  form.temperature = Number(data.temperature ?? 0.7)
+  form.max_tokens = Number(data.max_tokens ?? 4096)
+  form.timeout_ms = Number(data.timeout_ms ?? 300000)
+  maskedApiKey.value = data.api_key_masked || ''
+  syncCurrentModelsIntoOptions([])
+}
+
+function assignResponse(data: LLMSettingsResponse) {
+  assignSettings(data)
+  presets.value = data.presets || []
+  activePresetId.value = data.active_preset_id || null
+  selectedPresetId.value = data.active_preset_id || null
+  if (!presetName.value && activePresetId.value) {
+    const active = presets.value.find(item => item.id === activePresetId.value)
+    presetName.value = active?.name || ''
+  }
+  syncCurrentModelsIntoOptions(modelOptions.value)
+}
+
+function applyVendorPreset(vendor: string) {
+  form.vendor = vendor
+  if (vendor === 'claude') {
+    form.api_format = 'anthropic_messages'
+    return
+  }
+
+  form.api_format = vendor === 'codex' ? 'openai_responses' : 'openai_chat_completions'
+  if (vendor === 'codex' && !form.model) form.model = 'gpt-5.2-codex'
+}
+
+function getViewportBounds() {
+  const maxX = Math.max(FAB_MARGIN, window.innerWidth - FAB_SIZE - FAB_MARGIN)
+  const maxY = Math.max(FAB_MARGIN, window.innerHeight - FAB_SIZE - FAB_MARGIN)
+  return {
+    minX: FAB_MARGIN,
+    minY: FAB_MARGIN,
+    maxX,
+    maxY,
+  }
+}
+
+function clampFabPosition(x: number, y: number) {
+  const bounds = getViewportBounds()
+  return {
+    x: Math.min(bounds.maxX, Math.max(bounds.minX, x)),
+    y: Math.min(bounds.maxY, Math.max(bounds.minY, y)),
+  }
+}
+
+function defaultFabPosition() {
+  const bounds = getViewportBounds()
+  return {
+    x: bounds.maxX,
+    y: bounds.maxY,
+  }
+}
+
+function saveFabPosition() {
+  try {
+    window.localStorage.setItem(FAB_STORAGE_KEY, JSON.stringify({
+      x: fabPosition.x,
+      y: fabPosition.y,
+    }))
+  } catch {
+    /* ignore */
+  }
+}
+
+function applyFabPosition(x: number, y: number, persist = true) {
+  const next = clampFabPosition(x, y)
+  fabPosition.x = next.x
+  fabPosition.y = next.y
+  if (persist) saveFabPosition()
+}
+
+function loadFabPosition() {
+  const fallback = defaultFabPosition()
+  try {
+    const raw = window.localStorage.getItem(FAB_STORAGE_KEY)
+    if (!raw) {
+      applyFabPosition(fallback.x, fallback.y, false)
+      return
+    }
+    const parsed = JSON.parse(raw) as { x?: number; y?: number }
+    const x = Number(parsed?.x)
+    const y = Number(parsed?.y)
+    if (Number.isFinite(x) && Number.isFinite(y)) {
+      applyFabPosition(x, y, false)
+      return
+    }
+  } catch {
+    /* ignore */
+  }
+  applyFabPosition(fallback.x, fallback.y, false)
+}
+
+function handlePointerMove(event: PointerEvent) {
+  if (!dragState.active || event.pointerId !== dragState.pointerId) return
+
+  const deltaX = event.clientX - dragState.startX
+  const deltaY = event.clientY - dragState.startY
+  if (!dragState.moved && Math.hypot(deltaX, deltaY) >= 6) {
+    dragState.moved = true
+  }
+  if (!dragState.moved) return
+
+  applyFabPosition(dragState.originX + deltaX, dragState.originY + deltaY)
+}
+
+function stopDragging() {
+  dragState.active = false
+  dragState.pointerId = -1
+  dragState.startX = 0
+  dragState.startY = 0
+  dragState.originX = 0
+  dragState.originY = 0
+}
+
+function handlePointerUp(event: PointerEvent) {
+  if (!dragState.active || event.pointerId !== dragState.pointerId) return
+  suppressNextClick.value = dragState.moved
+  stopDragging()
+}
+
+function handlePointerDown(event: PointerEvent) {
+  if (event.button !== 0) return
+  dragState.active = true
+  dragState.pointerId = event.pointerId
+  dragState.startX = event.clientX
+  dragState.startY = event.clientY
+  dragState.originX = fabPosition.x
+  dragState.originY = fabPosition.y
+  dragState.moved = false
+}
+
+function handleFabClick() {
+  if (suppressNextClick.value) {
+    suppressNextClick.value = false
+    return
+  }
+  showModal.value = true
+}
+
+function handleWindowResize() {
+  applyFabPosition(fabPosition.x, fabPosition.y, false)
+}
+
+async function loadSettings() {
+  loading.value = true
+  try {
+    const data = await llmSettingsApi.get()
+    assignResponse(data)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleOpen() {
+  testResult.value = null
+  await loadSettings()
+}
+
+async function handleSave() {
+  saving.value = true
+  try {
+    const saved = await llmSettingsApi.save({ ...form })
+    assignResponse(saved)
+    message.success('模型接入配置已保存')
+  } catch (error) {
+    const err = error as { response?: { data?: { detail?: string } }; message?: string }
+    message.error(err.response?.data?.detail || err.message || '保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function handleSavePreset() {
+  if (!presetName.value.trim()) {
+    message.warning('先填写预设名称')
+    return
+  }
+
+  presetSaving.value = true
+  try {
+    const result = await llmSettingsApi.savePreset({
+      preset_id: selectedPresetId.value,
+      name: presetName.value.trim(),
+      set_active: true,
+      settings: { ...form },
+    })
+    assignResponse(result)
+    const active = presets.value.find(item => item.id === activePresetId.value)
+    presetName.value = active?.name || presetName.value
+    message.success('预设已保存并设为当前配置')
+  } catch (error) {
+    const err = error as { response?: { data?: { detail?: string } }; message?: string }
+    message.error(err.response?.data?.detail || err.message || '保存预设失败')
+  } finally {
+    presetSaving.value = false
+  }
+}
+
+async function handleApplyPreset() {
+  if (!selectedPresetId.value) {
+    message.warning('先选择一个预设')
+    return
+  }
+
+  try {
+    const result = await llmSettingsApi.activatePreset(selectedPresetId.value)
+    assignResponse(result)
+    const active = presets.value.find(item => item.id === activePresetId.value)
+    presetName.value = active?.name || ''
+    message.success('预设已应用')
+  } catch (error) {
+    const err = error as { response?: { data?: { detail?: string } }; message?: string }
+    message.error(err.response?.data?.detail || err.message || '应用预设失败')
+  }
+}
+
+async function handleDeletePreset() {
+  if (!selectedPresetId.value) {
+    message.warning('先选择一个预设')
+    return
+  }
+
+  const preset = presets.value.find(item => item.id === selectedPresetId.value)
+  dialog.warning({
+    title: '删除预设',
+    content: `确认删除预设“${preset?.name || '未命名预设'}”？`,
+    positiveText: '删除',
+    negativeText: '取消',
+    async onPositiveClick() {
+      const result = await llmSettingsApi.deletePreset(selectedPresetId.value as string)
+      assignResponse(result)
+      presetName.value = ''
+      message.success('预设已删除')
+    },
+  })
+}
+
+async function handleTest() {
+  testing.value = true
+  testResult.value = null
+  try {
+    const result = await llmSettingsApi.test({ ...form })
+    testResult.value = { success: true, message: result.message }
+    message.success('连接测试成功')
+  } catch (error) {
+    const err = error as { response?: { data?: { detail?: string } }; message?: string }
+    const detail = err.response?.data?.detail || err.message || '连接测试失败'
+    testResult.value = { success: false, message: detail }
+    message.error(detail)
+  } finally {
+    testing.value = false
+  }
+}
+
+async function handleLoadModels() {
+  modelsLoading.value = true
+  try {
+    const result = await llmSettingsApi.listModels({ ...form })
+    modelOptions.value = mergeModelOptions(result.items, [
+      form.model,
+      form.fast_model,
+      form.review_model,
+      form.scene_director_model,
+      form.state_extractor_model,
+    ])
+    if (!result.items.length) {
+      message.warning('没有拉取到可选模型，请检查接口兼容性')
+      return
+    }
+    message.success(`已获取 ${result.count} 个模型`)
+  } catch (error) {
+    const err = error as { response?: { data?: { detail?: string } }; message?: string }
+    message.error(err.response?.data?.detail || err.message || '获取模型列表失败')
+  } finally {
+    modelsLoading.value = false
+  }
+}
+
+onMounted(() => {
+  loadFabPosition()
+  window.addEventListener('pointermove', handlePointerMove)
+  window.addEventListener('pointerup', handlePointerUp)
+  window.addEventListener('pointercancel', handlePointerUp)
+  window.addEventListener('resize', handleWindowResize)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('pointermove', handlePointerMove)
+  window.removeEventListener('pointerup', handlePointerUp)
+  window.removeEventListener('pointercancel', handlePointerUp)
+  window.removeEventListener('resize', handleWindowResize)
+})
+</script>
+
+<style scoped>
+.llm-fab-wrap {
+  position: fixed;
+  z-index: 1200;
+}
+
+.llm-fab {
+  width: 56px;
+  height: 56px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 14px 32px rgba(79, 70, 229, 0.28), 0 4px 12px rgba(15, 23, 42, 0.16);
+  touch-action: none;
+  user-select: none;
+  cursor: grab;
+}
+
+.llm-fab:active {
+  cursor: grabbing;
+}
+
+.llm-fab:hover {
+  transform: translateY(-1px);
+}
+
+.llm-settings-modal :deep(.n-card) {
+  border-radius: 18px;
+}
+
+.llm-settings-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.llm-tip {
+  border-radius: 14px;
+}
+
+.llm-section-card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(246, 248, 255, 0.98));
+  border: 1px solid rgba(99, 102, 241, 0.12);
+}
+
+.api-key-card {
+  background: linear-gradient(180deg, rgba(248, 250, 255, 0.98), rgba(239, 246, 255, 0.98));
+}
+
+.preset-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.preset-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(99, 102, 241, 0.14);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 246, 255, 0.96));
+  text-align: left;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  cursor: pointer;
+}
+
+.preset-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+}
+
+.preset-card--active {
+  border-color: rgba(79, 70, 229, 0.55);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.14);
+  background: linear-gradient(180deg, rgba(238, 242, 255, 0.98), rgba(248, 250, 255, 0.98));
+}
+
+.preset-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.preset-sub {
+  font-size: 12px;
+  line-height: 1.45;
+  color: #6b7280;
+}
+
+.llm-form :deep(.n-form-item) {
+  margin-bottom: 0;
+}
+
+.llm-test-result {
+  border-radius: 14px;
+}
+
+@media (max-width: 900px) {
+  .preset-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+</style>

--- a/infrastructure/ai/model_defaults.py
+++ b/infrastructure/ai/model_defaults.py
@@ -1,0 +1,48 @@
+"""Helpers for resolving runtime LLM model names from runtime settings and env."""
+import os
+
+from infrastructure.ai.runtime_settings import load_llm_settings
+
+
+def get_openai_default_model() -> str:
+    """Default model for OpenAI-compatible providers."""
+    runtime = load_llm_settings()
+    return runtime.get("model") or os.getenv("OPENAI_MODEL") or os.getenv("LLM_MODEL") or "gpt-4o"
+
+
+def get_anthropic_default_model() -> str:
+    """Default model for Anthropic providers."""
+    runtime = load_llm_settings()
+    return runtime.get("model") or os.getenv("ANTHROPIC_MODEL") or os.getenv("LLM_MODEL") or "claude-sonnet-4-6"
+
+
+def get_default_model() -> str:
+    """Provider-aware default model for generic runtime components."""
+    provider = (load_llm_settings().get("api_format") or "").lower()
+    if provider != "anthropic_messages":
+        return get_openai_default_model()
+    return get_anthropic_default_model()
+
+
+def get_fast_model() -> str:
+    """Fast-path model for lightweight analysis tasks."""
+    runtime = load_llm_settings()
+    return runtime.get("fast_model") or os.getenv("FAST_LLM_MODEL") or get_default_model()
+
+
+def get_review_model() -> str:
+    """Model used for review and audit tasks."""
+    runtime = load_llm_settings()
+    return runtime.get("review_model") or os.getenv("REVIEW_LLM_MODEL") or get_fast_model()
+
+
+def get_scene_director_model() -> str:
+    """Model used by scene director analysis."""
+    runtime = load_llm_settings()
+    return runtime.get("scene_director_model") or os.getenv("SCENE_DIRECTOR_MODEL") or get_fast_model()
+
+
+def get_state_extractor_model() -> str:
+    """Model used for chapter-state extraction."""
+    runtime = load_llm_settings()
+    return runtime.get("state_extractor_model") or os.getenv("STATE_EXTRACTOR_MODEL") or get_default_model()

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -1,95 +1,69 @@
-"""OpenAI LLM 提供商实现"""
+"""OpenAI-compatible provider supporting chat completions and responses APIs."""
+import json
 import logging
-import os
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
-from openai import AsyncOpenAI
+import httpx
 
 from domain.ai.services.llm_service import GenerationConfig, GenerationResult
 from domain.ai.value_objects.prompt import Prompt
 from domain.ai.value_objects.token_usage import TokenUsage
 from infrastructure.ai.config.settings import Settings
+from infrastructure.ai.model_defaults import get_openai_default_model
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
 
-# 从环境变量读取模型配置，默认使用 gpt-4o
-DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
-
 
 class OpenAIProvider(BaseProvider):
-    """OpenAI LLM 提供商实现
-    
-    使用 OpenAI API 实现 LLM 服务。
-    """
+    """Provider for OpenAI-compatible chat completions and responses APIs."""
 
-    def __init__(self, settings: Settings):
-        """初始化 OpenAI 提供商
-        
-        Args:
-            settings: AI 配置设置
-            
-        Raises:
-            ValueError: 如果 API key 未设置
-        """
+    def __init__(self, settings: Settings, api_format: str = "openai_chat_completions"):
         super().__init__(settings)
-        
+
         if not settings.api_key:
             raise ValueError("API key is required for OpenAIProvider")
-            
-        # 初始化 AsyncOpenAI 客户端
-        client_kwargs = {
-            "api_key": settings.api_key,
+
+        self.api_format = (api_format or "openai_chat_completions").strip().lower()
+        base_url = (settings.base_url or "https://api.openai.com/v1").rstrip("/")
+        self.chat_url = f"{base_url}/chat/completions"
+        self.responses_url = f"{base_url}/responses"
+        self.headers = {
+            "Authorization": f"Bearer {settings.api_key}",
+            "Content-Type": "application/json",
         }
-        if settings.base_url:
-            client_kwargs["base_url"] = settings.base_url
-            
-        self.async_client = AsyncOpenAI(**client_kwargs)
 
     async def generate(
         self,
         prompt: Prompt,
         config: GenerationConfig
     ) -> GenerationResult:
-        """生成文本
-        
-        Args:
-            prompt: 提示词
-            config: 生成配置
-            
-        Returns:
-            生成结果
-            
-        Raises:
-            RuntimeError: 当 API 调用失败或返回空内容时
-        """
+        payload = self._build_payload(prompt, config, stream=False)
+        url = self._request_url()
+
         try:
-            messages = [
-                {"role": "system", "content": prompt.system},
-                {"role": "user", "content": prompt.user}
-            ]
-            
-            response = await self.async_client.chat.completions.create(
-                model=config.model or DEFAULT_MODEL,
-                messages=messages,
-                temperature=config.temperature,
-                max_tokens=config.max_tokens,
-            )
-            
-            if not response.choices or not response.choices[0].message.content:
-                raise RuntimeError("API returned empty content")
-                
-            content = response.choices[0].message.content
-            
-            input_tokens = response.usage.prompt_tokens if response.usage else 0
-            output_tokens = response.usage.completion_tokens if response.usage else 0
-            token_usage = TokenUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens
-            )
-            
-            return GenerationResult(content=content, token_usage=token_usage)
-            
+            async with httpx.AsyncClient(timeout=300.0) as client:
+                response = await client.post(url, headers=self.headers, json=payload)
+                response.raise_for_status()
+
+                content_type = response.headers.get("content-type", "").lower()
+                if "text/event-stream" in content_type:
+                    content, prompt_tokens, completion_tokens = self._collect_sse_text(response.text)
+                else:
+                    data = response.json()
+                    content = self._extract_content(data)
+                    prompt_tokens, completion_tokens = self._extract_usage(data)
+
+                if not content or not content.strip():
+                    raise RuntimeError("API returned empty content")
+
+                return GenerationResult(
+                    content=content,
+                    token_usage=TokenUsage(
+                        input_tokens=prompt_tokens,
+                        output_tokens=completion_tokens,
+                    ),
+                )
         except RuntimeError:
             raise
         except Exception as e:
@@ -100,36 +74,274 @@ class OpenAIProvider(BaseProvider):
         prompt: Prompt,
         config: GenerationConfig
     ) -> AsyncIterator[str]:
-        """流式生成内容
-        
-        Args:
-            prompt: 提示词
-            config: 生成配置
-            
-        Yields:
-            生成的文本片段
-            
-        Raises:
-            RuntimeError: 当流式生成失败时
-        """
+        payload = self._build_payload(prompt, config, stream=True)
+        url = self._request_url()
+
         try:
-            messages = [
-                {"role": "system", "content": prompt.system},
-                {"role": "user", "content": prompt.user}
-            ]
-            
-            stream = await self.async_client.chat.completions.create(
-                model=config.model or DEFAULT_MODEL,
-                messages=messages,
-                temperature=config.temperature,
-                max_tokens=config.max_tokens,
-                stream=True,
-            )
-            
-            async for chunk in stream:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    yield chunk.choices[0].delta.content
-                    
+            async with httpx.AsyncClient(timeout=300.0) as client:
+                async with client.stream("POST", url, headers=self.headers, json=payload) as response:
+                    response.raise_for_status()
+
+                    content_type = response.headers.get("content-type", "").lower()
+                    if "text/event-stream" not in content_type:
+                        text = await response.aread()
+                        decoded = text.decode(errors="replace")
+                        try:
+                            data = json.loads(decoded)
+                            content = self._extract_content(data)
+                        except Exception:
+                            content = decoded
+                        if content:
+                            yield content
+                        return
+
+                    buffer = ""
+                    async for chunk in response.aiter_text():
+                        buffer += chunk
+                        while "\n\n" in buffer:
+                            event_text, buffer = buffer.split("\n\n", 1)
+                            for piece in self._parse_sse_event(event_text):
+                                yield piece
+
+                    if buffer.strip():
+                        for piece in self._parse_sse_event(buffer):
+                            yield piece
         except Exception as e:
-            logger.error(f"[Stream] Failed: {e}")
+            logger.error("[OpenAIProvider stream] Failed: %s", e)
             raise RuntimeError(f"Failed to stream text: {str(e)}") from e
+
+    def _request_url(self) -> str:
+        return self.responses_url if self.api_format == "openai_responses" else self.chat_url
+
+    def _build_payload(self, prompt: Prompt, config: GenerationConfig, stream: bool) -> dict[str, Any]:
+        model = config.model or get_openai_default_model()
+        if self.api_format == "openai_responses":
+            payload: dict[str, Any] = {
+                "model": model,
+                "instructions": prompt.system,
+                "input": prompt.user,
+                "max_output_tokens": config.max_tokens,
+                "stream": stream,
+            }
+            if config.temperature is not None:
+                payload["temperature"] = config.temperature
+            return payload
+
+        return {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": prompt.system},
+                {"role": "user", "content": prompt.user},
+            ],
+            "temperature": config.temperature,
+            "max_tokens": config.max_tokens,
+            "stream": stream,
+        }
+
+    def _extract_content(self, data: Any) -> str:
+        if self.api_format == "openai_responses":
+            return self._extract_responses_content(data)
+        return self._extract_chat_content(data)
+
+    def _extract_usage(self, data: Any) -> tuple[int, int]:
+        if not isinstance(data, dict):
+            return 0, 0
+
+        usage = data.get("usage", {})
+        if self.api_format == "openai_responses" and not usage and isinstance(data.get("response"), dict):
+            usage = data["response"].get("usage", {})
+        if not isinstance(usage, dict):
+            return 0, 0
+
+        if self.api_format == "openai_responses":
+            input_tokens = int(usage.get("input_tokens", 0) or 0)
+            output_tokens = int(usage.get("output_tokens", 0) or 0)
+            if not input_tokens and not output_tokens:
+                input_tokens = int(usage.get("prompt_tokens", 0) or 0)
+                output_tokens = int(usage.get("completion_tokens", 0) or 0)
+            return input_tokens, output_tokens
+
+        return (
+            int(usage.get("prompt_tokens", 0) or 0),
+            int(usage.get("completion_tokens", 0) or 0),
+        )
+
+    def _extract_chat_content(self, data: Any) -> str:
+        if not isinstance(data, dict):
+            return ""
+        choices = data.get("choices") or []
+        if not choices:
+            return ""
+        message = choices[0].get("message") or {}
+        return self._coerce_content_to_text(message.get("content", ""))
+
+    def _extract_responses_content(self, data: Any) -> str:
+        if not isinstance(data, dict):
+            return ""
+
+        output_text = data.get("output_text")
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text
+
+        if isinstance(output_text, list):
+            joined = "".join(str(item) for item in output_text if item)
+            if joined.strip():
+                return joined
+
+        pieces: list[str] = []
+        for item in data.get("output") or []:
+            if not isinstance(item, dict):
+                continue
+
+            item_text = item.get("text")
+            if item_text:
+                pieces.append(str(item_text))
+
+            message = item.get("message")
+            if isinstance(message, dict):
+                pieces.append(self._coerce_content_to_text(message.get("content", "")))
+
+            content = item.get("content")
+            pieces.append(self._coerce_content_to_text(content))
+
+        return "".join(piece for piece in pieces if piece)
+
+    def _coerce_content_to_text(self, content: Any) -> str:
+        if isinstance(content, str):
+            return content
+
+        if not isinstance(content, list):
+            return ""
+
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+
+            if not isinstance(item, dict):
+                continue
+
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+                continue
+
+            nested_text = item.get("output_text")
+            if isinstance(nested_text, str):
+                parts.append(nested_text)
+
+        return "".join(parts)
+
+    def _collect_sse_text(self, raw_text: str) -> tuple[str, int, int]:
+        pieces: list[str] = []
+        prompt_tokens = 0
+        completion_tokens = 0
+        fallback_content = ""
+
+        for block in raw_text.split("\n\n"):
+            for piece in self._parse_sse_event(block):
+                pieces.append(piece)
+
+            data_obj = self._parse_sse_data_object(block)
+            if self.api_format == "openai_responses" and not fallback_content:
+                fallback_content = self._extract_responses_sse_fallback(data_obj)
+            next_prompt_tokens, next_completion_tokens = self._extract_usage(data_obj)
+            if next_prompt_tokens:
+                prompt_tokens = next_prompt_tokens
+            if next_completion_tokens:
+                completion_tokens = next_completion_tokens
+
+        content = "".join(pieces) or fallback_content
+        return content, prompt_tokens, completion_tokens
+
+    def _parse_sse_event(self, event_text: str) -> list[str]:
+        payloads = self._extract_sse_payloads(event_text)
+        pieces: list[str] = []
+
+        for payload in payloads:
+            if payload == "[DONE]":
+                continue
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+
+            if self.api_format == "openai_responses":
+                pieces.extend(self._parse_responses_sse_data(data))
+                continue
+
+            choices = data.get("choices") or []
+            if not choices:
+                continue
+
+            delta = choices[0].get("delta") or {}
+            content = delta.get("content")
+            if content:
+                pieces.append(str(content))
+                continue
+
+            message = choices[0].get("message") or {}
+            content = message.get("content")
+            if content:
+                pieces.append(self._coerce_content_to_text(content))
+
+        return pieces
+
+    def _parse_responses_sse_data(self, data: Any) -> list[str]:
+        if not isinstance(data, dict):
+            return []
+
+        event_type = str(data.get("type") or "")
+        pieces: list[str] = []
+
+        if event_type in {
+            "response.output_text.delta",
+            "response.refusal.delta",
+            "response.reasoning_summary_text.delta",
+        }:
+            delta = data.get("delta")
+            if isinstance(delta, str) and delta:
+                pieces.append(delta)
+            return pieces
+
+        return pieces
+
+    def _extract_responses_sse_fallback(self, data: Any) -> str:
+        if not isinstance(data, dict):
+            return ""
+
+        event_type = str(data.get("type") or "")
+        if event_type in {
+            "response.output_text.done",
+            "response.refusal.done",
+            "response.reasoning_summary_text.done",
+        }:
+            text = data.get("text")
+            if isinstance(text, str):
+                return text
+
+        if event_type == "response.completed":
+            return self._extract_responses_content(data.get("response"))
+
+        return self._extract_responses_content(data)
+
+    def _parse_sse_data_object(self, event_text: str) -> Any:
+        payloads = self._extract_sse_payloads(event_text)
+        for payload in payloads:
+            if payload == "[DONE]":
+                continue
+            try:
+                return json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+        return None
+
+    def _extract_sse_payloads(self, event_text: str) -> list[str]:
+        payloads: list[str] = []
+        for line in event_text.splitlines():
+            line = line.strip()
+            if not line.startswith("data:"):
+                continue
+            payloads.append(line[5:].strip())
+        return payloads

--- a/infrastructure/ai/runtime_settings.py
+++ b/infrastructure/ai/runtime_settings.py
@@ -1,0 +1,320 @@
+"""Runtime-persisted LLM settings shared by the API and provider resolution."""
+from __future__ import annotations
+
+import json
+import os
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+from uuid import uuid4
+
+from application.paths import DATA_DIR
+
+
+LLM_SETTINGS_PATH = DATA_DIR / "system" / "llm_settings.json"
+
+DEFAULT_LLM_SETTINGS: Dict[str, Any] = {
+    "vendor": "openai",
+    "api_format": "openai_chat_completions",
+    "base_url": "",
+    "api_key": "",
+    "model": "",
+    "fast_model": "",
+    "review_model": "",
+    "scene_director_model": "",
+    "state_extractor_model": "",
+    "temperature": 0.7,
+    "max_tokens": 4096,
+    "timeout_ms": 300000,
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _settings_from_env() -> Dict[str, Any]:
+    provider = (os.getenv("LLM_PROVIDER") or "anthropic").strip().lower()
+    if provider == "openai":
+        vendor = "openai"
+        api_format = "openai_chat_completions"
+        base_url = (os.getenv("OPENAI_BASE_URL") or "").strip()
+        api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+        model = (os.getenv("OPENAI_MODEL") or os.getenv("LLM_MODEL") or "").strip()
+    else:
+        vendor = "claude"
+        api_format = "anthropic_messages"
+        base_url = (os.getenv("ANTHROPIC_BASE_URL") or "").strip()
+        api_key = (
+            os.getenv("ANTHROPIC_API_KEY")
+            or os.getenv("ANTHROPIC_AUTH_TOKEN")
+            or ""
+        ).strip()
+        model = (os.getenv("ANTHROPIC_MODEL") or os.getenv("LLM_MODEL") or "").strip()
+
+    settings = deepcopy(DEFAULT_LLM_SETTINGS)
+    settings.update(
+        {
+            "vendor": vendor,
+            "api_format": api_format,
+            "base_url": base_url,
+            "api_key": api_key,
+            "model": model,
+            "fast_model": (os.getenv("FAST_LLM_MODEL") or "").strip(),
+            "review_model": (os.getenv("REVIEW_LLM_MODEL") or "").strip(),
+            "scene_director_model": (os.getenv("SCENE_DIRECTOR_MODEL") or "").strip(),
+            "state_extractor_model": (os.getenv("STATE_EXTRACTOR_MODEL") or "").strip(),
+            "temperature": _safe_float(os.getenv("LLM_TEMPERATURE"), DEFAULT_LLM_SETTINGS["temperature"]),
+            "max_tokens": _safe_int(os.getenv("LLM_MAX_TOKENS"), DEFAULT_LLM_SETTINGS["max_tokens"]),
+            "timeout_ms": _safe_int(os.getenv("LLM_TIMEOUT_MS"), DEFAULT_LLM_SETTINGS["timeout_ms"]),
+        }
+    )
+    return settings
+
+
+def _safe_int(value: Any, default: int) -> int:
+    try:
+        if value in (None, ""):
+            return default
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(value: Any, default: float) -> float:
+    try:
+        if value in (None, ""):
+            return default
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_vendor(vendor: Any, api_format: str) -> str:
+    raw = str(vendor or "").strip().lower()
+    if raw:
+        return raw
+    if api_format == "anthropic_messages":
+        return "claude"
+    if api_format == "openai_responses":
+        return "codex"
+    return "openai"
+
+
+def _normalize_format(api_format: Any) -> str:
+    raw = str(api_format or "").strip().lower()
+    if raw in {"anthropic_messages", "openai_chat_completions", "openai_responses"}:
+        return raw
+    if raw == "codex":
+        return "openai_responses"
+    return "anthropic_messages" if raw == "claude" else "openai_chat_completions"
+
+
+def _normalize_settings(payload: Dict[str, Any]) -> Dict[str, Any]:
+    settings = deepcopy(DEFAULT_LLM_SETTINGS)
+    settings.update(payload or {})
+
+    settings["api_format"] = _normalize_format(settings.get("api_format"))
+    settings["vendor"] = _normalize_vendor(settings.get("vendor"), settings["api_format"])
+
+    for key in (
+        "base_url",
+        "api_key",
+        "model",
+        "fast_model",
+        "review_model",
+        "scene_director_model",
+        "state_extractor_model",
+    ):
+        settings[key] = str(settings.get(key) or "").strip()
+
+    settings["temperature"] = _safe_float(settings.get("temperature"), DEFAULT_LLM_SETTINGS["temperature"])
+    settings["max_tokens"] = max(1, _safe_int(settings.get("max_tokens"), DEFAULT_LLM_SETTINGS["max_tokens"]))
+    settings["timeout_ms"] = max(1000, _safe_int(settings.get("timeout_ms"), DEFAULT_LLM_SETTINGS["timeout_ms"]))
+    return settings
+
+
+def _masked(value: str) -> str:
+    if not value:
+        return ""
+    if len(value) <= 10:
+        return "*" * len(value)
+    return f"{value[:4]}...{value[-4:]}"
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _empty_store() -> Dict[str, Any]:
+    return {
+        "current": _settings_from_env(),
+        "active_preset_id": None,
+        "presets": [],
+    }
+
+
+def _normalize_preset(payload: Dict[str, Any]) -> Dict[str, Any]:
+    settings = _normalize_settings(payload.get("settings") or payload)
+    return {
+        "id": str(payload.get("id") or uuid4()),
+        "name": str(payload.get("name") or "未命名预设").strip() or "未命名预设",
+        "updated_at": str(payload.get("updated_at") or _now_iso()),
+        "settings": settings,
+    }
+
+
+def load_llm_store() -> Dict[str, Any]:
+    if not LLM_SETTINGS_PATH.exists():
+        return _empty_store()
+
+    try:
+        payload = json.loads(LLM_SETTINGS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return _empty_store()
+
+    if not isinstance(payload, dict):
+        return _empty_store()
+
+    if "current" not in payload and "presets" not in payload:
+        return {
+            "current": _normalize_settings(payload),
+            "active_preset_id": None,
+            "presets": [],
+        }
+
+    store = _empty_store()
+    store["current"] = _normalize_settings(payload.get("current") or _settings_from_env())
+    store["active_preset_id"] = payload.get("active_preset_id")
+    store["presets"] = [
+        _normalize_preset(item)
+        for item in (payload.get("presets") or [])
+        if isinstance(item, dict)
+    ]
+
+    preset_ids = {item["id"] for item in store["presets"]}
+    if store["active_preset_id"] not in preset_ids:
+        store["active_preset_id"] = None
+
+    return store
+
+
+def save_llm_store(store: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = {
+        "current": _normalize_settings(store.get("current") or _settings_from_env()),
+        "active_preset_id": store.get("active_preset_id"),
+        "presets": [
+            _normalize_preset(item)
+            for item in (store.get("presets") or [])
+            if isinstance(item, dict)
+        ],
+    }
+    preset_ids = {item["id"] for item in normalized["presets"]}
+    if normalized["active_preset_id"] not in preset_ids:
+        normalized["active_preset_id"] = None
+
+    _ensure_parent(LLM_SETTINGS_PATH)
+    LLM_SETTINGS_PATH.write_text(
+        json.dumps(normalized, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return normalized
+
+
+def load_llm_settings() -> Dict[str, Any]:
+    return load_llm_store()["current"]
+
+
+def save_llm_settings(payload: Dict[str, Any], active_preset_id: str | None = None) -> Dict[str, Any]:
+    store = load_llm_store()
+    store["current"] = _normalize_settings(payload)
+    store["active_preset_id"] = active_preset_id
+    return save_llm_store(store)["current"]
+
+
+def save_llm_preset(
+    *,
+    name: str,
+    settings: Dict[str, Any],
+    preset_id: str | None = None,
+    set_active: bool = False,
+) -> Dict[str, Any]:
+    store = load_llm_store()
+    normalized_settings = _normalize_settings(settings)
+    target_id = preset_id or str(uuid4())
+
+    updated = False
+    for preset in store["presets"]:
+        if preset["id"] == target_id:
+            preset["name"] = name.strip() or preset["name"]
+            preset["updated_at"] = _now_iso()
+            preset["settings"] = normalized_settings
+            updated = True
+            break
+
+    if not updated:
+        store["presets"].append(
+            {
+                "id": target_id,
+                "name": name.strip() or "未命名预设",
+                "updated_at": _now_iso(),
+                "settings": normalized_settings,
+            }
+        )
+
+    if set_active:
+        store["current"] = normalized_settings
+        store["active_preset_id"] = target_id
+
+    return save_llm_store(store)
+
+
+def activate_llm_preset(preset_id: str) -> Dict[str, Any]:
+    store = load_llm_store()
+    for preset in store["presets"]:
+        if preset["id"] == preset_id:
+            store["current"] = deepcopy(preset["settings"])
+            store["active_preset_id"] = preset_id
+            return save_llm_store(store)
+    raise KeyError(preset_id)
+
+
+def delete_llm_preset(preset_id: str) -> Dict[str, Any]:
+    store = load_llm_store()
+    store["presets"] = [preset for preset in store["presets"] if preset["id"] != preset_id]
+    if store["active_preset_id"] == preset_id:
+        store["active_preset_id"] = None
+    return save_llm_store(store)
+
+
+def _preset_response(preset: Dict[str, Any]) -> Dict[str, Any]:
+    settings = deepcopy(preset["settings"])
+    return {
+        "id": preset["id"],
+        "name": preset["name"],
+        "updated_at": preset["updated_at"],
+        "vendor": settings.get("vendor", ""),
+        "api_format": settings.get("api_format", ""),
+        "base_url": settings.get("base_url", ""),
+        "api_key": "",
+        "api_key_masked": _masked(settings.get("api_key", "")),
+        "model": settings.get("model", ""),
+        "fast_model": settings.get("fast_model", ""),
+        "review_model": settings.get("review_model", ""),
+        "scene_director_model": settings.get("scene_director_model", ""),
+        "state_extractor_model": settings.get("state_extractor_model", ""),
+        "temperature": settings.get("temperature", DEFAULT_LLM_SETTINGS["temperature"]),
+        "max_tokens": settings.get("max_tokens", DEFAULT_LLM_SETTINGS["max_tokens"]),
+        "timeout_ms": settings.get("timeout_ms", DEFAULT_LLM_SETTINGS["timeout_ms"]),
+    }
+
+
+def get_llm_settings_response() -> Dict[str, Any]:
+    store = load_llm_store()
+    settings = deepcopy(store["current"])
+    settings["api_key_masked"] = _masked(settings.get("api_key", ""))
+    settings["api_key"] = ""
+    settings["active_preset_id"] = store.get("active_preset_id")
+    settings["presets"] = [_preset_response(item) for item in store["presets"]]
+    return settings

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -31,6 +31,7 @@ from infrastructure.persistence.database.sqlite_foreshadowing_repository import 
 from infrastructure.persistence.database.sqlite_timeline_repository import SqliteTimelineRepository
 from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
 from infrastructure.ai.config.settings import Settings
+from infrastructure.ai.runtime_settings import load_llm_settings
 
 from application.core.services.novel_service import NovelService
 from application.core.services.chapter_service import ChapterService
@@ -111,6 +112,27 @@ def _openai_settings(require_key: bool = True) -> Optional[Settings]:
             )
         return None
     return Settings(api_key=key, base_url=_openai_base_url())
+
+
+def build_llm_service_from_runtime_settings(runtime_settings: Optional[dict] = None):
+    """Build an LLM service from persisted runtime settings, falling back to Mock."""
+    settings_payload = runtime_settings or load_llm_settings()
+    api_format = (settings_payload.get("api_format") or "").strip().lower()
+    api_key = (settings_payload.get("api_key") or "").strip()
+    base_url = (settings_payload.get("base_url") or "").strip() or None
+
+    provider_settings = Settings(api_key=api_key or None, base_url=base_url)
+
+    if api_format == "anthropic_messages":
+        if api_key:
+            return AnthropicProvider(provider_settings)
+    else:
+        if api_key:
+            from infrastructure.ai.providers.openai_provider import OpenAIProvider
+            return OpenAIProvider(provider_settings, api_format=api_format or "openai_chat_completions")
+
+    from infrastructure.ai.providers.mock_provider import MockProvider
+    return MockProvider()
 
 
 def get_storage() -> FileStorage:
@@ -311,21 +333,8 @@ def get_hosted_write_service() -> HostedWriteService:
 
 
 def get_llm_service():
-    """获取 LLM 服务实例（根据 LLM_PROVIDER 决定使用 OpenAI 或 Anthropic，无配置用 Mock）。供多模块复用。"""
-    provider = os.getenv("LLM_PROVIDER", "anthropic").lower()
-    
-    if provider == "openai":
-        settings = _openai_settings(require_key=False)
-        if settings:
-            from infrastructure.ai.providers.openai_provider import OpenAIProvider
-            return OpenAIProvider(settings)
-    else:
-        settings = _anthropic_settings(require_key=False)
-        if settings:
-            return AnthropicProvider(settings)
-            
-    from infrastructure.ai.providers.mock_provider import MockProvider
-    return MockProvider()
+    """?? LLM ????????????????????????"""
+    return build_llm_service_from_runtime_settings()
 
 
 def get_setup_main_plot_suggestion_service():

--- a/interfaces/api/v1/workbench/llm_settings.py
+++ b/interfaces/api/v1/workbench/llm_settings.py
@@ -1,0 +1,208 @@
+"""Runtime LLM settings endpoints used by the settings modal."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+import httpx
+
+from domain.ai.services.llm_service import GenerationConfig
+from domain.ai.value_objects.prompt import Prompt
+from infrastructure.ai.runtime_settings import (
+    DEFAULT_LLM_SETTINGS,
+    activate_llm_preset,
+    delete_llm_preset,
+    get_llm_settings_response,
+    load_llm_settings,
+    load_llm_store,
+    save_llm_preset,
+    save_llm_settings,
+)
+from interfaces.api.dependencies import build_llm_service_from_runtime_settings
+
+
+router = APIRouter(prefix="/api/v1/settings/llm", tags=["llm-settings"])
+
+
+class LLMSettingsPayload(BaseModel):
+    vendor: str = Field(default=DEFAULT_LLM_SETTINGS["vendor"])
+    api_format: str = Field(default=DEFAULT_LLM_SETTINGS["api_format"])
+    base_url: str = Field(default="")
+    api_key: str = Field(default="")
+    model: str = Field(default="")
+    fast_model: str = Field(default="")
+    review_model: str = Field(default="")
+    scene_director_model: str = Field(default="")
+    state_extractor_model: str = Field(default="")
+    temperature: float = Field(default=DEFAULT_LLM_SETTINGS["temperature"], ge=0.0, le=2.0)
+    max_tokens: int = Field(default=DEFAULT_LLM_SETTINGS["max_tokens"], ge=1, le=65536)
+    timeout_ms: int = Field(default=DEFAULT_LLM_SETTINGS["timeout_ms"], ge=1000, le=600000)
+
+
+class TestConnectionPayload(LLMSettingsPayload):
+    prompt: Optional[str] = Field(default=None)
+
+
+class ModelListRequest(LLMSettingsPayload):
+    pass
+
+
+class SavePresetPayload(BaseModel):
+    preset_id: Optional[str] = Field(default=None)
+    name: str = Field(..., min_length=1, max_length=100)
+    set_active: bool = Field(default=False)
+    settings: LLMSettingsPayload
+
+
+@router.get("")
+async def get_llm_settings():
+    return get_llm_settings_response()
+
+
+@router.put("")
+async def update_llm_settings(payload: LLMSettingsPayload):
+    current = load_llm_settings()
+    merged = payload.model_dump()
+    if not merged.get("api_key"):
+        merged["api_key"] = current.get("api_key", "")
+    store = load_llm_store()
+    save_llm_settings(merged, active_preset_id=store.get("active_preset_id"))
+    return get_llm_settings_response()
+
+
+@router.post("/test")
+async def test_llm_settings(payload: TestConnectionPayload):
+    candidate = payload.model_dump()
+    if not candidate.get("api_key"):
+        candidate["api_key"] = load_llm_settings().get("api_key", "")
+
+    try:
+        llm_service = build_llm_service_from_runtime_settings(candidate)
+        prompt = Prompt(
+            system="You are a connection test endpoint. Reply with a short success message.",
+            user=payload.prompt or "Return OK and the active model in one short sentence.",
+        )
+        result = await llm_service.generate(
+            prompt,
+            GenerationConfig(
+                model=candidate.get("model") or None,
+                max_tokens=min(candidate.get("max_tokens") or 128, 256),
+                temperature=min(candidate.get("temperature") or 0.2, 0.7),
+            ),
+        )
+        return {
+            "success": True,
+            "vendor": candidate.get("vendor"),
+            "api_format": candidate.get("api_format"),
+            "model": candidate.get("model"),
+            "message": result.content.strip(),
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/presets")
+async def save_preset(payload: SavePresetPayload):
+    settings = payload.settings.model_dump()
+    if not settings.get("api_key"):
+        settings["api_key"] = load_llm_settings().get("api_key", "")
+    save_llm_preset(
+        name=payload.name,
+        settings=settings,
+        preset_id=payload.preset_id,
+        set_active=payload.set_active,
+    )
+    return get_llm_settings_response()
+
+
+@router.post("/presets/{preset_id}/activate")
+async def activate_preset(preset_id: str):
+    try:
+        activate_llm_preset(preset_id)
+        return get_llm_settings_response()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Preset not found") from exc
+
+
+@router.delete("/presets/{preset_id}")
+async def remove_preset(preset_id: str):
+    delete_llm_preset(preset_id)
+    return get_llm_settings_response()
+
+
+def _normalize_model_items(data: Any) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    if isinstance(data, dict):
+        raw_items = data.get("data") or data.get("models") or data.get("items") or []
+    elif isinstance(data, list):
+        raw_items = data
+    else:
+        raw_items = []
+
+    for item in raw_items:
+        model_id = None
+        owned_by = ""
+        if isinstance(item, dict):
+            model_id = item.get("id") or item.get("name") or item.get("model")
+            owned_by = str(item.get("owned_by") or item.get("provider") or "")
+        elif isinstance(item, str):
+            model_id = item
+
+        if not model_id:
+            continue
+
+        model_id = str(model_id).strip()
+        if not model_id or model_id in seen:
+            continue
+
+        seen.add(model_id)
+        items.append({
+            "label": f"{model_id} ({owned_by})" if owned_by else model_id,
+            "value": model_id,
+        })
+
+    items.sort(key=lambda item: item["value"])
+    return items
+
+
+@router.post("/models")
+async def list_models(payload: ModelListRequest):
+    candidate = payload.model_dump()
+    if not candidate.get("api_key"):
+        candidate["api_key"] = load_llm_settings().get("api_key", "")
+
+    api_format = (candidate.get("api_format") or "").strip().lower()
+    api_key = (candidate.get("api_key") or "").strip()
+    if not api_key:
+        raise HTTPException(status_code=400, detail="API key is required to fetch model list")
+
+    base_url = (candidate.get("base_url") or "").strip()
+    timeout = max(1.0, (candidate.get("timeout_ms") or 300000) / 1000)
+
+    if api_format == "anthropic_messages":
+        url = f"{(base_url or 'https://api.anthropic.com').rstrip('/')}/v1/models"
+        headers = {
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        }
+    else:
+        url = f"{(base_url or 'https://api.openai.com/v1').rstrip('/')}/models"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+        }
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            data = response.json()
+        return {
+            "success": True,
+            "items": _normalize_model_items(data),
+            "count": len(_normalize_model_items(data)),
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to fetch model list: {exc}") from exc

--- a/interfaces/main.py
+++ b/interfaces/main.py
@@ -69,7 +69,7 @@ from interfaces.api.v1.audit import chapter_review_routes, macro_refactor, chapt
 from interfaces.api.v1.analyst import voice, narrative_state, foreshadow_ledger
 
 # Workbench module
-from interfaces.api.v1.workbench import sandbox, writer_block, monitor
+from interfaces.api.v1.workbench import sandbox, writer_block, monitor, llm_settings
 from interfaces.api.stats.routers.stats import create_stats_router
 from interfaces.api.stats.services.stats_service import StatsService
 from interfaces.api.stats.repositories.sqlite_stats_repository_adapter import SqliteStatsRepositoryAdapter
@@ -334,6 +334,7 @@ app.include_router(foreshadow_ledger.router, prefix="/api/v1")
 app.include_router(writer_block.router, prefix="/api/v1")
 app.include_router(sandbox.router, prefix="/api/v1")
 app.include_router(monitor.router, prefix="/api/v1")
+app.include_router(llm_settings.router)
 
 # 注册统计路由（使用 SQLite 适配器）
 stats_repository = SqliteStatsRepositoryAdapter(get_database())


### PR DESCRIPTION
## ����˵��

���� PR Ϊ PlotPilot ������һ�׿���ҳ����ֱ�����õĴ�ģ�ͽ����������������˶� OpenAI Responses / Codex Responses Э����֧�֣������û����� OpenAI ���ݡ�Claude �����Լ����� Responses Э���ĵ��������ء�

## ��Ҫ�Ķ�

1. ����ͳһ�� LLM ��������
- ��ǰ���������½��������ð�ť����ҳ�͹���̨ҳ�涼����ֱ�Ӵ���ģ�ͽ������õ�����
- ���õ���֧�ֱ��浱ǰ��������������������ΪԤ�衢�л�Ԥ�衢ɾ��Ԥ�衣
- API Key �ں��˱���ʱ�����������ԣ�ǰ���ٴδ�������ʱ����ֱ������չʾ��

2. ֧���Զ��� API ��ַ��API Key ��ģ��ѡ��
- �����ֶ���д�Զ��� API ��ַ��
- ������д API Key�����ڲ����Ǿ� key ��ǰ���¸����������á�
- ����ģ���б���ȡ�����������Ӽ��ݽӿ���ȡ `/models` ��������������ģ�ͺ͸߼�ģ�͵�����ѡ����
- �߼�ģ������֧�ֵ������� `fast_model`��`review_model`��`scene_director_model`��`state_extractor_model`��ͬʱҲ�����ֶ�����������

3. ��������ʱ LLM ���ó־û�����
- ��������ʱ LLM ���ô洢�߼���ͳһ���浱ǰ��Ծ������Ԥ���б���
- �����������ýӿڣ����ڻ�ȡ���á��������á��������ӡ���ȡģ���б��Լ�����Ԥ�衣
- �������е� LLM provider ѡ����Ϊ���ȶ�ȡ����ʱ���ã�����ֻ���������������������뷽ʽ��

4. ���Ӷ� OpenAI Responses / Codex Responses Э����֧��
- ǰ��Э����ʽ���� `openai_responses` ѡ�
- `Codex` Ԥ��Ĭ���л��� `openai_responses`��
- ���� `OpenAIProvider` ����ͬʱ֧�֣�
  - `openai_chat_completions` -> `/chat/completions`
  - `openai_responses` -> `/responses`
- �� `Responses` ģʽ�£����˻ᰴ `instructions + input + max_output_tokens` ��֯������
- �����˶Է���ʽ���غ� SSE ��ʽ���ص��ı���ȡ�߼��������� `usage` ��Ϣ������

## ��֤����

�����ɵ���֤��
- Python �����ļ���ͨ������ `compileall` �﷨���顣
- ������ OpenAI Responses Э��������ʵ�ӿ�������ȷ�ϣ�
  - ģ���б���������ȡ��
  - `gpt-5.4` ���� `/responses` ���������ã�
  - ��ʽ `text/event-stream` �������������ա�

δ���ɵ���֤��
- ǰ������ `npm run build` ��ǰ�޷���Ϊ���θĶ������ձ�׼����Ϊ�ֿ����Ѿ����ڶദ�뱾 PR �޹ص� TypeScript ������

## Ӱ�췶Χ

�� PR ��ҪӰ�����²��֣�
- ǰ��ȫ�����ð�ť��ģ�ͽ������õ���
- LLM ��������ǰ���˽ӿ�
- ����ʱ provider ѡ���߼�
- OpenAI ���� provider ��Э���ַ��� Responses Э������

## ��ע

�� PR �������κ�˽�� API Key��˽�нӿڵ�ַ������ʱʹ�õ��������á�
