### PR TITLE
fix: 修复反向代理部署时 trailing slash 重定向使用后端本地地址

### DIFF
--- a/interfaces/main.py
+++ b/interfaces/main.py
@@ -97,6 +97,32 @@ app = FastAPI(
     description="AI 小说创作平台 API"
 )
 
+# 修复反向代理场景下 trailing slash 重定向使用后端本地地址的 bug
+# 当 FastAPI 的 trailing slash 重定向指向 127.0.0.1 时，
+# 从 X-Forwarded-Host / Host / Referer 获取真实地址并改写 Location header
+@app.middleware("http")
+async def fix_redirect_host(request, call_next):
+    response = await call_next(request)
+    if response.status_code in (301, 307, 308):
+        location = response.headers.get("location", "")
+        if location and ("127.0.0.1" in location or "localhost" in location):
+            from urllib.parse import urlparse, urlunparse
+            parsed = urlparse(location)
+            original_host = request.headers.get("x-forwarded-host") or request.headers.get("host", "")
+            if not original_host or "127.0.0.1" in original_host or "localhost" in original_host:
+                referer = request.headers.get("referer", "")
+                if referer:
+                    from urllib.parse import urlparse as _urlparse
+                    ref_host = _urlparse(referer).netloc
+                    if ref_host and "127.0.0.1" not in ref_host and "localhost" not in ref_host:
+                        original_host = ref_host
+            if original_host and "127.0.0.1" not in original_host and "localhost" not in original_host:
+                scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+                new_location = urlunparse((scheme, original_host, parsed.path, parsed.params, parsed.query, parsed.fragment))
+                response.headers["location"] = new_location
+    return response
+
+
 @app.on_event("startup")
 async def startup_event():
     """应用启动事件"""


### PR DESCRIPTION
## 问题

反向代理（Vite dev proxy / Nginx 等）部署时，请求 `/api/v1/novels`（无尾斜杠）触发 FastAPI 的 307 重定向，但 `Location` header 使用了后端本地地址 `http://127.0.0.1:8005/api/v1/novels/`，浏览器无法跟随。

详见：#17

## 修复

添加 HTTP middleware，检测重定向 URL 中的本地地址，从 `X-Forwarded-Host` / `Host` / `Referer` header 获取真实地址并改写 `Location` header。

## 测试

```bash
# 直接访问后端
curl -sI http://192.168.x.x:8005/api/v1/novels
# → location: http://192.168.x.x:8005/api/v1/novels/ ✅

# 通过反向代理
curl -sI http://192.168.x.x:3000/api/v1/novels
# → location: http://192.168.x.x:3000/api/v1/novels/ ✅
```

Closes #17