### PR TITLE
Dev yxf 2604

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,11 +13,74 @@ ARK_REASONING_EFFORT=medium
 # 代理 TLS 问题时直连
 # ARK_NO_PROXY=1
 
+# ---------------------------------------------------------------------------
+# LLM 配置
+# ---------------------------------------------------------------------------
 # 可选默认篇幅
 # AITEXT_DEFAULT_CHAPTERS=5
 # AITEXT_DEFAULT_WORDS_PER_CHAPTER=2500
 # AITEXT_SUMMARY_MAX_CHAPTERS=5
+# PlotPilot 主 LLM：OpenAI 兼容（AsyncOpenAI -> /v1/chat/completions）。
 
+
+# ---------------------------------------------------------------------------
+# LLM 配置 - 硅基流动
+# ---------------------------------------------------------------------------
+# 若使用 /api/v1/chat 路径，请确保启用 OpenAI 兼容服务（通常端口 :1234，路径 /v1）。
+LLM_PROVIDER=openai
+# 关闭思考/推理过程（关键配置）
+LLM_DISABLE_REASONING=true
+# 强制启用关闭思考的扩展参数（即使没有 base_url 也生效）
+LLM_FORCE_COMPAT_NO_THINK_EXTRAS=true
+# 启用 Qwen assistant 预填机制（跳过思考阶段的关键）
+LLM_QWEN_ASSISTANT_PREFILL=true
+# 测试开关（不影响实际运行）
+# RUN_QWEN_NO_THINK_LIVE=1
+OPENAI_API_KEY=sk-00000000000000000000000000000000000000000000000000000000
+# API 接入地址
+OPENAI_BASE_URL=https://api.siliconflow.cn/v1
+# 模型名称
+OPENAI_MODEL=Qwen/Qwen3.5-397B-A17B
+
+
+# ---------------------------------------------------------------------------
 # 日志配置
+# ---------------------------------------------------------------------------
 LOG_LEVEL=INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_FILE=logs/aitext.log
+
+# ---------------------------------------------------------------------------
+# Embeddings：OpenAI 兼容接口（/v1/embeddings）
+# ---------------------------------------------------------------------------
+# 配置1：本地模式
+# EMBEDDING_SERVICE=local
+# EMBEDDING_MODEL_PATH=C:\Users\user01\.cache\modelscope\hub\models\AI-ModelScope\bge-small-zh-v1___5
+# 
+# 配置2：外部服务模式
+EMBEDDING_SERVICE=external
+EMBEDDING_API_BASE_URL=http://IP:PORT/v1
+EMBEDDING_API_MODEL=模型名称
+EMBEDDING_API_DIMENSION=1024
+EMBEDDING_API_KEY=sk-00000000000000000000000000000000000000000000000000000000
+
+
+# ---------------------------------------------------------------------------
+# 向量存储：ChromaDB 本地或 Qdrant
+# ---------------------------------------------------------------------------
+VECTOR_STORE_ENABLED=true
+# 配置1：chromadb
+# VECTOR_STORE_TYPE=chromadb
+# VECTOR_STORE_PATH=./data/chromadb
+# 
+# 配置2：Qdrant
+VECTOR_STORE_TYPE=qdrant
+# 本地模式：使用 Qdrant 时（与 docker compose 默认一致：http://localhost:6333）
+# QDRANT_HOST=localhost
+# QDRANT_PORT=6333
+# 
+# 配置3：Qdrant Cloud 等可填完整 URL（设置后优先于 HOST+PORT）
+QDRANT_URL=http://IP:PORT
+QDRANT_API_KEY=
+QDRANT_TIMEOUT=30
+# 仅 host+port 模式：是否 HTTPS（未设置则由客户端推断）
+QDRANT_HTTPS=false

--- a/.qoder/skills/plotpilot/SKILL.md
+++ b/.qoder/skills/plotpilot/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: plotpilot
+description: >-
+  Enforces PlotPilot (墨枢) DDD layering, FastAPI/Vue 3 conventions, DI, and test layout for this repository.
+  Use when implementing or refactoring PlotPilot backend (domain/application/infrastructure/interfaces),
+  frontend (Vue/TypeScript), scripts, or tests; or when the user requests project standards or consistency.
+---
+
+# PlotPilot 开发规范（必须遵守）
+
+## 项目摘要
+
+- **产品**：AI 长篇小说创作平台（自动驾驶生成、Bible、知识图谱、伏笔、文风分析、故事结构）。
+- **后端**：Python **FastAPI**，入口 `interfaces/main.py`（`uvicorn interfaces.main:app`）。
+- **前端**：**Vue 3 + TypeScript + Vite + Naive UI + Pinia + ECharts**（`frontend/`）。
+- **数据**：**SQLite** 主库；向量检索 **Qdrant/Chroma**（`infrastructure/ai/`）。
+- **文档**：架构说明见 `docs/ARCHITECTURE.md`；README 为运行与目录总览。
+
+## 架构铁律（DDD四层）
+
+改动前先判断代码属于哪一层；**禁止破坏依赖方向**。
+
+| 层 | 路径 | 允许依赖 | 禁止 |
+|----|------|----------|------|
+| Domain | `domain/` | 标准库、本层 `domain/*` | 依赖 `application/`、`infrastructure/`、`interfaces/` |
+| Application | `application/` | `domain/`、（构造时注入的）基础设施抽象接口类型 | 在领域服务中直接写 SQL/HTTP/SDK调用（应经仓储或已注入的端口） |
+| Infrastructure | `infrastructure/` | `domain/`（实现接口）、第三方库 | 被 `domain/` 导入具体实现类 |
+| Interfaces | `interfaces/` | `application/`、`domain/`（异常/DTO 等）、`infrastructure/`（组装、路由） | 在路由里堆业务规则；应委托 Application Service |
+
+- **仓储**：接口在 `domain/*/repositories/`（如 `NovelRepository`）；实现命名为 `Sqlite*Repository` 等，放在 `infrastructure/persistence/database/`。
+- **应用服务**：`*_service.py` 于 `application/<module>/services/`，编排用例；跨边界数据用 `application/*/dtos/`。
+- **领域异常**：`domain/shared/exceptions.py`（如 `EntityNotFoundError`）；路由层捕获并映射为 HTTP 状态码。
+
+## 后端实现约定
+
+1. **路由**：`interfaces/api/v1/<领域>/`，`APIRouter(prefix=..., tags=...)`；版本与聚合与 `interfaces/main.py` 中 `include_router` 保持一致。
+2. **请求/响应模型**：路由文件内 `pydantic.BaseModel` 或复用 `application` DTO；字段用 `Field(..., description=...)` 与项目现有风格一致。
+3. **依赖注入**：新建可注入服务时，在 `interfaces/api/dependencies.py` 增加 `get_*` 工厂，路由使用 `Depends(get_*)`。**不要**在路由里 `new` 长生命周期资源。
+4. **日志**：模块级 `logger = logging.getLogger(__name__)`；启动日志配置已由 `interfaces/main.py` / middleware 处理。
+5. **启动副作用**：自动驾驶守护进程、运行中小说状态等与 `startup`/`shutdown` 相关的逻辑集中在 `interfaces/main.py`；新增后台行为前先评估是否应放入现有 daemon 流程。
+6. **环境**：`interfaces/main.py` 顶部设置 HF/Transformers 离线变量；勿在领域层依赖 HuggingFace 隐式下载行为。
+7. **异步**：领域仓储接口同时存在同步/异步方法时（如 `save` / `async_save`），调用方与守护进程路径须与现有用法一致，避免混用导致死锁或未落盘。
+
+## 前端实现约定
+
+1. **API 客户端**：`frontend/src/api/config.ts` 的 `apiClient`（`baseURL` 默认 `/api/v1`，超时较长以适配 LLM）；新接口按资源拆文件（如 `novel.ts`、`chapter.ts`），并在 `api/index.ts` 按需导出。
+2. **类型**：共享 API 类型放 `frontend/src/types/api.ts`（若已有同类则扩展而非重复定义）。
+3. **路由**：`frontend/src/router/index.ts`；页面在 `views/`，可复用块在 `components/`。
+4. **状态**：Pinia store 放 `stores/`；跨页刷新信号等沿用现有 `workbenchRefreshStore` 等模式。
+5. **安全展示**：用户生成内容渲染继续用 **DOMPurify** 等现有净化路径，勿引入未净化的 `v-html`。
+
+## 测试与质量
+
+- **单元测试**：`tests/unit/`，按层镜像目录（如 `tests/unit/application/...`）。
+- **集成测试**：`tests/integration/`，含 API 与持久化等。
+- 新行为：**优先**为应用服务或仓储增加单元测试；HTTP 行为用集成测试覆盖。
+- 运行：`pytest tests/unit/ tests/integration/ -v`（或按 README 覆盖率命令）。
+
+## 脚本与数据
+
+-一次性迁移、评测、环境检查放在 `scripts/`；大规模数据迁移保持**可重复执行/幂等**说明（参考现有 `scripts/migrations/` 风格）。
+- 数据目录与路径 helper使用 `application/paths.py`（如 `DATA_DIR`、`get_db_path`），避免硬编码仓库相对路径散落。
+
+## 提交与范围
+
+- **最小改动**：只改完成任务所需的文件；禁止顺带大范围格式化或无关重构。
+- **Conventional Commits**（README）：`feat:`、`fix:` 等；说明用完整句子。
+- **许可**：Apache 2.0 + Commons Clause；勿引入与商业闭源冲突或不可审计的依赖而不加说明。
+
+## 新功能落地检查清单（复制使用）
+
+```
+- [ ] 领域模型/规则落在 domain/；无上层 import
+- [ ] 用例编排在 application/*/services/；DTO 在 application/*/dtos/
+- [ ] 新仓储接口在 domain/，实现在 infrastructure/persistence/database/
+- [ ] 路由仅编排：Depends + Service；异常映射一致
+- [ ] 新依赖在 dependencies.py 注册
+- [ ] 前端 api 模块 + 路由/页面（如需要）
+- [ ] tests/unit 或 tests/integration 覆盖核心路径
+```
+
+## 与用户沟通
+
+- 用户要求中文时：**回复使用中文**；代码注释与已有文件保持一致（本项目中文注释较多）。
+
+## 进一步阅读
+
+- 分层与模块职责：`docs/ARCHITECTURE.md`
+- 运行与环境变量：根目录 `README.md`

--- a/application/blueprint/services/continuous_planning_service.py
+++ b/application/blueprint/services/continuous_planning_service.py
@@ -4,6 +4,7 @@
 """
 
 import json
+import re
 import uuid
 import logging
 from typing import Dict, List, Optional
@@ -735,14 +736,14 @@ class ContinuousPlanningService:
 
     def _parse_llm_response(self, response) -> Dict:
         """解析 LLM 响应"""
+        import logging
+        logger = logging.getLogger(__name__)
+        
         # 如果是 GenerationResult 对象，提取 content 属性
         if hasattr(response, 'content'):
             content = response.content.strip()
         else:
             content = response.strip()
-
-        # 调试日志
-        print(f"[DEBUG] LLM 原始响应: {content[:200]}...")
 
         # 查找 JSON 代码块
         if "```json" in content:
@@ -768,9 +769,91 @@ class ContinuousPlanningService:
             if json_start < len(content):
                 content = content[json_start:]
 
-        print(f"[DEBUG] 清理后的内容: {content[:200]}...")
+        # 尝试修复常见的 JSON 格式问题
+        content = self._repair_json(content)
 
-        return json.loads(content)
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError as e:
+            logger.error(f"JSON 解析失败: {e}")
+            logger.error(f"JSON 内容（前 500 字符）: {content[:500]}")
+            logger.error(f"JSON 内容（后 200 字符）: {content[-200:]}")
+            raise ValueError(f"LLM 返回的 JSON 格式错误: {e}")
+
+    def _repair_json(self, content: str) -> str:
+        """尝试修复常见的 JSON 格式问题"""
+        if not content:
+            return content
+
+        # 1. 移除尾部的逗号（在数组或对象结束前）
+        content = re.sub(r',\s*}', '}', content)
+        content = re.sub(r',\s*]', ']', content)
+
+        # 2. 修复未闭合的字符串 - 查找未闭合的引号
+        # 这种情况通常是因为 LLM 输出被截断
+        lines = content.split('\n')
+        repaired_lines = []
+        
+        for line in lines:
+            # 更准确地计算引号：排除转义的引号
+            # 从后往前检查，找到最后一个未配对的引号
+            quote_positions = []
+            i = 0
+            while i < len(line):
+                if line[i] == '\\' and i + 1 < len(line) and line[i+1] == '"':
+                    i += 2  # 跳过转义引号
+                    continue
+                if line[i] == '"':
+                    quote_positions.append(i)
+                i += 1
+            
+            # 如果引号数量是奇数，需要修复
+            if len(quote_positions) % 2 != 0:
+                # 在最后一个引号位置后添加闭合引号
+                last_quote_pos = quote_positions[-1]
+                line = line[:last_quote_pos+1] + '"' + line[last_quote_pos+1:]
+            
+            repaired_lines.append(line)
+        
+        content = '\n'.join(repaired_lines)
+
+        # 3. 确保 JSON 完整闭合
+        # 计算括号和方括号的匹配
+        stack = []
+        in_string = False
+        escape_next = False
+        
+        for i, char in enumerate(content):
+            if escape_next:
+                escape_next = False
+                continue
+            if char == '\\':
+                escape_next = True
+                continue
+            if char == '"' and not escape_next:
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if char in '{[':
+                stack.append(char)
+            elif char in '}]':
+                if stack:
+                    open_char = stack.pop()
+                    if (open_char == '{' and char != '}') or (open_char == '[' and char != ']'):
+                        # 不匹配，停止修复
+                        break
+        
+        # 如果还有未闭合的括号，尝试添加闭合符号
+        if stack:
+            logger.warning(f"JSON 有 {len(stack)} 个未闭合的括号，尝试修复")
+            closing_map = {'{': '}', '[': ']'}
+            # 从最后一个有效字符后添加闭合符号
+            content = content.rstrip()
+            for open_char in reversed(stack):
+                content += closing_map[open_char]
+
+        return content
 
     def _calculate_chapter_distribution(self, total_chapters: int, parts: int) -> Dict[str, List[int]]:
         """计算黄金比例的章数分配

--- a/application/engine/services/context_budget_allocator.py
+++ b/application/engine/services/context_budget_allocator.py
@@ -20,6 +20,7 @@ from domain.novel.repositories.foreshadowing_repository import ForeshadowingRepo
 from domain.novel.repositories.chapter_repository import ChapterRepository
 from domain.bible.repositories.bible_repository import BibleRepository
 from infrastructure.persistence.database.story_node_repository import StoryNodeRepository
+from infrastructure.persistence.database.triple_repository import TripleRepository
 from domain.ai.services.vector_store import VectorStore
 from domain.ai.services.embedding_service import EmbeddingService
 from application.ai.vector_retrieval_facade import VectorRetrievalFacade
@@ -140,6 +141,7 @@ class ContextBudgetAllocator:
         bible_repository: Optional[BibleRepository] = None,
         story_node_repository: Optional[StoryNodeRepository] = None,
         chapter_element_repository = None,
+        triple_repository: Optional[TripleRepository] = None,
         vector_store: Optional[VectorStore] = None,
         embedding_service: Optional[EmbeddingService] = None,
     ):
@@ -148,6 +150,7 @@ class ContextBudgetAllocator:
         self.bible_repo = bible_repository
         self.story_node_repo = story_node_repository
         self.chapter_element_repo = chapter_element_repository
+        self.triple_repo = triple_repository
         
         # 向量检索门面
         self.vector_facade = None

--- a/application/engine/services/context_builder.py
+++ b/application/engine/services/context_builder.py
@@ -21,6 +21,7 @@ from domain.novel.repositories.foreshadowing_repository import ForeshadowingRepo
 from domain.ai.services.vector_store import VectorStore
 from domain.ai.services.embedding_service import EmbeddingService
 from application.engine.services.context_budget_allocator import ContextBudgetAllocator
+from infrastructure.persistence.database.triple_repository import TripleRepository
 
 if TYPE_CHECKING:
     from application.engine.dtos.scene_director_dto import SceneDirectorAnalysis
@@ -59,6 +60,7 @@ class ContextBuilder:
         story_node_repository=None,
         bible_repository=None,
         chapter_element_repository=None,
+        triple_repository: Optional[TripleRepository] = None,
     ):
         self.bible_service = bible_service
         self.storyline_manager = storyline_manager
@@ -72,6 +74,7 @@ class ContextBuilder:
         self.story_node_repository = story_node_repository
         self.bible_repository = bible_repository
         self.chapter_element_repository = chapter_element_repository
+        self.triple_repository = triple_repository
 
         # 预算分配器（核心组件）
         self.budget_allocator = ContextBudgetAllocator(
@@ -80,6 +83,7 @@ class ContextBuilder:
             bible_repository=bible_repository,
             story_node_repository=story_node_repository,
             chapter_element_repository=chapter_element_repository,
+            triple_repository=triple_repository,
             vector_store=vector_store,
             embedding_service=embedding_service,
         )

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -1,7 +1,6 @@
 """自动 Bible 生成器 - 从小说标题生成完整的人物、地点、风格设定和世界观"""
 import logging
 import json
-import re
 import uuid
 import sys
 from typing import Dict, Any
@@ -132,14 +131,15 @@ class AutoBibleGenerator:
             print(f"[DEBUG] Has 'worldbuilding' key: {'worldbuilding' in bible_data}", file=sys.stderr, flush=True)
             print(f"[DEBUG] worldbuilding_service is None: {self.worldbuilding_service is None}", file=sys.stderr, flush=True)
             # 保存文风
-            if "style" in bible_data:
+            style_content = bible_data.get("style", "")
+            if style_content and style_content.strip():
                 style_id = f"{novel_id}-style-1"
                 try:
                     self.bible_service.add_style_note(
                         novel_id=novel_id,
                         note_id=style_id,
                         category="文风公约",
-                        content=bible_data["style"]
+                        content=style_content
                     )
                     logger.info(f"Style note saved: {style_id}")
                 except Exception as e:
@@ -344,7 +344,7 @@ JSON 格式（不要有其他文字）：
 只输出 JSON，不要有任何解释文字。"""
 
         prompt = Prompt(system=system_prompt, user=user_prompt)
-        config = GenerationConfig(max_tokens=4096, temperature=0.7)
+        config = GenerationConfig(max_tokens=2048, temperature=0.7)
 
         result = await self.llm_service.generate(prompt, config)
 
@@ -634,7 +634,30 @@ JSON 格式：
 
 请生成世界观和文风公约。只输出 JSON，不要有任何解释文字。"""
 
-        return await self._call_llm_and_parse(system_prompt, user_prompt)
+        result = await self._call_llm_and_parse(system_prompt, user_prompt)
+
+        # 修复：LLM 可能直接返回世界观维度而不是包装在 worldbuilding 键下
+        # 检查是否存在世界观的5个维度键但没有 worldbuilding 包装
+        worldbuilding_keys = {"core_rules", "geography", "society", "culture", "daily_life"}
+        if worldbuilding_keys.issubset(result.keys()) and "worldbuilding" not in result:
+            logger.info("LLM returned unwrapped worldbuilding data, re-wrapping...")
+            wrapped = {
+                "worldbuilding": {
+                    "core_rules": result.get("core_rules", {}),
+                    "geography": result.get("geography", {}),
+                    "society": result.get("society", {}),
+                    "culture": result.get("culture", {}),
+                    "daily_life": result.get("daily_life", {})
+                }
+            }
+            # 只有当 style 有内容时才添加
+            style_content = result.get("style", "")
+            if style_content and style_content.strip():
+                wrapped["style"] = style_content
+            result = wrapped
+            print(f"[DEBUG] Re-wrapped worldbuilding data", file=sys.stderr, flush=True)
+
+        return result
 
     async def _generate_characters(self, premise: str, target_chapters: int, worldbuilding: Dict[str, Any]) -> Dict[str, Any]:
         """基于世界观生成人物"""
@@ -676,7 +699,19 @@ JSON 格式：
 
 请基于这个世界观生成主要人物。只输出 JSON，不要有任何解释文字。"""
 
-        return await self._call_llm_and_parse(system_prompt, user_prompt)
+        result = await self._call_llm_and_parse(system_prompt, user_prompt)
+
+        # 兼容处理：LLM 可能直接返回数组而不是包装在 characters 键下
+        if isinstance(result, list):
+            logger.info("LLM returned unwrapped characters array, re-wrapping...")
+            result = {"characters": result}
+        elif isinstance(result, dict) and "characters" not in result:
+            # 检查是否包含人物字段（name, role）
+            if "name" in result and "role" in result:
+                logger.info("LLM returned single character object, wrapping in list...")
+                result = {"characters": [result]}
+
+        return result
 
     async def _generate_locations(self, premise: str, target_chapters: int, worldbuilding: Dict[str, Any], characters: list) -> Dict[str, Any]:
         """基于世界观和人物生成地点"""
@@ -724,7 +759,19 @@ JSON 格式：
 
 请基于世界观和人物生成完整地图。只输出 JSON，不要有任何解释文字。"""
 
-        return await self._call_llm_and_parse(system_prompt, user_prompt)
+        result = await self._call_llm_and_parse(system_prompt, user_prompt)
+
+        # 兼容处理：LLM 可能直接返回数组而不是包装在 locations 键下
+        if isinstance(result, list):
+            logger.info("LLM returned unwrapped locations array, re-wrapping...")
+            result = {"locations": result}
+        elif isinstance(result, dict) and "locations" not in result:
+            # 检查是否包含地点字段（name, type/description）
+            if "name" in result and ("type" in result or "description" in result):
+                logger.info("LLM returned single location object, wrapping in list...")
+                result = {"locations": [result]}
+
+        return result
 
     def _summarize_worldbuilding(self, wb: Dict[str, Any]) -> str:
         """总结世界观为文本"""
@@ -738,11 +785,11 @@ JSON 格式：
                 parts.append(f"{key}: {items}")
         return "\n".join(parts)
 
-    async def _call_llm_and_parse(self, system_prompt: str, user_prompt: str) -> Dict[str, Any]:
+    async def _call_llm_and_parse(self, system_prompt: str, user_prompt: str, max_tokens: int = 4096) -> Dict[str, Any]:
         """调用 LLM 并解析 JSON"""
         print(f"[DEBUG] _call_llm_and_parse: Creating prompt", file=sys.stderr, flush=True)
         prompt = Prompt(system=system_prompt, user=user_prompt)
-        config = GenerationConfig(max_tokens=4096, temperature=0.7)
+        config = GenerationConfig(max_tokens=max_tokens, temperature=0.7)
         print(f"[DEBUG] _call_llm_and_parse: Calling LLM service", file=sys.stderr, flush=True)
         result = await self.llm_service.generate(prompt, config)
         print(f"[DEBUG] _call_llm_and_parse: LLM returned result", file=sys.stderr, flush=True)
@@ -751,23 +798,51 @@ JSON 格式：
             content = result.content.strip()
             print(f"[DEBUG] Raw LLM content length: {len(content)}", file=sys.stderr, flush=True)
 
-            # 移除可能的 markdown 代码块标记
+            # 移除可能的 markdown 代码块标记（取最长的一段）
             if "```json" in content:
-                content = content.split("```json")[1].split("```")[0]
+                # 找到所有 ```json ... ``` 块，取内容最长的那个
+                import re
+                blocks = re.findall(r'```json\s*([\s\S]*?)```', content)
+                if blocks:
+                    content = max(blocks, key=len).strip()
+                else:
+                    content = content.split("```json")[1].split("```")[0]
             elif "```" in content:
-                content = content.split("```")[1].split("```")[0]
+                blocks = re.findall(r'```\s*([\s\S]*?)```', content)
+                if blocks:
+                    content = max(blocks, key=len).strip()
+                else:
+                    content = content.split("```")[1].split("```")[0]
 
             content = content.strip()
+            print(f"[DEBUG] After markdown strip length: {len(content)}", file=sys.stderr, flush=True)
+            print(f"[DEBUG] After markdown strip first 100 chars: {content[:100]!r}", file=sys.stderr, flush=True)
 
-            # 提取完整的最外层 JSON 对象
+            # 修复：LLM 有时输出不完整的 JSON（缺少最外层 {}），如 '"locations": [...]'
+            # 检测是否以引号开头（说明缺少最外层 {）
+            if content and content[0] == '"':
+                content = '{' + content + '}'
+                print(f"[DEBUG] Wrapped missing outer braces, new length: {len(content)}", file=sys.stderr, flush=True)
+
+            # 使用栈来正确提取最外层 JSON 对象（处理嵌套情况）
             content = self._extract_outermost_json(content)
 
-            # 修复常见的 JSON 格式问题
-            content = self._repair_json(content)
-
             print(f"[DEBUG] Cleaned content length: {len(content)}", file=sys.stderr, flush=True)
-            parsed = json.loads(content)
-            print(f"[DEBUG] Successfully parsed JSON with keys: {list(parsed.keys())}", file=sys.stderr, flush=True)
+
+            # 先尝试直接解析
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError:
+                # 失败则尝试补全缺失的闭合括号（LLM 输出被 max_tokens 截断时常见）
+                repaired = self._close_truncated_json(content)
+                print(f"[DEBUG] Attempting repair, repaired length: {len(repaired)}", file=sys.stderr, flush=True)
+                parsed = json.loads(repaired)
+                logger.info("Parsed JSON after truncation repair")
+
+            if isinstance(parsed, dict):
+                print(f"[DEBUG] Successfully parsed JSON with keys: {list(parsed.keys())}", file=sys.stderr, flush=True)
+            else:
+                print(f"[DEBUG] Successfully parsed JSON as list, length: {len(parsed)}", file=sys.stderr, flush=True)
             return parsed
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON: {e}")
@@ -783,39 +858,135 @@ JSON 格式：
             return {}
 
     def _extract_outermost_json(self, content: str) -> str:
-        """提取最外层的 JSON 对象"""
-        start = content.find('{')
-        if start == -1:
+        """提取最外层的 JSON 对象或数组"""
+        # 找到第一个 { 或 [ 的位置，取最先出现的
+        obj_start = content.find('{')
+        arr_start = content.find('[')
+
+        if obj_start == -1 and arr_start == -1:
             return content
-        
-        # 使用栈来匹配最外层的 }
+
+        if obj_start == -1:
+            start = arr_start
+        elif arr_start == -1:
+            start = obj_start
+        else:
+            start = min(obj_start, arr_start)
+
+        # 使用栈来匹配最外层的闭合符
         depth = 0
         in_string = False
+        i = start
+
+        while i < len(content):
+            char = content[i]
+
+            if in_string:
+                if char == '\\':
+                    i += 2  # 跳过转义字符及其后一个字符
+                    continue
+                if char == '"':
+                    in_string = False
+            else:
+                if char == '"':
+                    in_string = True
+                elif char in ('{', '['):
+                    depth += 1
+                elif char in ('}', ']'):
+                    depth -= 1
+                    if depth == 0:
+                        return content[start:i + 1]
+
+            i += 1
+
+        # 如果没找到完整闭合，返回从 start 开始的全部内容
+        return content[start:]
+
+    def _close_truncated_json(self, content: str) -> str:
+        """修复被截断的 JSON：移除末尾不完整的 token，然后补全缺失的闭合括号"""
+        if not content:
+            return content
+
+        # 第一步：移除末尾不完整的字符串（未闭合的 "...）
+        # 从末尾向前扫描，找到最后一个完整的值结束位置
+        truncated = content.rstrip()
+
+        # 移除末尾不完整的 token：逐步回退到最后一个 } 或 ] 或 " 或数字
+        # 先移除末尾可能不完整的字符串字面量
+        in_string = False
         escape_next = False
-        end = start
-        
-        for i, char in enumerate(content[start:], start):
+        last_safe_pos = len(truncated)
+
+        i = 0
+        string_start = -1
+        while i < len(truncated):
+            char = truncated[i]
             if escape_next:
                 escape_next = False
+                i += 1
                 continue
-            if char == '\\':
+            if char == '\\' and in_string:
                 escape_next = True
+                i += 1
                 continue
-            if char == '"' and not escape_next:
+            if char == '"':
+                if in_string:
+                    in_string = False
+                    last_safe_pos = i + 1
+                    string_start = -1
+                else:
+                    in_string = True
+                    string_start = i
+            elif not in_string and char in ('}', ']', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'):
+                last_safe_pos = i + 1
+            i += 1
+
+        # 如果末尾有未闭合的字符串，截断到最后一个安全位置
+        if in_string and string_start != -1:
+            truncated = truncated[:string_start]
+            logger.info(f"Removed incomplete string literal at pos {string_start}")
+
+        # 移除末尾多余的逗号
+        import re
+        truncated = re.sub(r',\s*$', '', truncated.rstrip())
+
+        # 第二步：用栈统计未闭合的括号，从后向前补全
+        stack = []
+        in_string = False
+        escape_next = False
+        i = 0
+        while i < len(truncated):
+            char = truncated[i]
+            if escape_next:
+                escape_next = False
+                i += 1
+                continue
+            if char == '\\' and in_string:
+                escape_next = True
+                i += 1
+                continue
+            if char == '"':
                 in_string = not in_string
+                i += 1
                 continue
             if in_string:
+                i += 1
                 continue
-            if char == '{':
-                depth += 1
-            elif char == '}':
-                depth -= 1
-                if depth == 0:
-                    end = i
-                    break
-        
-        
-        return content[start:end+1]
+            if char in ('{', '['):
+                stack.append(char)
+            elif char in ('}', ']'):
+                if stack:
+                    stack.pop()
+            i += 1
+
+        # 补全缺失的闭合符
+        close_map = {'{': '}', '[': ']'}
+        suffix = ''.join(close_map[c] for c in reversed(stack))
+        if suffix:
+            logger.info(f"Closing truncated JSON with: {suffix!r}")
+            truncated = truncated + suffix
+
+        return truncated
 
     def _repair_json(self, content: str) -> str:
         """尝试修复常见的 JSON 格式问题"""

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -344,7 +344,7 @@ JSON 格式（不要有其他文字）：
 只输出 JSON，不要有任何解释文字。"""
 
         prompt = Prompt(system=system_prompt, user=user_prompt)
-        config = GenerationConfig(max_tokens=2048, temperature=0.7)
+        config = GenerationConfig(max_tokens=4096, temperature=0.7)
 
         result = await self.llm_service.generate(prompt, config)
 
@@ -742,7 +742,7 @@ JSON 格式：
         """调用 LLM 并解析 JSON"""
         print(f"[DEBUG] _call_llm_and_parse: Creating prompt", file=sys.stderr, flush=True)
         prompt = Prompt(system=system_prompt, user=user_prompt)
-        config = GenerationConfig(max_tokens=2048, temperature=0.7)
+        config = GenerationConfig(max_tokens=4096, temperature=0.7)
         print(f"[DEBUG] _call_llm_and_parse: Calling LLM service", file=sys.stderr, flush=True)
         result = await self.llm_service.generate(prompt, config)
         print(f"[DEBUG] _call_llm_and_parse: LLM returned result", file=sys.stderr, flush=True)

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -759,11 +759,8 @@ JSON 格式：
 
             content = content.strip()
 
-            # 尝试找到第一个 { 和最后一个 }
-            start = content.find('{')
-            end = content.rfind('}')
-            if start != -1 and end != -1:
-                content = content[start:end+1]
+            # 提取完整的最外层 JSON 对象
+            content = self._extract_outermost_json(content)
 
             # 修复常见的 JSON 格式问题
             content = self._repair_json(content)
@@ -775,10 +772,50 @@ JSON 格式：
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON: {e}")
             logger.error(f"Content length: {len(content)}")
+            # 打印出错位置附近的内容
+            if e.pos is not None:
+                start = max(0, e.pos - 100)
+                end = min(len(content), e.pos + 100)
+                logger.error(f"Error context (pos {e.pos}): ...{content[start:e.pos]}<--ERROR-->{content[e.pos:end]}...")
             logger.error(f"Raw content (first 1000 chars): {content[:1000]}")
             logger.error(f"Raw content (last 500 chars): {content[-500:]}")
             print(f"[DEBUG] JSON parse failed, returning empty dict", file=sys.stderr, flush=True)
             return {}
+
+    def _extract_outermost_json(self, content: str) -> str:
+        """提取最外层的 JSON 对象"""
+        start = content.find('{')
+        if start == -1:
+            return content
+        
+        # 使用栈来匹配最外层的 }
+        depth = 0
+        in_string = False
+        escape_next = False
+        end = start
+        
+        for i, char in enumerate(content[start:], start):
+            if escape_next:
+                escape_next = False
+                continue
+            if char == '\\':
+                escape_next = True
+                continue
+            if char == '"' and not escape_next:
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if char == '{':
+                depth += 1
+            elif char == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        
+        
+        return content[start:end+1]
 
     def _repair_json(self, content: str) -> str:
         """尝试修复常见的 JSON 格式问题"""

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -1,6 +1,7 @@
 """自动 Bible 生成器 - 从小说标题生成完整的人物、地点、风格设定和世界观"""
 import logging
 import json
+import re
 import uuid
 import sys
 from typing import Dict, Any
@@ -764,6 +765,9 @@ JSON 格式：
             if start != -1 and end != -1:
                 content = content[start:end+1]
 
+            # 修复常见的 JSON 格式问题
+            content = self._repair_json(content)
+
             print(f"[DEBUG] Cleaned content length: {len(content)}", file=sys.stderr, flush=True)
             parsed = json.loads(content)
             print(f"[DEBUG] Successfully parsed JSON with keys: {list(parsed.keys())}", file=sys.stderr, flush=True)
@@ -775,6 +779,72 @@ JSON 格式：
             logger.error(f"Raw content (last 500 chars): {content[-500:]}")
             print(f"[DEBUG] JSON parse failed, returning empty dict", file=sys.stderr, flush=True)
             return {}
+
+    def _repair_json(self, content: str) -> str:
+        """尝试修复常见的 JSON 格式问题"""
+        if not content:
+            return content
+
+        # 1. 移除尾部的逗号
+        content = re.sub(r',\s*}', '}', content)
+        content = re.sub(r',\s*]', ']', content)
+
+        # 2. 修复未闭合的字符串
+        lines = content.split('\n')
+        repaired_lines = []
+        
+        for line in lines:
+            quote_positions = []
+            i = 0
+            while i < len(line):
+                if line[i] == '\\' and i + 1 < len(line) and line[i+1] == '"':
+                    i += 2
+                    continue
+                if line[i] == '"':
+                    quote_positions.append(i)
+                i += 1
+            
+            if len(quote_positions) % 2 != 0:
+                last_quote_pos = quote_positions[-1]
+                line = line[:last_quote_pos+1] + '"' + line[last_quote_pos+1:]
+            
+            repaired_lines.append(line)
+        
+        content = '\n'.join(repaired_lines)
+
+        # 3. 确保 JSON 完整闭合
+        stack = []
+        in_string = False
+        escape_next = False
+        
+        for i, char in enumerate(content):
+            if escape_next:
+                escape_next = False
+                continue
+            if char == '\\':
+                escape_next = True
+                continue
+            if char == '"' and not escape_next:
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if char in '{[':
+                stack.append(char)
+            elif char in '}]':
+                if stack:
+                    open_char = stack.pop()
+                    if (open_char == '{' and char != '}') or (open_char == '[' and char != ']'):
+                        break
+        
+        if stack:
+            logger.warning(f"JSON has {len(stack)} unclosed brackets, attempting repair")
+            closing_map = {'{': '}', '[': ']'}
+            content = content.rstrip()
+            for open_char in reversed(stack):
+                content += closing_map[open_char]
+
+        return content
 
     async def _generate_character_triples(self, novel_id: str, character_ids: list):
         """从人物关系生成三元组"""

--- a/domain/ai/services/llm_service.py
+++ b/domain/ai/services/llm_service.py
@@ -1,6 +1,6 @@
 # domain/ai/services/llm_service.py
 from abc import ABC, abstractmethod
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 from domain.ai.value_objects.prompt import Prompt
 from domain.ai.value_objects.token_usage import TokenUsage
 
@@ -9,7 +9,7 @@ class GenerationConfig:
     """生成配置"""
     def __init__(
         self,
-        model: str = "claude-sonnet-4-6",
+        model: Optional[str] = None,
         max_tokens: int = 4096,
         temperature: float = 1.0
     ):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "web-app",
-  "version": "0.0.0",
+  "name": "plotpilot",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "web-app",
-      "version": "0.0.0",
+      "name": "plotpilot",
+      "version": "1.0.0",
       "dependencies": {
         "@types/dompurify": "^3.0.5",
         "@vicons/ionicons5": "^0.13.0",
@@ -34,7 +34,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmmirror.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "license": "MIT",
       "engines": {
@@ -43,7 +43,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
@@ -52,7 +52,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.2",
-      "resolved": "https://registry.npmmirror.com/@babel/parser/-/parser-7.29.2.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "license": "MIT",
       "dependencies": {
@@ -67,7 +67,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmmirror.com/@babel/types/-/types-7.29.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
@@ -80,7 +80,7 @@
     },
     "node_modules/@css-render/plugin-bem": {
       "version": "0.15.14",
-      "resolved": "https://registry.npmmirror.com/@css-render/plugin-bem/-/plugin-bem-0.15.14.tgz",
+      "resolved": "https://registry.npmjs.org/@css-render/plugin-bem/-/plugin-bem-0.15.14.tgz",
       "integrity": "sha512-QK513CJ7yEQxm/P3EwsI+d+ha8kSOcjGvD6SevM41neEMxdULE+18iuQK6tEChAWMOQNQPLG/Rw3Khb69r5neg==",
       "license": "MIT",
       "peerDependencies": {
@@ -89,7 +89,7 @@
     },
     "node_modules/@css-render/vue3-ssr": {
       "version": "0.15.14",
-      "resolved": "https://registry.npmmirror.com/@css-render/vue3-ssr/-/vue3-ssr-0.15.14.tgz",
+      "resolved": "https://registry.npmjs.org/@css-render/vue3-ssr/-/vue3-ssr-0.15.14.tgz",
       "integrity": "sha512-//8027GSbxE9n3QlD73xFY6z4ZbHbvrOVB7AO6hsmrEzGbg+h2A09HboUyDgu+xsmj7JnvJD39Irt+2D0+iV8g==",
       "license": "MIT",
       "peerDependencies": {
@@ -97,64 +97,85 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emnapi/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emnapi/runtime/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmmirror.com/@emotion/hash/-/hash-0.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmmirror.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "license": "Apache-2.0"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -171,9 +192,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmmirror.com/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -181,9 +202,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
       "cpu": [
         "arm64"
       ],
@@ -198,9 +219,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
       "cpu": [
         "arm64"
       ],
@@ -215,9 +236,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
       "cpu": [
         "x64"
       ],
@@ -232,9 +253,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
       "cpu": [
         "x64"
       ],
@@ -249,9 +270,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
       "cpu": [
         "arm"
       ],
@@ -266,13 +287,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -283,13 +307,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -300,13 +327,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -317,13 +347,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -334,13 +367,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -351,13 +387,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -368,9 +407,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
       "cpu": [
         "arm64"
       ],
@@ -385,9 +424,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
       "cpu": [
         "wasm32"
       ],
@@ -395,16 +434,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
       "cpu": [
         "arm64"
       ],
@@ -419,9 +460,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
       "cpu": [
         "x64"
       ],
@@ -436,15 +477,15 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
-      "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmmirror.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
@@ -453,9 +494,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tybys/wasm-util/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmmirror.com/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
       "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
       "license": "MIT",
       "dependencies": {
@@ -464,13 +513,13 @@
     },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
-      "resolved": "https://registry.npmmirror.com/@types/lodash/-/lodash-4.17.24.tgz",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "license": "MIT"
     },
     "node_modules/@types/lodash-es": {
       "version": "4.17.12",
-      "resolved": "https://registry.npmmirror.com/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
       "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
       "license": "MIT",
       "dependencies": {
@@ -478,9 +527,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -489,30 +538,30 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
-      "resolved": "https://registry.npmmirror.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
       "license": "MIT"
     },
     "node_modules/@vicons/ionicons5": {
       "version": "0.13.0",
-      "resolved": "https://registry.npmmirror.com/@vicons/ionicons5/-/ionicons5-0.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/@vicons/ionicons5/-/ionicons5-0.13.0.tgz",
       "integrity": "sha512-zvZKBPjEXKN7AXNo2Na2uy+nvuv6SP4KAMQxpKL2vfHMj0fSvuw7JZcOPCjQC3e7ayssKnaoFVAhbYcW6v41qQ==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmmirror.com/@vitejs/plugin-vue/-/plugin-vue-6.0.5.tgz",
-      "integrity": "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.6.tgz",
+      "integrity": "sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.2"
+        "@rolldown/pluginutils": "1.0.0-rc.13"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -524,7 +573,7 @@
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmmirror.com/@volar/language-core/-/language-core-2.4.28.tgz",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
       "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
       "dev": true,
       "license": "MIT",
@@ -534,14 +583,14 @@
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmmirror.com/@volar/source-map/-/source-map-2.4.28.tgz",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
       "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.28",
-      "resolved": "https://registry.npmmirror.com/@volar/typescript/-/typescript-2.4.28.tgz",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
       "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
       "dev": true,
       "license": "MIT",
@@ -552,39 +601,39 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-core/-/compiler-core-3.5.31.tgz",
-      "integrity": "sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.31",
+        "@vue/shared": "3.5.32",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-dom/-/compiler-dom-3.5.31.tgz",
-      "integrity": "sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.31",
-        "@vue/shared": "3.5.31"
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-sfc/-/compiler-sfc-3.5.31.tgz",
-      "integrity": "sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.31",
-        "@vue/compiler-dom": "3.5.31",
-        "@vue/compiler-ssr": "3.5.31",
-        "@vue/shared": "3.5.31",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.8",
@@ -592,18 +641,18 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/compiler-ssr/-/compiler-ssr-3.5.31.tgz",
-      "integrity": "sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.31",
-        "@vue/shared": "3.5.31"
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/devtools-api": {
       "version": "7.7.9",
-      "resolved": "https://registry.npmmirror.com/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
       "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
       "license": "MIT",
       "dependencies": {
@@ -612,7 +661,7 @@
     },
     "node_modules/@vue/devtools-kit": {
       "version": "7.7.9",
-      "resolved": "https://registry.npmmirror.com/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
       "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
       "license": "MIT",
       "dependencies": {
@@ -627,7 +676,7 @@
     },
     "node_modules/@vue/devtools-shared": {
       "version": "7.7.9",
-      "resolved": "https://registry.npmmirror.com/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
       "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
       "license": "MIT",
       "dependencies": {
@@ -636,7 +685,7 @@
     },
     "node_modules/@vue/language-core": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmmirror.com/@vue/language-core/-/language-core-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.6.tgz",
       "integrity": "sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==",
       "dev": true,
       "license": "MIT",
@@ -651,58 +700,58 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/reactivity/-/reactivity-3.5.31.tgz",
-      "integrity": "sha512-DtKXxk9E/KuVvt8VxWu+6Luc9I9ETNcqR1T1oW1gf02nXaZ1kuAx58oVu7uX9XxJR0iJCro6fqBLw9oSBELo5g==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.31"
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/runtime-core/-/runtime-core-3.5.31.tgz",
-      "integrity": "sha512-AZPmIHXEAyhpkmN7aWlqjSfYynmkWlluDNPHMCZKFHH+lLtxP/30UJmoVhXmbDoP1Ng0jG0fyY2zCj1PnSSA6Q==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.31",
-        "@vue/shared": "3.5.31"
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/runtime-dom/-/runtime-dom-3.5.31.tgz",
-      "integrity": "sha512-xQJsNRmGPeDCJq/u813tyonNgWBFjzfVkBwDREdEWndBnGdHLHgkwNBQxLtg4zDrzKTEcnikUy1UUNecb3lJ6g==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.31",
-        "@vue/runtime-core": "3.5.31",
-        "@vue/shared": "3.5.31",
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
         "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/server-renderer/-/server-renderer-3.5.31.tgz",
-      "integrity": "sha512-GJuwRvMcdZX/CriUnyIIOGkx3rMV3H6sOu0JhdKbduaeCji6zb60iOGMY7tFoN24NfsUYoFBhshZtGxGpxO4iA==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.31",
-        "@vue/shared": "3.5.31"
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
       },
       "peerDependencies": {
-        "vue": "3.5.31"
+        "vue": "3.5.32"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/@vue/shared/-/shared-3.5.31.tgz",
-      "integrity": "sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
       "license": "MIT"
     },
     "node_modules/@vue/tsconfig": {
       "version": "0.9.1",
-      "resolved": "https://registry.npmmirror.com/@vue/tsconfig/-/tsconfig-0.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.9.1.tgz",
       "integrity": "sha512-buvjm+9NzLCJL29KY1j1991YYJ5e6275OiK+G4jtmfIb+z4POywbdm0wXusT9adVWqe0xqg70TbI7+mRx4uU9w==",
       "dev": true,
       "license": "MIT",
@@ -721,7 +770,7 @@
     },
     "node_modules/@vueuse/core": {
       "version": "14.2.1",
-      "resolved": "https://registry.npmmirror.com/@vueuse/core/-/core-14.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.2.1.tgz",
       "integrity": "sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==",
       "license": "MIT",
       "dependencies": {
@@ -738,7 +787,7 @@
     },
     "node_modules/@vueuse/metadata": {
       "version": "14.2.1",
-      "resolved": "https://registry.npmmirror.com/@vueuse/metadata/-/metadata-14.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
       "integrity": "sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==",
       "license": "MIT",
       "funding": {
@@ -747,7 +796,7 @@
     },
     "node_modules/@vueuse/shared": {
       "version": "14.2.1",
-      "resolved": "https://registry.npmmirror.com/@vueuse/shared/-/shared-14.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-14.2.1.tgz",
       "integrity": "sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==",
       "license": "MIT",
       "funding": {
@@ -759,27 +808,27 @@
     },
     "node_modules/alien-signals": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmmirror.com/alien-signals/-/alien-signals-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
       "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/async-validator": {
       "version": "4.2.5",
-      "resolved": "https://registry.npmmirror.com/async-validator/-/async-validator-4.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
       "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
       "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -789,7 +838,7 @@
     },
     "node_modules/birpc": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmmirror.com/birpc/-/birpc-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
       "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
       "license": "MIT",
       "funding": {
@@ -798,7 +847,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
@@ -811,7 +860,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
@@ -823,7 +872,7 @@
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmmirror.com/copy-anything/-/copy-anything-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
       "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
       "license": "MIT",
       "dependencies": {
@@ -838,7 +887,7 @@
     },
     "node_modules/css-render": {
       "version": "0.15.14",
-      "resolved": "https://registry.npmmirror.com/css-render/-/css-render-0.15.14.tgz",
+      "resolved": "https://registry.npmjs.org/css-render/-/css-render-0.15.14.tgz",
       "integrity": "sha512-9nF4PdUle+5ta4W5SyZdLCCmFd37uVimSjg1evcTqKJCyvCEEj12WKzOSBNak6r4im4J4iYXKH1OWpUV5LBYFg==",
       "license": "MIT",
       "dependencies": {
@@ -848,19 +897,19 @@
     },
     "node_modules/css-render/node_modules/csstype": {
       "version": "3.0.11",
-      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/date-fns/-/date-fns-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
       "funding": {
@@ -870,7 +919,7 @@
     },
     "node_modules/date-fns-tz": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmmirror.com/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
       "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
       "license": "MIT",
       "peerDependencies": {
@@ -879,13 +928,13 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.20",
-      "resolved": "https://registry.npmmirror.com/dayjs/-/dayjs-1.11.20.tgz",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "engines": {
@@ -894,7 +943,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -903,9 +952,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -913,7 +962,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
@@ -927,7 +976,7 @@
     },
     "node_modules/echarts": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/echarts/-/echarts-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
       "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -935,15 +984,9 @@
         "zrender": "6.0.0"
       }
     },
-    "node_modules/echarts/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
-    },
     "node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmmirror.com/entities/-/entities-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
@@ -955,7 +998,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
@@ -964,7 +1007,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
@@ -973,7 +1016,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
@@ -985,7 +1028,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
@@ -1000,19 +1043,19 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
     "node_modules/evtd": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmmirror.com/evtd/-/evtd-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/evtd/-/evtd-0.2.4.tgz",
       "integrity": "sha512-qaeGN5bx63s/AXgQo8gj6fBkxge+OoLddLniox5qtLAEY5HSnuSlISXVPxnSae1dWblvTh4/HoMIB+mbMsvZzw==",
       "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
@@ -1029,9 +1072,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -1050,7 +1093,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
@@ -1066,7 +1109,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
@@ -1081,7 +1124,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -1090,7 +1133,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
@@ -1114,7 +1157,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
@@ -1127,7 +1170,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
@@ -1139,7 +1182,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
@@ -1151,7 +1194,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "dependencies": {
@@ -1166,7 +1209,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
       "dependencies": {
@@ -1178,7 +1221,7 @@
     },
     "node_modules/highlight.js": {
       "version": "11.11.1",
-      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-11.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -1187,13 +1230,13 @@
     },
     "node_modules/hookable": {
       "version": "5.5.3",
-      "resolved": "https://registry.npmmirror.com/hookable/-/hookable-5.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
     "node_modules/is-what": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmmirror.com/is-what/-/is-what-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
       "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
       "license": "MIT",
       "engines": {
@@ -1205,7 +1248,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
@@ -1235,7 +1278,7 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
@@ -1256,7 +1299,7 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
@@ -1277,7 +1320,7 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
@@ -1298,7 +1341,7 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
@@ -1319,7 +1362,7 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
@@ -1340,12 +1383,15 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1361,12 +1407,15 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1382,12 +1431,15 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1403,12 +1455,15 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1424,7 +1479,7 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
@@ -1445,7 +1500,7 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
@@ -1465,20 +1520,20 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmmirror.com/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
@@ -1486,9 +1541,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmmirror.com/marked/-/marked-17.0.5.tgz",
-      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -1499,7 +1554,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
@@ -1508,7 +1563,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
@@ -1517,7 +1572,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
@@ -1529,20 +1584,20 @@
     },
     "node_modules/mitt": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/mitt/-/mitt-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmmirror.com/muggle-string/-/muggle-string-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/naive-ui": {
       "version": "2.44.1",
-      "resolved": "https://registry.npmmirror.com/naive-ui/-/naive-ui-2.44.1.tgz",
+      "resolved": "https://registry.npmjs.org/naive-ui/-/naive-ui-2.44.1.tgz",
       "integrity": "sha512-reo8Esw0p58liZwbUutC7meW24Xbn3EwNv91zReWKm2W4JPu+zfgJRn/F7aO0BFmvN+h2brA2M5lRvYqLq4kuA==",
       "license": "MIT",
       "dependencies": {
@@ -1574,7 +1629,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
@@ -1592,26 +1647,26 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
@@ -1624,7 +1679,7 @@
     },
     "node_modules/pinia": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/pinia/-/pinia-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
       "dependencies": {
@@ -1644,9 +1699,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1673,7 +1728,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
       "engines": {
@@ -1682,19 +1737,19 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmmirror.com/rfdc/-/rfdc-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1703,39 +1758,39 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/seemly": {
       "version": "0.3.10",
-      "resolved": "https://registry.npmmirror.com/seemly/-/seemly-0.3.10.tgz",
+      "resolved": "https://registry.npmjs.org/seemly/-/seemly-0.3.10.tgz",
       "integrity": "sha512-2+SMxtG1PcsL0uyhkumlOU6Qo9TAQ/WyH7tthnPIOQB05/12jz9naq6GZ6iZ6ApVsO3rr2gsnTf3++OV63kE1Q==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -1744,7 +1799,7 @@
     },
     "node_modules/speakingurl": {
       "version": "14.0.1",
-      "resolved": "https://registry.npmmirror.com/speakingurl/-/speakingurl-14.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
       "license": "BSD-3-Clause",
       "engines": {
@@ -1753,7 +1808,7 @@
     },
     "node_modules/superjson": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmmirror.com/superjson/-/superjson-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
       "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
       "license": "MIT",
       "dependencies": {
@@ -1764,14 +1819,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1782,21 +1837,19 @@
     },
     "node_modules/treemate": {
       "version": "0.3.11",
-      "resolved": "https://registry.npmmirror.com/treemate/-/treemate-0.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/treemate/-/treemate-0.3.11.tgz",
       "integrity": "sha512-M8RGFoKtZ8dF+iwJfAJTOH/SM4KluKOKRJpjCMhI8bG3qB74zrFoArKZ62ll0Fr3mqkMJiQOmWYkdYgDeITYQg==",
       "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
@@ -1810,14 +1863,14 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.16.0.tgz",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vdirs": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmmirror.com/vdirs/-/vdirs-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/vdirs/-/vdirs-0.1.8.tgz",
       "integrity": "sha512-H9V1zGRLQZg9b+GdMk8MXDN2Lva0zx72MPahDKc30v+DtwKjfyOSXWRIX4t2mhDubM1H09gPhWeth/BJWPHGUw==",
       "license": "MIT",
       "dependencies": {
@@ -1828,16 +1881,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmmirror.com/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
+        "rolldown": "1.0.0-rc.15",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -1855,7 +1908,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -1907,7 +1960,7 @@
     },
     "node_modules/vooks": {
       "version": "0.2.12",
-      "resolved": "https://registry.npmmirror.com/vooks/-/vooks-0.2.12.tgz",
+      "resolved": "https://registry.npmjs.org/vooks/-/vooks-0.2.12.tgz",
       "integrity": "sha512-iox0I3RZzxtKlcgYaStQYKEzWWGAduMmq+jS7OrNdQo1FgGfPMubGL3uGHOU9n97NIvfFDBGnpSvkWyb/NSn/Q==",
       "license": "MIT",
       "dependencies": {
@@ -1919,22 +1972,22 @@
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vue": {
-      "version": "3.5.31",
-      "resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.31.tgz",
-      "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.31",
-        "@vue/compiler-sfc": "3.5.31",
-        "@vue/runtime-dom": "3.5.31",
-        "@vue/server-renderer": "3.5.31",
-        "@vue/shared": "3.5.31"
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -1947,7 +2000,7 @@
     },
     "node_modules/vue-echarts": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmmirror.com/vue-echarts/-/vue-echarts-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.0.1.tgz",
       "integrity": "sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==",
       "license": "MIT",
       "peerDependencies": {
@@ -1957,7 +2010,7 @@
     },
     "node_modules/vue-router": {
       "version": "4.6.4",
-      "resolved": "https://registry.npmmirror.com/vue-router/-/vue-router-4.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
       "dependencies": {
@@ -1972,13 +2025,13 @@
     },
     "node_modules/vue-router/node_modules/@vue/devtools-api": {
       "version": "6.6.4",
-      "resolved": "https://registry.npmmirror.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
     "node_modules/vue-tsc": {
       "version": "3.2.6",
-      "resolved": "https://registry.npmmirror.com/vue-tsc/-/vue-tsc-3.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.6.tgz",
       "integrity": "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==",
       "dev": true,
       "license": "MIT",
@@ -1995,7 +2048,7 @@
     },
     "node_modules/vueuc": {
       "version": "0.4.65",
-      "resolved": "https://registry.npmmirror.com/vueuc/-/vueuc-0.4.65.tgz",
+      "resolved": "https://registry.npmjs.org/vueuc/-/vueuc-0.4.65.tgz",
       "integrity": "sha512-lXuMl+8gsBmruudfxnMF9HW4be8rFziylXFu1VHVNbLVhRTXXV4njvpRuJapD/8q+oFEMSfQMH16E/85VoWRyQ==",
       "license": "MIT",
       "dependencies": {
@@ -2013,18 +2066,12 @@
     },
     "node_modules/zrender": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/zrender/-/zrender-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
       "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"
       }
-    },
-    "node_modules/zrender/node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
     }
   }
 }

--- a/frontend/src/components/StoryStructureTree.vue
+++ b/frontend/src/components/StoryStructureTree.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="story-structure" @click="closeMenu">
+  <div class="story-structure" :class="{ narrow: isNarrow }" @click="closeMenu" ref="rootEl">
     <div class="structure-body" v-if="treeData.length > 0">
       <n-tree
         :data="treeData"
@@ -62,6 +62,17 @@
       negative-text="取消"
       @positive-click="doRename"
     >
+      <!-- 节点信息摘要（只读） -->
+      <div v-if="menuTargetNode" class="rename-info">
+        <div v-if="menuTargetNode.chapter_start && menuTargetNode.chapter_end" class="rename-info-row">
+          <span class="rename-info-label">章节范围</span>
+          <span>第 {{ menuTargetNode.chapter_start }}～{{ menuTargetNode.chapter_end }} 章（共 {{ menuTargetNode.chapter_count }} 章）</span>
+        </div>
+        <div v-if="menuTargetNode.description" class="rename-info-row rename-info-desc">
+          <span class="rename-info-label">摘要</span>
+          <span>{{ menuTargetNode.description }}</span>
+        </div>
+      </div>
       <n-input v-model:value="renameValue" placeholder="输入新标题" @keydown.enter="doRename" />
     </n-modal>
 
@@ -80,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, h, onMounted, watch } from 'vue'
+import { ref, computed, h, onMounted, onUnmounted, watch } from 'vue'
 import { NTree, NEmpty, NSpin, NTag, NButton, NSpace, NDropdown, NModal, NInput, useMessage, useDialog } from 'naive-ui'
 import { structureApi, type StoryNode } from '@/api/structure'
 import { chapterApi } from '@/api/chapter'
@@ -100,8 +111,28 @@ const emit = defineEmits<{
 const message = useMessage()
 const dialog = useDialog()
 
+// 宽度监测：面板过窄时隐藏后缀文字
+const rootEl = ref<HTMLElement | null>(null)
+const isNarrow = ref(false)
+const NARROW_THRESHOLD = 280
+let ro: ResizeObserver | null = null
+
+onMounted(() => {
+  loadTree()
+  if (rootEl.value) {
+    ro = new ResizeObserver(entries => {
+      const w = entries[0]?.contentRect.width ?? rootEl.value?.offsetWidth ?? 999
+      isNarrow.value = w < NARROW_THRESHOLD
+    })
+    ro.observe(rootEl.value)
+  }
+})
+
+onUnmounted(() => {
+  ro?.disconnect()
+})
+
 const loading = ref(false)
-/** 全托管时空侧栏提示：避免与「启动结构规划」主按钮混淆 */
 const autopilotEmptyMode = ref<null | 'planning' | 'review'>(null)
 const structureEmptyDescription = computed(() => {
   if (autopilotEmptyMode.value === 'planning') {
@@ -403,8 +434,14 @@ const doAddChild = async () => {
   }
 }
 
+/** 构建节点的悬浮提示文本（仅摘要） */
+const buildTooltip = (option: StoryNode): string => {
+  return option.description ? `摘要：${option.description}` : ''
+}
+
 // 渲染节点标签
 const renderLabel = ({ option }: { option: StoryNode }) => {
+  const tooltip = buildTooltip(option)
   const elements: any[] = [
     h('span', { class: 'node-icon' }, option.icon),
     h('span', { class: 'node-title' }, option.display_name),
@@ -422,29 +459,19 @@ const renderLabel = ({ option }: { option: StoryNode }) => {
       }, () => (hasContent ? '已收稿' : '未收稿'))
     )
   }
-  return h('span', { class: 'node-label' }, elements)
+  return h('span', { class: 'node-label', title: tooltip || undefined }, elements)
 }
 
-// 渲染节点后缀
+// 渲染节点后缀（章节范围 / 字数常态显示）
 const renderSuffix = ({ option }: { option: StoryNode }) => {
-  const elements: any[] = []
-  if (option.description && ['part', 'volume', 'act'].includes(option.node_type)) {
-    elements.push(
-      h('span', {
-        class: 'node-description',
-        style: { color: '#999', fontSize: '12px', marginLeft: '8px' },
-      }, option.description)
-    )
+  if (option.chapter_start && option.chapter_end) {
+    return h('span', { class: 'node-range' },
+      `第 ${option.chapter_start}～${option.chapter_end} 章（${option.chapter_count} 章）`)
   }
   if (option.node_type === 'chapter' && option.word_count) {
-    elements.push(h('span', { class: 'node-range' }, `${option.word_count}字`))
+    return h('span', { class: 'node-range' }, `${option.word_count} 字`)
   }
-  if (option.chapter_start && option.chapter_end) {
-    elements.push(
-      h('span', { class: 'node-range' }, `${option.chapter_start}-${option.chapter_end}章 (${option.chapter_count})`)
-    )
-  }
-  return elements.length > 0 ? h('span', {}, elements) : null
+  return null
 }
 
 // 节点属性（右键绑定）
@@ -453,8 +480,7 @@ const nodeProps = ({ option }: { option: StoryNode }) => ({
   onContextmenu: (e: MouseEvent) => handleContextMenu(e, option),
 })
 
-onMounted(() => { loadTree() })
-
+// loadTree 已在顶部 onMounted 中调用
 defineExpose({ loadTree })
 </script>
 
@@ -480,17 +506,50 @@ defineExpose({ loadTree })
 .node-label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
+  cursor: default;
 }
 .node-icon { font-size: 16px; }
 .node-title { font-size: 13px; }
 .node-range {
   font-size: 12px;
   color: #999;
-  margin-left: 8px;
+  white-space: nowrap;
+  transition: opacity 0.15s;
+}
+
+/* 面板过窄时隐藏后缀，避免节点标题换行 */
+.narrow :deep(.node-range) {
+  display: none;
 }
 .node-level-1 { font-weight: 600; }
 .node-level-2 { font-weight: 500; }
 .node-level-3 { font-weight: normal; }
 .node-level-4 { font-weight: normal; font-size: 13px; }
+
+/* 重命名弹窗信息区 */
+.rename-info {
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  background: var(--n-color-embedded, rgba(128,128,128,0.06));
+  border-radius: 6px;
+  font-size: 12px;
+  color: #888;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.rename-info-row {
+  display: flex;
+  gap: 8px;
+}
+.rename-info-label {
+  color: #aaa;
+  white-space: nowrap;
+  min-width: 48px;
+}
+.rename-info-desc span:last-child {
+  line-height: 1.6;
+  word-break: break-all;
+}
 </style>

--- a/frontend/src/components/autopilot/AutopilotDashboard.vue
+++ b/frontend/src/components/autopilot/AutopilotDashboard.vue
@@ -74,8 +74,7 @@ function handleBreakerReset() {
 
 <style scoped>
 .autopilot-dashboard {
-  height: 100%;
-  overflow-y: auto;
+  /* 高度由内容自然撑开，由父容器 .managed-stack 统一负责滚动 */
 }
 
 .monitor-copy-hint {

--- a/frontend/src/components/autopilot/RealtimeLogStream.vue
+++ b/frontend/src/components/autopilot/RealtimeLogStream.vue
@@ -166,10 +166,66 @@ const lastWordCount = ref(0)
 const lastTimestamp = ref(0)
 const writingSpeed = ref(0)
 
-// 滚动流式显示：只显示最近的增量文字
+// 打字机效果
 const lastContentLength = ref(0)
-const streamingText = ref('')
+const streamingText = ref('')          // 当前显示的文字（固定最后 N 行）
 const scrollContainer2 = ref<HTMLElement | null>(null)
+
+const TYPEWRITER_INTERVAL = 28         // ms / 字，约 35字/秒视觉速度
+const MAX_DISPLAY_LINES = 6            // 最多保留行数
+const CHARS_PER_LINE = 42              // 估算每行字数（用于裁行）
+
+let typewriterQueue: string[] = []     // 待打印字符队列
+let typewriterTimer: number | null = null
+
+/** 把显示文本裁剪到最后 MAX_DISPLAY_LINES 行 */
+function trimToMaxLines(text: string): string {
+  const lines = text.split('\n')
+  if (lines.length <= MAX_DISPLAY_LINES) return text
+
+  // 按视觉折行估算：每段文字超过 CHARS_PER_LINE 算多行
+  let totalVisualLines = 0
+  const kept: string[] = []
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const visualLines = Math.max(1, Math.ceil(lines[i].length / CHARS_PER_LINE))
+    totalVisualLines += visualLines
+    if (totalVisualLines > MAX_DISPLAY_LINES + 2) break
+    kept.unshift(lines[i])
+  }
+  return kept.join('\n')
+}
+
+/** 启动打字机循环 */
+function startTypewriter() {
+  if (typewriterTimer !== null) return
+  typewriterTimer = window.setInterval(() => {
+    if (typewriterQueue.length === 0) {
+      clearInterval(typewriterTimer!)
+      typewriterTimer = null
+      return
+    }
+    // 每帧打 1~3 个字（中英文均算 1 字）
+    const batch = typewriterQueue.splice(0, 2).join('')
+    streamingText.value = trimToMaxLines(streamingText.value + batch)
+
+    nextTick(() => {
+      if (scrollContainer2.value) {
+        scrollContainer2.value.scrollTop = scrollContainer2.value.scrollHeight
+      }
+    })
+  }, TYPEWRITER_INTERVAL)
+}
+
+/** 清空打字机 */
+function resetTypewriter() {
+  if (typewriterTimer !== null) {
+    clearInterval(typewriterTimer)
+    typewriterTimer = null
+  }
+  typewriterQueue = []
+  streamingText.value = ''
+  lastContentLength.value = 0
+}
 
 const isWritingContent = computed(() => props.writingContent && props.writingContent.length > 0 && (props.writingChapterNumber || 0) > 0)
 const writingWordCount = computed(() => props.writingContent?.length || 0)
@@ -458,8 +514,7 @@ watch(
       lastWordCount.value = 0
       lastTimestamp.value = 0
       writingSpeed.value = 0
-      lastContentLength.value = 0
-      streamingText.value = ''
+      resetTypewriter()
       return
     }
     const now = Date.now()
@@ -474,23 +529,12 @@ watch(
       }
     }
 
-    // 流式滚动显示：只显示最近的文字（避免内容无限累积导致重复显示）
+    // 把新增字符推入打字机队列
     if (currentCount > lastContentLength.value) {
-      // 只保留最后 500 个字符，避免内容过长
-      const displayLimit = 500
-      if (currentCount > displayLimit) {
-        streamingText.value = content.slice(-displayLimit)
-      } else {
-        streamingText.value = content
-      }
+      const newChars = content.slice(lastContentLength.value)
+      typewriterQueue.push(...newChars.split(''))
       lastContentLength.value = currentCount
-
-      // 自动滚动到底部
-      nextTick(() => {
-        if (scrollContainer2.value) {
-          scrollContainer2.value.scrollTop = scrollContainer2.value.scrollHeight
-        }
-      })
+      startTypewriter()
     }
 
     lastWordCount.value = currentCount
@@ -501,10 +545,7 @@ watch(
 // 监听章节变化，清空滚动文本
 watch(
   () => props.writingChapterNumber,
-  () => {
-    streamingText.value = ''
-    lastContentLength.value = 0
-  }
+  () => { resetTypewriter() }
 )
 
 onUnmounted(() => {
@@ -516,6 +557,7 @@ onUnmounted(() => {
     clearTimeout(reconnectTimer)
     reconnectTimer = null
   }
+  resetTypewriter()
 })
 </script>
 
@@ -617,11 +659,14 @@ onUnmounted(() => {
 }
 
 .writing-stream-bar .stream-content-preview {
-  max-height: 120px;
-  overflow-y: auto;
+  height: 128px;           /* 约 6行 × line-height 1.7 × 12px ≈ 122px，留少量余量 */
+  overflow: hidden;
   padding: 6px 10px;
   border-top: 1px solid rgba(24, 160, 88, 0.1);
   background: rgba(0, 0, 0, 0.02);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;  /* 内容始终贴底，新行从底部入场 */
 }
 
 .writing-stream-bar .content-text {

--- a/frontend/src/components/autopilot/TensionChart.vue
+++ b/frontend/src/components/autopilot/TensionChart.vue
@@ -75,6 +75,7 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 
 let chartInstance: echarts.ECharts | null = null
+let resizeObserver: ResizeObserver | null = null
 
 // 张力警戒线
 const tensionThreshold = computed(() => props.threshold ?? 5.0)
@@ -105,6 +106,12 @@ const maxTension = computed(() => {
 
 // ==================== 加载 ====================
 async function loadTensionData() {
+  // 销毁旧实例，避免 loading 期间 chartRef DOM 被卸载后实例失效
+  if (chartInstance) {
+    detachResizeObserver()
+    chartInstance.dispose()
+    chartInstance = null
+  }
   loading.value = true
   error.value = null
   try {
@@ -147,6 +154,7 @@ function renderChart() {
 
   if (!chartInstance) {
     chartInstance = echarts.init(chartRef.value)
+    attachResizeObserver()
   }
 
   const chapterNumbers = tensionData.value.map((d) => d.chapter_number)
@@ -285,6 +293,19 @@ function handleResize() {
   chartInstance?.resize()
 }
 
+function attachResizeObserver() {
+  if (!chartRef.value || resizeObserver) return
+  resizeObserver = new ResizeObserver(() => {
+    chartInstance?.resize()
+  })
+  resizeObserver.observe(chartRef.value)
+}
+
+function detachResizeObserver() {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+}
+
 // ==================== 监听 ====================
 watch(() => props.novelId, () => void loadTensionData())
 
@@ -307,6 +328,7 @@ onMounted(() => {
 onUnmounted(() => {
   window.removeEventListener('resize', handleResize)
   if (resizeTimer) clearTimeout(resizeTimer)
+  detachResizeObserver()
   chartInstance?.dispose()
   chartInstance = null
 })

--- a/frontend/src/components/graphs/CastGraphCompact.vue
+++ b/frontend/src/components/graphs/CastGraphCompact.vue
@@ -209,9 +209,9 @@ onMounted(async () => {
   flex-shrink: 0;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
-  padding: 8px 10px;
+  padding: 6px 10px;
   border-bottom: 1px solid rgba(148, 163, 184, 0.2);
   background: #fff;
 }
@@ -219,7 +219,9 @@ onMounted(async () => {
 .cgc-hint {
   font-size: 11px;
   line-height: 1.45;
-  max-width: min(100%, 380px);
+  flex: 1;
+  min-width: 0;
+  /* 提示文字可折叠，但不会把按钮挤出行外 */
 }
 
 .cgc-hint code {

--- a/frontend/src/components/graphs/LocationGraphCompact.vue
+++ b/frontend/src/components/graphs/LocationGraphCompact.vue
@@ -245,9 +245,9 @@ onMounted(async () => {
   flex-shrink: 0;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
-  padding: 8px 10px;
+  padding: 6px 10px;
   border-bottom: 1px solid rgba(148, 163, 184, 0.2);
   background: #fff;
 }
@@ -255,7 +255,8 @@ onMounted(async () => {
 .lgc-hint {
   font-size: 11px;
   line-height: 1.45;
-  max-width: min(100%, 380px);
+  flex: 1;
+  min-width: 0;
 }
 
 .lgc-hint code {

--- a/frontend/src/components/onboarding/NovelSetupGuide.vue
+++ b/frontend/src/components/onboarding/NovelSetupGuide.vue
@@ -697,7 +697,15 @@ const handleNext = async () => {
     try {
       await bibleApi.generateBible(props.novelId, 'characters')
       // 轮询检查人物生成状态
+      let characterCheckCount = 0
+      const maxCharacterChecks = 60 // 最多检查60次，每次2秒，共2分钟
       const checkCharacters = async () => {
+        characterCheckCount++
+        if (characterCheckCount > maxCharacterChecks) {
+          console.warn('Character generation timeout')
+          generatingCharacters.value = false
+          return
+        }
         const bible = await bibleApi.getBible(props.novelId)
         bibleData.value = bible
         if (bible.characters && bible.characters.length > 0) {
@@ -719,14 +727,28 @@ const handleNext = async () => {
     try {
       await bibleApi.generateBible(props.novelId, 'locations')
       // 轮询检查地点生成状态
+      let locationCheckCount = 0
+      const maxLocationChecks = 60 // 最多检查60次，每次2秒，共2分钟
       const checkLocations = async () => {
-        const bible = await bibleApi.getBible(props.novelId)
-        bibleData.value = bible
-        if (bible.locations && bible.locations.length > 0) {
+        locationCheckCount++
+        if (locationCheckCount > maxLocationChecks) {
+          console.warn('Location generation timeout')
           generatingLocations.value = false
-          locationsGenerated.value = true
-        } else {
-          window.setTimeout(checkLocations, 2000)
+          return
+        }
+        try {
+          const bible = await bibleApi.getBible(props.novelId)
+          bibleData.value = bible
+          if (bible.locations && bible.locations.length > 0) {
+            generatingLocations.value = false
+            locationsGenerated.value = true
+          } else {
+            window.setTimeout(checkLocations, 2000)
+          }
+        } catch (pollError) {
+          console.warn('Poll getBible failed, retrying...', pollError)
+          // 请求失败时仍然继续轮询，但间隔延长到4秒
+          window.setTimeout(checkLocations, 4000)
         }
       }
       await checkLocations()

--- a/frontend/src/components/onboarding/NovelSetupGuide.vue
+++ b/frontend/src/components/onboarding/NovelSetupGuide.vue
@@ -651,7 +651,7 @@ async function startBibleGeneration() {
       clearGenerationTimers()
       generatingBible.value = false
       bibleError.value = '生成超时，请稍后在工作台手动重试'
-    }, 120000)
+    }, 300000)
 
     schedulePoll(0)
   } catch (error: unknown) {

--- a/frontend/src/components/panels/BiblePanel.vue
+++ b/frontend/src/components/panels/BiblePanel.vue
@@ -1,52 +1,56 @@
 <template>
   <div class="bible-panel">
     <header class="bible-hero">
-      <div class="bible-hero-main">
-        <div class="bible-title-row">
-          <h3 class="bible-title">作品设定</h3>
-          <n-tag size="small" round :bordered="false" class="bible-badge">Story Bible</n-tag>
-        </div>
-        <p class="bible-lead">
-          <strong>梗概锁定</strong>（主线与不可违背设定）与<strong>写作公约</strong>（人称、时态、叙事距离、基调与禁区）——全书的「写什么」与「怎么写」。
-        </p>
-        <div class="bible-roles" aria-label="资料分工">
-          <div class="bible-role-item bible-role-here">
-            <span class="bible-role-k">梗概锁定</span>
-            <span class="bible-role-v">此处 · 主线与不可违背设定（全书上下文）</span>
-          </div>
-          <div class="bible-role-item">
-            <span class="bible-role-k">世界观构建</span>
-            <span class="bible-role-v">世界观 Tab · 5维度框架</span>
-          </div>
-          <div class="bible-role-item bible-role-here">
-            <span class="bible-role-k">写作风格</span>
-            <span class="bible-role-v">此处 · 文风公约</span>
-          </div>
-          <div class="bible-role-item">
-            <span class="bible-role-k">角色与地点</span>
-            <span class="bible-role-v">知识库 · 三元组关系</span>
-          </div>
-          <div class="bible-role-item">
-            <span class="bible-role-k">叙事线索</span>
-            <span class="bible-role-v">故事线/情节弧/时间线</span>
-          </div>
-        </div>
-        <div class="bible-stats" aria-live="polite">
-          <span class="bible-stat bible-stat-premise" :class="{ 'is-done': stats.premiseOk }">
-            梗概锁定 {{ stats.premiseOk ? '已填' : '待补充' }}
-          </span>
-          <span class="bible-stat-dot" aria-hidden="true" />
-          <span class="bible-stat bible-stat-style" :class="{ 'is-done': stats.styleOk }">
-            文风公约 {{ stats.styleOk ? '已填' : '待补充' }}
-          </span>
+      <!-- 标题行：title + badge + 按钮同行 -->
+      <div class="bible-title-row">
+        <h3 class="bible-title">作品设定</h3>
+        <n-tag size="small" round :bordered="false" class="bible-badge">Story Bible</n-tag>
+        <div class="bible-hero-actions">
+          <n-button size="small" secondary :loading="generating" @click="generateBible" title="用 AI 根据小说标题重新生成设定">
+            ✦ AI 生成
+          </n-button>
+          <n-button size="small" type="primary" :loading="saving" @click="save">保存设定</n-button>
         </div>
       </div>
-      <n-space class="bible-hero-actions" :size="8" align="center">
-        <n-button size="small" secondary :loading="generating" @click="generateBible" title="用 AI 根据小说标题重新生成设定">
-          ✦ AI 生成
-        </n-button>
-        <n-button size="small" type="primary" :loading="saving" @click="save">保存设定</n-button>
-      </n-space>
+
+      <!-- 说明文字 -->
+      <p class="bible-lead">
+        <strong>梗概锁定</strong>（主线与不可违背设定）与<strong>写作公约</strong>（人称、时态、叙事距离、基调与禁区）——全书的「写什么」与「怎么写」。
+      </p>
+
+      <!-- 色块：每行两个，自适应宽度 -->
+      <div class="bible-roles" aria-label="资料分工">
+        <div class="bible-role-item bible-role-here">
+          <span class="bible-role-k">梗概锁定</span>
+          <span class="bible-role-v">此处 · 主线与不可违背设定（全书上下文）</span>
+        </div>
+        <div class="bible-role-item">
+          <span class="bible-role-k">世界观构建</span>
+          <span class="bible-role-v">世界观 Tab · 5维度框架</span>
+        </div>
+        <div class="bible-role-item bible-role-here">
+          <span class="bible-role-k">写作风格</span>
+          <span class="bible-role-v">此处 · 文风公约</span>
+        </div>
+        <div class="bible-role-item">
+          <span class="bible-role-k">角色与地点</span>
+          <span class="bible-role-v">知识库 · 三元组关系</span>
+        </div>
+        <div class="bible-role-item">
+          <span class="bible-role-k">叙事线索</span>
+          <span class="bible-role-v">故事线/情节弧/时间线</span>
+        </div>
+      </div>
+
+      <div class="bible-stats" aria-live="polite">
+        <span class="bible-stat bible-stat-premise" :class="{ 'is-done': stats.premiseOk }">
+          梗概锁定 {{ stats.premiseOk ? '已填' : '待补充' }}
+        </span>
+        <span class="bible-stat-dot" aria-hidden="true" />
+        <span class="bible-stat bible-stat-style" :class="{ 'is-done': stats.styleOk }">
+          文风公约 {{ stats.styleOk ? '已填' : '待补充' }}
+        </span>
+      </div>
     </header>
 
     <n-scrollbar class="bible-scroll">
@@ -482,25 +486,23 @@ onMounted(() => {
 
 .bible-hero {
   flex-shrink: 0;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 14px;
-  padding: 14px 2px 12px;
+  padding: 12px 2px 12px;
   border-bottom: 1px solid rgba(15, 23, 42, 0.07);
-}
-
-.bible-hero-main {
-  min-width: 0;
-  flex: 1;
 }
 
 .bible-title-row {
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 8px;
   margin-bottom: 8px;
+}
+
+.bible-hero-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .bible-title {
@@ -521,11 +523,10 @@ onMounted(() => {
 }
 
 .bible-lead {
-  margin: 0 0 12px;
+  margin: 0 0 10px;
   font-size: 12px;
   line-height: 1.65;
   color: #475569;
-  max-width: 52em;
 }
 
 .bible-lead strong {
@@ -535,12 +536,12 @@ onMounted(() => {
 
 .bible-roles {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px 12px;
-  margin-bottom: 12px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  margin-bottom: 10px;
 }
 
-@media (max-width: 520px) {
+@media (max-width: 320px) {
   .bible-roles {
     grid-template-columns: 1fr;
   }
@@ -601,11 +602,6 @@ onMounted(() => {
 .bible-stat-premise.is-done,
 .bible-stat-style.is-done {
   color: #15803d;
-}
-
-.bible-hero-actions {
-  flex-shrink: 0;
-  padding-top: 2px;
 }
 
 .bible-scroll {

--- a/frontend/src/components/stats/StatsTopBar.vue
+++ b/frontend/src/components/stats/StatsTopBar.vue
@@ -17,7 +17,7 @@
         <template #trigger>
           <div class="stat-content">
             <span class="stat-label">{{ stat.label }}</span>
-            <span class="stat-value">{{ stat.value }}</span>
+            <span class="stat-value" :class="{ 'stat-value-date': stat.key === 'updated' }">{{ stat.value }}</span>
           </div>
         </template>
         <span>{{ stat.tooltip }}</span>
@@ -39,8 +39,6 @@ const statsStore = useStatsStore()
 
 // Constants
 const DECIMAL_PRECISION = 1
-const MS_PER_DAY = 1000 * 60 * 60 * 24
-const DAYS_THRESHOLD = 7
 
 // State
 const loading = ref(false)
@@ -117,19 +115,9 @@ function formatDate(dateStr: string | undefined): string {
   if (!dateStr) return '—'
   try {
     const date = new Date(dateStr)
-    const now = new Date()
-    const diffMs = now.getTime() - date.getTime()
-    const diffDays = Math.floor(diffMs / MS_PER_DAY)
-
-    if (diffDays === 0) {
-      return '今天'
-    } else if (diffDays === 1) {
-      return '昨天'
-    } else if (diffDays < DAYS_THRESHOLD) {
-      return `${diffDays}天前`
-    } else {
-      return date.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric' })
-    }
+    if (isNaN(date.getTime())) return dateStr
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
   } catch {
     return dateStr
   }
@@ -190,6 +178,12 @@ onMounted(async () => {
 .stat-value {
   font-size: 24px;
   font-weight: 600;
+}
+
+.stat-value-date {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
 .stat-item:hover .stat-value {

--- a/frontend/src/components/workbench/WorkArea.vue
+++ b/frontend/src/components/workbench/WorkArea.vue
@@ -1071,7 +1071,30 @@ defineExpose({ ensureAssistedMode })
   min-height: 0;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 0.2s;
+}
+
+.managed-stack:hover {
+  scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+}
+
+/* Webkit */
+.managed-stack::-webkit-scrollbar {
+  width: 6px;
+}
+.managed-stack::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+  transition: background 0.2s;
+}
+.managed-stack:hover::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.2);
+}
+.managed-stack::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .managed-daemon-hint {
@@ -1093,18 +1116,12 @@ defineExpose({ ensureAssistedMode })
 }
 
 .managed-monitor {
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+  flex-shrink: 0;
   background: var(--app-surface);
 }
 
 .managed-monitor :deep(.autopilot-dashboard) {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
+  /* 不再独立滚动，随父容器整体滚动 */
 }
 
 .work-header {

--- a/frontend/src/views/Workbench.vue
+++ b/frontend/src/views/Workbench.vue
@@ -4,48 +4,79 @@
 
     <n-spin :show="pageLoading" class="workbench-spin" description="加载工作台…">
       <div class="workbench-inner">
-        <n-split direction="horizontal" :min="0.12" :max="0.30" :default-size="0.18">
-          <template #1>
-            <ChapterList
-              ref="chapterListRef"
-              :slug="slug"
-              :chapters="chapters"
-              :current-chapter-id="currentChapterId"
-              @select="onSidebarChapterSelect"
-              @back="goHome"
-              @refresh="handleChapterUpdated"
-              @plan-act="handlePlanAct"
-            />
-          </template>
 
-          <template #2>
-            <n-split direction="horizontal" :min="0.40" :max="0.75" :default-size="0.60">
-              <template #1>
-                <WorkArea
-                  ref="workAreaRef"
-                  :slug="slug"
-                  :book-title="bookTitle"
-                  :chapters="chapters"
-                  :current-chapter-id="currentChapterId"
-                  :chapter-content="chapterContent"
-                  :chapter-loading="chapterLoading"
-                  @set-right-panel="setRightPanel"
-                  @chapter-updated="handleChapterUpdated"
-                />
-              </template>
+        <!-- 左侧面板 -->
+        <div
+          class="side-pane left-pane"
+          :style="{ width: leftCollapsed ? '0px' : leftWidth + 'px' }"
+        >
+          <ChapterList
+            ref="chapterListRef"
+            :slug="slug"
+            :chapters="chapters"
+            :current-chapter-id="currentChapterId"
+            @select="onSidebarChapterSelect"
+            @back="goHome"
+            @refresh="handleChapterUpdated"
+            @plan-act="handlePlanAct"
+          />
+        </div>
 
-              <template #2>
-                <SettingsPanel
-                  :slug="slug"
-                  :current-panel="rightPanel"
-                  :bible-key="biblePanelKey"
-                  :current-chapter="currentChapter"
-                  @update:current-panel="onSettingsPanelChange"
-                />
-              </template>
-            </n-split>
-          </template>
-        </n-split>
+        <!-- 左侧分割线 + 折叠按钮 -->
+        <div
+          class="divider left-divider"
+          @mousedown="startDragLeft"
+        >
+          <button
+            class="collapse-btn"
+            @mousedown.stop
+            @click="leftCollapsed = !leftCollapsed"
+            :title="leftCollapsed ? '展开左侧' : '收起左侧'"
+          >{{ leftCollapsed ? '›' : '‹' }}</button>
+        </div>
+
+        <!-- 中间主区域 -->
+        <div class="main-pane">
+          <WorkArea
+            ref="workAreaRef"
+            :slug="slug"
+            :book-title="bookTitle"
+            :chapters="chapters"
+            :current-chapter-id="currentChapterId"
+            :chapter-content="chapterContent"
+            :chapter-loading="chapterLoading"
+            @set-right-panel="setRightPanel"
+            @chapter-updated="handleChapterUpdated"
+          />
+        </div>
+
+        <!-- 右侧分割线 + 折叠按钮 -->
+        <div
+          class="divider right-divider"
+          @mousedown="startDragRight"
+        >
+          <button
+            class="collapse-btn"
+            @mousedown.stop
+            @click="rightCollapsed = !rightCollapsed"
+            :title="rightCollapsed ? '展开右侧' : '收起右侧'"
+          >{{ rightCollapsed ? '‹' : '›' }}</button>
+        </div>
+
+        <!-- 右侧面板 -->
+        <div
+          class="side-pane right-pane"
+          :style="{ width: rightCollapsed ? '0px' : rightWidth + 'px' }"
+        >
+          <SettingsPanel
+            :slug="slug"
+            :current-panel="rightPanel"
+            :bible-key="biblePanelKey"
+            :current-chapter="currentChapter"
+            @update:current-panel="onSettingsPanelChange"
+          />
+        </div>
+
       </div>
     </n-spin>
 
@@ -60,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, ref, watch, type ComponentPublicInstance } from 'vue'
+import { onMounted, onUnmounted, computed, ref, watch, type ComponentPublicInstance } from 'vue'
 import { useRoute } from 'vue-router'
 import { useMessage } from 'naive-ui'
 import { useWorkbench } from '../composables/useWorkbench'
@@ -82,6 +113,61 @@ const slug = route.params.slug as string
 const chapterListRef = ref<ComponentPublicInstance<{ refreshStoryTree: () => void }> | null>(null)
 const workAreaRef = ref<ComponentPublicInstance<{ ensureAssistedMode: () => void }> | null>(null)
 
+// ── 侧栏宽度 & 折叠 ──────────────────────────────────
+const LEFT_MIN = 140
+const LEFT_MAX = 800
+const RIGHT_MIN = 368
+const RIGHT_MAX = 800
+
+const leftWidth = ref(388)
+const rightWidth = ref(558)
+const leftCollapsed = ref(false)
+const rightCollapsed = ref(false)
+
+// 拖拽左侧分割线
+let dragging: 'left' | 'right' | null = null
+let dragStartX = 0
+let dragStartWidth = 0
+
+function startDragLeft(e: MouseEvent) {
+  dragging = 'left'
+  dragStartX = e.clientX
+  dragStartWidth = leftWidth.value
+  document.addEventListener('mousemove', onDrag)
+  document.addEventListener('mouseup', stopDrag)
+}
+
+function startDragRight(e: MouseEvent) {
+  dragging = 'right'
+  dragStartX = e.clientX
+  dragStartWidth = rightWidth.value
+  document.addEventListener('mousemove', onDrag)
+  document.addEventListener('mouseup', stopDrag)
+}
+
+function onDrag(e: MouseEvent) {
+  if (dragging === 'left') {
+    const delta = e.clientX - dragStartX
+    const next = Math.min(LEFT_MAX, Math.max(LEFT_MIN, dragStartWidth + delta))
+    leftWidth.value = next
+    if (leftCollapsed.value) leftCollapsed.value = false
+  } else if (dragging === 'right') {
+    const delta = dragStartX - e.clientX   // 右侧：向左拖变大
+    const next = Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, dragStartWidth + delta))
+    rightWidth.value = next
+    if (rightCollapsed.value) rightCollapsed.value = false
+  }
+}
+
+function stopDrag() {
+  dragging = null
+  document.removeEventListener('mousemove', onDrag)
+  document.removeEventListener('mouseup', stopDrag)
+}
+
+onUnmounted(stopDrag)
+
+// ── Workbench 逻辑 ────────────────────────────────────
 async function onSidebarChapterSelect(chapterId: number, title = '') {
   await handleChapterSelect(chapterId, title)
   workAreaRef.value?.ensureAssistedMode?.()
@@ -95,7 +181,6 @@ const handleChapterUpdated = async () => {
   workbenchRefresh.bumpAfterChapterDeskChange()
 }
 
-// 幕→章 规划弹层
 const showActPlanning = ref(false)
 const actPlanningId = ref('')
 const actPlanningTitle = ref('')
@@ -161,9 +246,7 @@ onMounted(async () => {
 
 watch(
   () => route.query.chapter,
-  () => {
-    void syncChapterFromRoute()
-  }
+  () => { void syncChapterFromRoute() }
 )
 </script>
 
@@ -182,21 +265,94 @@ watch(
 }
 
 .workbench-spin :deep(.n-spin-content) {
-  min-height: 100%;
   height: 100%;
+  min-height: 100%;
 }
 
 .workbench-inner {
   height: 100%;
   min-height: 0;
-}
-
-.workbench-inner :deep(.n-split) {
-  height: 100%;
-}
-
-.workbench-inner :deep(.n-split-pane-1) {
-  min-height: 0;
+  display: flex;
+  flex-direction: row;
   overflow: hidden;
+}
+
+/* ── 侧面板 ── */
+.side-pane {
+  flex-shrink: 0;
+  overflow: hidden;
+  transition: width 0.2s ease;
+  min-width: 0;
+}
+
+.left-pane  { border-right: 1px solid var(--aitext-split-border, #e4e4e4); }
+.right-pane { border-left:  1px solid var(--aitext-split-border, #e4e4e4); }
+
+/* 折叠时去掉边框避免 1px 残留 */
+.left-pane[style*="width: 0"]  { border-right: none; }
+.right-pane[style*="width: 0"] { border-left: none; }
+
+/* ── 中间区 ── */
+.main-pane {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* ── 分割线 ── */
+.divider {
+  position: relative;
+  flex-shrink: 0;
+  width: 5px;
+  background: transparent;
+  cursor: col-resize;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.divider::after {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0;
+  left: 2px;
+  width: 1px;
+  background: transparent;
+  transition: background 0.15s;
+}
+
+.divider:hover::after {
+  background: var(--n-primary-color, #18a058);
+}
+
+/* ── 折叠按钮 ── */
+.collapse-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 20;
+  width: 16px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid var(--aitext-split-border, #ddd);
+  border-radius: 4px;
+  background: var(--app-surface, #fff);
+  cursor: pointer;
+  font-size: 12px;
+  color: #aaa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.10);
+  transition: color 0.15s, background 0.15s;
+  user-select: none;
+  line-height: 1;
+}
+
+.collapse-btn:hover {
+  color: var(--n-primary-color, #18a058);
+  background: #f0faf5;
+  border-color: var(--n-primary-color, #18a058);
 }
 </style>

--- a/infrastructure/ai/llm_client.py
+++ b/infrastructure/ai/llm_client.py
@@ -2,6 +2,7 @@
 import os
 from typing import Optional, AsyncIterator
 from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
+from infrastructure.ai.providers.openai_provider import OpenAIProvider
 from infrastructure.ai.providers.mock_provider import MockProvider
 from infrastructure.ai.config.settings import Settings
 from domain.ai.value_objects.prompt import Prompt
@@ -9,40 +10,76 @@ from domain.ai.services.llm_service import GenerationConfig
 
 
 class LLMClient:
-    """LLM 客户端包装器，自动选择 Anthropic 或 Mock 提供者"""
+    """LLM 客户端包装器，根据 LLM_PROVIDER 自动选择提供者"""
 
     def __init__(self, provider=None):
         """初始化 LLM 客户端
 
         Args:
-            provider: 可选的 LLM 提供者实例。如果未提供，将自动创建。
+            provider: 可选的 LLM 提供者实例。如果未提供，将根据 LLM_PROVIDER 环境变量自动创建。
         """
         if provider:
             self.provider = provider
         else:
-            # 自动检测 API key 并选择提供者
-            api_key = self._get_api_key()
+            self.provider = self._create_provider()
+
+    def _create_provider(self):
+        """根据环境变量创建合适的提供者"""
+        provider_type = os.getenv("LLM_PROVIDER", "anthropic").lower()
+        
+        if provider_type == "openai":
+            api_key = self._get_openai_api_key()
             if api_key:
                 settings = Settings(
                     api_key=api_key,
-                    base_url=self._get_base_url()
+                    base_url=self._get_openai_base_url()
                 )
-                self.provider = AnthropicProvider(settings)
-            else:
-                self.provider = MockProvider()
+                return OpenAIProvider(settings)
+        else:
+            api_key = self._get_anthropic_api_key()
+            if api_key:
+                settings = Settings(
+                    api_key=api_key,
+                    base_url=self._get_anthropic_base_url()
+                )
+                return AnthropicProvider(settings)
+        
+        return MockProvider()
 
-    def _get_api_key(self) -> Optional[str]:
-        """获取 API key"""
+    def _get_openai_api_key(self) -> Optional[str]:
+        """获取 OpenAI API key"""
+        raw = os.getenv("OPENAI_API_KEY")
+        if raw is None:
+            return None
+        key = raw.strip()
+        return key or None
+
+    def _get_openai_base_url(self) -> Optional[str]:
+        """获取 OpenAI base URL"""
+        u = os.getenv("OPENAI_BASE_URL")
+        return u.strip() if u and u.strip() else None
+
+    def _get_anthropic_api_key(self) -> Optional[str]:
+        """获取 Anthropic API key"""
         raw = os.getenv("ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_AUTH_TOKEN")
         if raw is None:
             return None
         key = raw.strip()
         return key or None
 
-    def _get_base_url(self) -> Optional[str]:
-        """获取 base URL"""
+    def _get_anthropic_base_url(self) -> Optional[str]:
+        """获取 Anthropic base URL"""
         u = os.getenv("ANTHROPIC_BASE_URL")
         return u.strip() if u and u.strip() else None
+
+    # 向后兼容方法
+    def _get_api_key(self) -> Optional[str]:
+        """获取 API key（向后兼容，使用 Anthropic）"""
+        return self._get_anthropic_api_key()
+
+    def _get_base_url(self) -> Optional[str]:
+        """获取 base URL（向后兼容，使用 Anthropic）"""
+        return self._get_anthropic_base_url()
 
     async def generate(self, prompt: str, **kwargs) -> str:
         """生成文本

--- a/infrastructure/ai/llm_client.py
+++ b/infrastructure/ai/llm_client.py
@@ -60,9 +60,9 @@ class LLMClient:
             user=prompt
         )
 
-        # 创建 GenerationConfig 对象
+        # 创建 GenerationConfig 对象（model 留空则由当前 Provider 按环境变量解析）
         config = GenerationConfig(
-            model=kwargs.get("model", "claude-sonnet-4-6"),
+            model=kwargs.get("model"),
             max_tokens=kwargs.get("max_tokens", 4096),
             temperature=kwargs.get("temperature", 1.0)
         )

--- a/infrastructure/ai/llm_runtime_flags.py
+++ b/infrastructure/ai/llm_runtime_flags.py
@@ -1,0 +1,35 @@
+"""LLM 运行时开关（环境变量）。"""
+from __future__ import annotations
+
+import os
+
+
+def _env_truthy(name: str) -> bool:
+    return (os.getenv(name) or "").strip().lower() in ("1", "true", "yes")
+
+
+def is_llm_reasoning_disabled() -> bool:
+    """为真时：在 OpenAI 兼容请求中尽量关闭思考/推理；解析响应时不把 reasoning 当作最终输出。
+
+    环境变量：``LLM_DISABLE_REASONING``（``1`` / ``true`` / ``yes`` 为开启）。
+    """
+    return _env_truthy("LLM_DISABLE_REASONING")
+
+
+def force_compat_no_think_extras() -> bool:
+    """未配置 ``OPENAI_BASE_URL`` 时仍向请求体注入 Qwen 兼容扩展字段（部分反向代理无 base_url）。"""
+    return _env_truthy("LLM_FORCE_COMPAT_NO_THINK_EXTRAS")
+
+
+def use_qwen_assistant_prefill() -> bool:
+    """Qwen3.5：在消息末尾追加空的 assistant 段以跳过思考阶段（见相关 bug tracker #1559）。
+
+    仅在 ``LLM_DISABLE_REASONING`` 生效且未显式关闭时启用：
+    ``LLM_QWEN_ASSISTANT_PREFILL=false`` 可禁用。
+    """
+    if not is_llm_reasoning_disabled():
+        return False
+    v = (os.getenv("LLM_QWEN_ASSISTANT_PREFILL") or "").strip().lower()
+    if v in ("0", "false", "no"):
+        return False
+    return True

--- a/infrastructure/ai/local_embedding_service.py
+++ b/infrastructure/ai/local_embedding_service.py
@@ -1,5 +1,6 @@
 # infrastructure/ai/local_embedding_service.py
 
+# 必须在任何 HuggingFace/SentenceTransformer 导入前设置离线模式
 import os
 os.environ['HF_HUB_OFFLINE'] = '1'
 os.environ['TRANSFORMERS_OFFLINE'] = '1'
@@ -27,30 +28,26 @@ class LocalEmbeddingService(EmbeddingService):
     优先使用本地模型路径，避免从 HuggingFace 下载。
     """
 
-    def __init__(self, model_name: str = None, use_gpu: bool = True):
+    def __init__(self, model_name: str = None, use_gpu: bool = True, allow_remote: bool = False):
         """
         初始化本地 Embedding 服务
 
         Args:
             model_name: 模型名称或本地路径（如果为 None，从环境变量读取）
             use_gpu: 是否使用 GPU 加速（默认 True，自动检测）
+            allow_remote: 当本地不存在时是否允许联网拉取远端模型（默认 False）
         """
         try:
             from sentence_transformers import SentenceTransformer
             
-            # 优先使用环境变量配置的本地路径
+            # 优先使用显式参数；其次使用环境变量
             if model_name is None:
-                model_path = os.getenv("EMBEDDING_MODEL_PATH", "./.models/bge-small-zh-v1.5")
-                # 转换为绝对路径
-                model_path = str(Path(model_path).resolve())
-
-                # 检查本地路径是否存在
-                if os.path.exists(model_path):
-                    model_name = model_path
-                    logger.info(f"Using local model path: {model_path}")
-                else:
-                    # 如果本地路径不存在，报错而不是尝试下载
-                    raise FileNotFoundError(f"Local model not found at {model_path}. Please download the model first.")
+                # 兼容历史变量 EMBEDDING_MODEL_PATH，同时支持更语义化的 EMBEDDING_LOCAL_MODEL
+                model_name = (
+                    os.getenv("EMBEDDING_MODEL_PATH")
+                    or os.getenv("EMBEDDING_LOCAL_MODEL")
+                    or "./.models/bge-small-zh-v1.5"
+                )
 
             # 检测设备
             if use_gpu and torch.cuda.is_available():
@@ -60,6 +57,21 @@ class LocalEmbeddingService(EmbeddingService):
                 device = 'cpu'
                 logger.info("Using CPU")
 
+            # 路径存在则视为本地目录；否则按模型名处理（是否允许联网由 allow_remote 控制）
+            local_files_only = True
+            path_candidate = Path(model_name).resolve()
+            if path_candidate.exists():
+                model_name = str(path_candidate)
+                logger.info(f"Using local model path: {model_name}")
+            else:
+                local_files_only = not allow_remote
+                if local_files_only:
+                    logger.info(
+                        "Using model id in local-only mode: %s (set EMBEDDING_ALLOW_REMOTE=true to allow download)",
+                        model_name,
+                    )
+                else:
+                    logger.info(f"Using remote-capable model id: {model_name}")
             # 加载模型 - 使用 trust_remote_code=False 避免执行远程代码
             # 使用 local_files_only=True 确保只从本地加载
             self.model = SentenceTransformer(
@@ -68,7 +80,11 @@ class LocalEmbeddingService(EmbeddingService):
                 trust_remote_code=False,
                 local_files_only=True,
             )
-            self._dimension = self.model.get_sentence_embedding_dimension()
+            _dim_fn = getattr(self.model, "get_embedding_dimension", None)
+            if callable(_dim_fn):
+                self._dimension = _dim_fn()
+            else:
+                self._dimension = self.model.get_sentence_embedding_dimension()
             self.device = device
 
             logger.info(f"Loaded local embedding model: {model_name}, dimension: {self._dimension}, device: {device}")

--- a/infrastructure/ai/model_resolution.py
+++ b/infrastructure/ai/model_resolution.py
@@ -1,0 +1,28 @@
+"""按 Provider 将 GenerationConfig.model 解析为实际 API model标识。"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def resolve_openai_chat_model(requested: Optional[str]) -> str:
+    """OpenAI 兼容 Chat Completions：未指定或仍为 Anthropic 系 id 时回退到 OPENAI_MODEL。"""
+    default = (os.getenv("OPENAI_MODEL") or "gpt-4o").strip() or "gpt-4o"
+    if not requested or not str(requested).strip():
+        return default
+    r = str(requested).strip()
+    if r.lower().startswith("claude"):
+        return default
+    return r
+
+
+def resolve_anthropic_model(requested: Optional[str]) -> str:
+    """Anthropic Messages：未指定或误留 OpenAI/本地 id 时回退到 ANTHROPIC_MODEL。"""
+    default = (os.getenv("ANTHROPIC_MODEL") or "claude-sonnet-4-6").strip() or "claude-sonnet-4-6"
+    if not requested or not str(requested).strip():
+        return default
+    r = str(requested).strip()
+    low = r.lower()
+    if low.startswith("gpt-") or low.startswith("openai/"):
+        return default
+    return r

--- a/infrastructure/ai/openai_embedding_service.py
+++ b/infrastructure/ai/openai_embedding_service.py
@@ -1,6 +1,7 @@
 """OpenAI 嵌入服务实现"""
 import os
 from typing import List
+import httpx
 from openai import AsyncOpenAI
 from domain.ai.services.embedding_service import EmbeddingService
 
@@ -11,19 +12,34 @@ class OpenAIEmbeddingService(EmbeddingService):
     使用 OpenAI 的 text-embedding-3-small 模型生成文本嵌入向量。
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        model: str | None = None,
+        dimension: int | None = None,
+    ):
         """初始化 OpenAI 嵌入服务
 
         Raises:
             ValueError: 如果 OPENAI_API_KEY 环境变量未设置
         """
-        api_key = os.getenv("OPENAI_API_KEY")
+        api_key = api_key or os.getenv("EMBEDDING_API_KEY") or os.getenv("OPENAI_API_KEY")
         if not api_key:
-            raise ValueError("OPENAI_API_KEY environment variable is required")
+            raise ValueError("EMBEDDING_API_KEY or OPENAI_API_KEY environment variable is required")
 
-        self.client = AsyncOpenAI(api_key=api_key)
-        self.model = "text-embedding-3-small"
-        self._dimension = 1536
+        base_url = base_url or os.getenv("EMBEDDING_API_BASE_URL") or os.getenv("OPENAI_BASE_URL")
+        client_kwargs = {
+            "api_key": api_key,
+            # 与 LLM Provider 一致：显式提供 http_client，规避 openai/httpx 的 proxies 参数兼容问题
+            "http_client": httpx.AsyncClient(timeout=300.0),
+        }
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = AsyncOpenAI(**client_kwargs)
+        self.model = model or os.getenv("EMBEDDING_API_MODEL", "text-embedding-3-small")
+        dim_raw = str(dimension) if dimension is not None else os.getenv("EMBEDDING_API_DIMENSION")
+        self._dimension = int(dim_raw) if dim_raw else 1536
 
     def get_dimension(self) -> int:
         """获取嵌入向量的维度

--- a/infrastructure/ai/providers/anthropic_provider.py
+++ b/infrastructure/ai/providers/anthropic_provider.py
@@ -1,7 +1,6 @@
 """Anthropic LLM 提供商实现"""
 import json
 import logging
-import os
 from typing import AsyncIterator
 import httpx
 from anthropic import Anthropic, AsyncAnthropic
@@ -9,12 +8,10 @@ from domain.ai.value_objects.prompt import Prompt
 from domain.ai.value_objects.token_usage import TokenUsage
 from domain.ai.services.llm_service import GenerationConfig, GenerationResult
 from infrastructure.ai.config.settings import Settings
+from infrastructure.ai.model_resolution import resolve_anthropic_model
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
-
-# 从环境变量读取模型配置，默认使用 claude-sonnet-4-6
-DEFAULT_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-6")
 
 
 class AnthropicProvider(BaseProvider):
@@ -78,7 +75,7 @@ class AnthropicProvider(BaseProvider):
         try:
             # 使用 async_client 避免阻塞 asyncio 事件循环
             response = await self.async_client.messages.create(
-                model=config.model or DEFAULT_MODEL,
+                model=resolve_anthropic_model(config.model),
                 temperature=config.temperature,
                 max_tokens=config.max_tokens,
                 system=prompt.system,
@@ -130,7 +127,7 @@ class AnthropicProvider(BaseProvider):
         }
 
         payload = {
-            "model": config.model or DEFAULT_MODEL,
+            "model": resolve_anthropic_model(config.model),
             "max_tokens": config.max_tokens,
             "temperature": config.temperature,
             "system": prompt.system,

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -1,20 +1,173 @@
 """OpenAI LLM 提供商实现"""
 import logging
-import os
-from typing import AsyncIterator
+import re
+from typing import Any, AsyncIterator, Dict, List, Optional
 
+import httpx
 from openai import AsyncOpenAI
 
 from domain.ai.services.llm_service import GenerationConfig, GenerationResult
 from domain.ai.value_objects.prompt import Prompt
 from domain.ai.value_objects.token_usage import TokenUsage
 from infrastructure.ai.config.settings import Settings
+from infrastructure.ai.llm_runtime_flags import (
+    force_compat_no_think_extras,
+    is_llm_reasoning_disabled,
+    use_qwen_assistant_prefill,
+)
+from infrastructure.ai.model_resolution import resolve_openai_chat_model
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
 
-# 从环境变量读取模型配置，默认使用 gpt-4o
-DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+
+def _should_apply_local_no_think_extras(base_url: Optional[str]) -> bool:
+    return bool((base_url or "").strip()) or force_compat_no_think_extras()
+
+
+# Qwen3.5 / R1 等常见思考段标记（关闭思考后仍可能残留在 content中）
+_THINK_TAG_BLOCK = re.compile(
+    r"\x3cthink\x3e[\s\S]*?\x3c/think\x3e",
+    re.IGNORECASE | re.DOTALL,
+)
+#部分 Qwen 发行版使用双尖括号
+_THINK_DOUBLE_ANGLE = re.compile(
+    r"\x3c\x3cthink\x3e\x3e[\s\S]*?\x3c\x3c/think\x3e\x3e",
+    re.IGNORECASE | re.DOTALL,
+)
+_REDACTED_THINKING = re.compile(
+    r"<think>[\s\S]*?</think>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _strip_text(val: Any) -> Optional[str]:
+    if isinstance(val, str):
+        s = val.strip()
+        return s if s else None
+    return None
+
+
+def _text_from_content_field(raw: Any) -> Optional[str]:
+    """解析 message.content：字符串或多模态列表。"""
+    s = _strip_text(raw)
+    if s:
+        return s
+    if isinstance(raw, list):
+        parts: list[str] = []
+        for block in raw:
+            if isinstance(block, dict):
+                if block.get("type") == "text" and block.get("text"):
+                    t = _strip_text(block["text"])
+                    if t:
+                        parts.append(t)
+            else:
+                t = _strip_text(getattr(block, "text", None))
+                if t:
+                    parts.append(t)
+        if parts:
+            return "".join(parts)
+    return None
+
+
+def _strip_thinking_markers(text: str) -> str:
+    """去掉模型输出的思考围栏，便于 JSON 等下游解析。"""
+    s = _THINK_TAG_BLOCK.sub("", text)
+    s = _THINK_DOUBLE_ANGLE.sub("", s)
+    s = _REDACTED_THINKING.sub("", s)
+    low = s.lower()
+    if "\x3cthink\x3e" in low and "\x3c/think\x3e" not in low:
+        parts = re.split(r"(?i)\x3cthink\x3e", s, maxsplit=1)
+        if len(parts) == 2:
+            s = parts[1]
+    if "<think>" in low and "</think>" not in low:
+        parts = re.split(r"(?i)<think>", s, maxsplit=1)
+        if len(parts) == 2:
+            s = parts[1]
+    return s.strip()
+
+
+def _maybe_strip_for_no_think(text: str) -> str:
+    if not text or not is_llm_reasoning_disabled():
+        return text
+    return _strip_thinking_markers(text)
+
+
+def _build_chat_messages(prompt: Prompt, base_url: Optional[str]) -> List[Dict[str, str]]:
+    """构造 chat messages；在本地兼容栈上可对 Qwen3.5 追加 assistant 预填。"""
+    messages: List[Dict[str, str]] = [
+        {"role": "system", "content": prompt.system},
+        {"role": "user", "content": prompt.user},
+    ]
+    if (
+        _should_apply_local_no_think_extras(base_url)
+        and is_llm_reasoning_disabled()
+        and use_qwen_assistant_prefill()
+    ):
+        # Qwen：单空格即可触发「续写 assistant」跳过思考（bug-tracker #1559）
+        messages.append({"role": "assistant", "content": " "})
+    return messages
+
+
+def _openai_no_think_request_options(base_url: Optional[str]) -> Dict[str, Any]:
+    """关闭思考时附加参数：仅对配置了 base_url 的兼容网关发送扩展字段，避免官方 OpenAI 400。"""
+    if not is_llm_reasoning_disabled():
+        return {}
+    if not _should_apply_local_no_think_extras(base_url):
+        return {}
+    extra: Dict[str, Any] = {
+        "reasoning": "off",
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    if use_qwen_assistant_prefill():
+        extra["continue_assistant_turn"] = True
+    return {"extra_body": extra}
+
+
+def _extract_chat_message_text(message: Any) -> str:
+    """从 assistant message 取正文。兼容某些部署将输出放在 reasoning 字段的情况。"""
+    if message is None:
+        return ""
+
+    primary = _text_from_content_field(getattr(message, "content", None))
+    if primary:
+        return _maybe_strip_for_no_think(primary)
+
+    if is_llm_reasoning_disabled():
+        return ""
+
+    for attr in ("reasoning", "reasoning_content"):
+        alt = _strip_text(getattr(message, attr, None))
+        if alt:
+            return _maybe_strip_for_no_think(alt)
+
+    try:
+        data = message.model_dump(mode="python", exclude_none=False)
+    except Exception:
+        data = {}
+    if isinstance(data, dict):
+        for key in ("content", "reasoning", "reasoning_content"):
+            if key == "content":
+                t = _text_from_content_field(data.get(key))
+            else:
+                t = _strip_text(data.get(key))
+            if t:
+                return _maybe_strip_for_no_think(t)
+    return ""
+
+
+def _extract_stream_delta_text(delta: Any) -> Optional[str]:
+    """流式 chunk：content为空时尝试 reasoning / reasoning_content。"""
+    if delta is None:
+        return None
+    order = ("content",)
+    if not is_llm_reasoning_disabled():
+        order = ("content", "reasoning", "reasoning_content")
+    for attr in order:
+        s = _strip_text(getattr(delta, attr, None))
+        if s:
+            return s
+    return None
 
 
 class OpenAIProvider(BaseProvider):
@@ -40,6 +193,9 @@ class OpenAIProvider(BaseProvider):
         # 初始化 AsyncOpenAI 客户端
         client_kwargs = {
             "api_key": settings.api_key,
+            # 规避 openai/httpx 版本组合下 `proxies` 参数不兼容问题：
+            # 显式注入 http_client，避免 SDK 内部创建默认 AsyncClient 时触发 TypeError。
+            "http_client": httpx.AsyncClient(timeout=300.0),
         }
         if settings.base_url:
             client_kwargs["base_url"] = settings.base_url
@@ -64,22 +220,29 @@ class OpenAIProvider(BaseProvider):
             RuntimeError: 当 API 调用失败或返回空内容时
         """
         try:
-            messages = [
-                {"role": "system", "content": prompt.system},
-                {"role": "user", "content": prompt.user}
-            ]
-            
+            messages = _build_chat_messages(prompt, self.settings.base_url)
+
             response = await self.async_client.chat.completions.create(
-                model=config.model or DEFAULT_MODEL,
+                model=resolve_openai_chat_model(config.model),
                 messages=messages,
                 temperature=config.temperature,
                 max_tokens=config.max_tokens,
+                **_openai_no_think_request_options(self.settings.base_url),
             )
             
-            if not response.choices or not response.choices[0].message.content:
+            if not response.choices:
+                raise RuntimeError("API returned no choices")
+
+            message = response.choices[0].message
+            content = _extract_chat_message_text(message)
+            if not content:
+                finish = getattr(response.choices[0], "finish_reason", None)
+                logger.warning(
+                    "Chat completion has no extractable text (finish_reason=%s). "
+                    "If using reasoning models, ensure OPENAI_MODEL matches the loaded model.",
+                    finish,
+                )
                 raise RuntimeError("API returned empty content")
-                
-            content = response.choices[0].message.content
             
             input_tokens = response.usage.prompt_tokens if response.usage else 0
             output_tokens = response.usage.completion_tokens if response.usage else 0
@@ -113,22 +276,23 @@ class OpenAIProvider(BaseProvider):
             RuntimeError: 当流式生成失败时
         """
         try:
-            messages = [
-                {"role": "system", "content": prompt.system},
-                {"role": "user", "content": prompt.user}
-            ]
-            
+            messages = _build_chat_messages(prompt, self.settings.base_url)
+
             stream = await self.async_client.chat.completions.create(
-                model=config.model or DEFAULT_MODEL,
+                model=resolve_openai_chat_model(config.model),
                 messages=messages,
                 temperature=config.temperature,
                 max_tokens=config.max_tokens,
                 stream=True,
+                **_openai_no_think_request_options(self.settings.base_url),
             )
             
             async for chunk in stream:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    yield chunk.choices[0].delta.content
+                if not chunk.choices:
+                    continue
+                piece = _extract_stream_delta_text(chunk.choices[0].delta)
+                if piece:
+                    yield piece
                     
         except Exception as e:
             logger.error(f"[Stream] Failed: {e}")

--- a/infrastructure/ai/qdrant_vector_store.py
+++ b/infrastructure/ai/qdrant_vector_store.py
@@ -1,5 +1,6 @@
 # infrastructure/ai/qdrant_vector_store.py
-from typing import List
+from typing import List, Optional, Any
+
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, VectorParams, PointStruct
 from domain.ai.services.vector_store import VectorStore
@@ -8,16 +9,39 @@ from domain.ai.services.vector_store import VectorStore
 class QdrantVectorStore(VectorStore):
     """Qdrant 向量存储实现"""
 
-    def __init__(self, host: str = "localhost", port: int = 6333, api_key: str = None):
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 6333,
+        api_key: Optional[str] = None,
+        url: Optional[str] = None,
+        timeout: Optional[float] = None,
+        https: Optional[bool] = None,
+    ):
         """
         初始化 Qdrant 客户端
 
         Args:
-            host: Qdrant 服务器地址
-            port: Qdrant 服务器端口
-            api_key: Qdrant API 密钥（可选）
+            host: Qdrant 服务器地址（与 port 连用；若提供 url 则忽略）
+            port: Qdrant REST 端口（默认 6333）
+            api_key: Qdrant API 密钥（可选，云端常为必填）
+            url: 完整服务 URL（可选，例如 https://xxx.cloud.qdrant.io:6333；优先于 host/port）
+            timeout: 请求超时秒数（可选）
+            https: 是否使用 HTTPS（仅 host/port 模式；为 None 时由客户端默认）
         """
-        self.client = QdrantClient(host=host, port=port, api_key=api_key)
+        client_kwargs: dict[str, Any] = {}
+        if url:
+            client_kwargs["url"] = url.rstrip("/")
+        else:
+            client_kwargs["host"] = host
+            client_kwargs["port"] = port
+        if api_key:
+            client_kwargs["api_key"] = api_key
+        if timeout is not None:
+            client_kwargs["timeout"] = timeout
+        if https is not None:
+            client_kwargs["https"] = https
+        self.client = QdrantClient(**client_kwargs)
 
     async def insert(
         self,

--- a/infrastructure/ai/think_leak_detection.py
+++ b/infrastructure/ai/think_leak_detection.py
@@ -1,0 +1,65 @@
+"""检测 Chat Completions 原始输出中是否仍含常见「思考」围栏（集成测试 / 自检）。"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def bundle_message_text_fields(
+    content: Optional[str],
+    reasoning: Optional[str] = None,
+    reasoning_content: Optional[str] = None,
+) -> str:
+    """拼接可能被服务端拆到多字段的文本，用于检测。"""
+    parts = [content or "", reasoning or "", reasoning_content or ""]
+    return "".join(parts)
+
+
+def raw_text_contains_think_markers(text: str) -> bool:
+    """若正文仍含常见 think / redacted 标记则返回 True。"""
+    if not text:
+        return False
+    low = text.lower()
+    needles = (
+        "\x3cthink\x3e",
+        "\x3c\x3cthink\x3e\x3e",
+        "<think>",
+    )
+    return any(n in low for n in needles)
+
+
+def message_dump_has_think_leak(message: Any) -> bool:
+    """对 OpenAI SDK 的 message 对象做 model_dump 后检测常见思考字段。"""
+    try:
+        data = message.model_dump(mode="python", exclude_none=False)
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    bundle = bundle_message_text_fields(
+        data.get("content") if isinstance(data.get("content"), str) else None,
+        data.get("reasoning") if isinstance(data.get("reasoning"), str) else None,
+        data.get("reasoning_content") if isinstance(data.get("reasoning_content"), str) else None,
+    )
+    if raw_text_contains_think_markers(bundle):
+        return True
+    # 多模态 content 列表
+    raw_c = data.get("content")
+    if isinstance(raw_c, list):
+        for block in raw_c:
+            if isinstance(block, dict) and block.get("type") == "text":
+                t = block.get("text")
+                if isinstance(t, str) and raw_text_contains_think_markers(t):
+                    return True
+    return False
+
+
+def reasoning_channel_should_be_empty_when_disabled(message: Any) -> Optional[str]:
+    """若 message.reasoning / reasoning_content 非空则返回说明字符串，否则 None。"""
+    r = getattr(message, "reasoning", None)
+    rc = getattr(message, "reasoning_content", None)
+    if isinstance(r, str) and r.strip():
+        return "message.reasoning 非空（关思考时期望为空）"
+    if isinstance(rc, str) and rc.strip():
+        return "message.reasoning_content 非空（关思考时期望为空）"
+    return None

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -311,7 +311,14 @@ def get_hosted_write_service() -> HostedWriteService:
 
 
 def get_llm_service():
-    """获取 LLM 服务实例（根据 LLM_PROVIDER 决定使用 OpenAI 或 Anthropic，无配置用 Mock）。供多模块复用。"""
+    """获取 LLM 服务实例（根据 LLM_PROVIDER 决定使用 OpenAI 或 Anthropic，无配置用 Mock）。供多模块复用。
+
+    环境变量：
+    - LLM_PROVIDER: ``openai`` | ``anthropic``（默认 ``anthropic``）
+    - OpenAI 兼容：``OPENAI_API_KEY``、可选 ``OPENAI_BASE_URL``、``OPENAI_MODEL``（未在请求里指定或仍为 claude-* 时使用）
+    - 关闭思考/推理（OpenAI 兼容、利于 JSON 契约）：``LLM_DISABLE_REASONING=true``（在配置了 ``OPENAI_BASE_URL`` 时附加 ``chat_template_kwargs.enable_thinking=false``、Qwen assistant 预填与 ``continue_assistant_turn`` 等；解析时剥离常见思考标签）。无 base_url 时可设 ``LLM_FORCE_COMPAT_NO_THINK_EXTRAS=true``。``LLM_QWEN_ASSISTANT_PREFILL=false`` 可关闭预填。
+    - Anthropic：``ANTHROPIC_API_KEY`` 或 ``ANTHROPIC_AUTH_TOKEN``、可选 ``ANTHROPIC_BASE_URL``、``ANTHROPIC_MODEL``
+    """
     provider = os.getenv("LLM_PROVIDER", "anthropic").lower()
     
     if provider == "openai":
@@ -402,8 +409,8 @@ def get_embedding_service():
     """获取 Embedding 服务
 
     根据环境变量选择服务类型：
-    - EMBEDDING_SERVICE=local: 使用本地模型（BAAI/bge-small-zh-v1.5）
-    - EMBEDDING_SERVICE=openai: 使用 OpenAI API（需要 OPENAI_API_KEY）
+    - EMBEDDING_SERVICE=local: 使用本地模型（默认读取 EMBEDDING_MODEL_PATH，本地路径优先；可用 EMBEDDING_LOCAL_MODEL 指定模型 ID）
+    - EMBEDDING_SERVICE=openai/external/openai_compatible: 使用 OpenAI 兼容 Embedding API
     - 默认: local
 
     如果 VECTOR_STORE_ENABLED=false，返回 None。
@@ -416,17 +423,37 @@ def get_embedding_service():
     try:
         if service_type == "local":
             from infrastructure.ai.local_embedding_service import LocalEmbeddingService
-            model_path = os.getenv("EMBEDDING_MODEL_PATH", "BAAI/bge-small-zh-v1.5")
+            model_name = (
+                os.getenv("EMBEDDING_MODEL_PATH")
+                or os.getenv("EMBEDDING_LOCAL_MODEL")
+                or "./.models/bge-small-zh-v1.5"
+            )
             use_gpu = os.getenv("EMBEDDING_USE_GPU", "true").lower() == "true"
-            logger.info(f"Using local embedding service: {model_path}, GPU: {use_gpu}")
-            return LocalEmbeddingService(model_name=model_path, use_gpu=use_gpu)
-        elif service_type == "openai":
-            if not os.getenv("OPENAI_API_KEY"):
-                logger.warning("EMBEDDING_SERVICE=openai 但 OPENAI_API_KEY 未设置，向量检索已禁用")
+            allow_remote = os.getenv("EMBEDDING_ALLOW_REMOTE", "false").lower() in ("1", "true", "yes")
+            logger.info(
+                "Using local embedding service: model=%s, GPU=%s, allow_remote=%s",
+                model_name,
+                use_gpu,
+                allow_remote,
+            )
+            return LocalEmbeddingService(model_name=model_name, use_gpu=use_gpu, allow_remote=allow_remote)
+        elif service_type in ("openai", "external", "openai_compatible"):
+            api_key = os.getenv("EMBEDDING_API_KEY") or os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                logger.warning("EMBEDDING_SERVICE=%s 但 EMBEDDING_API_KEY/OPENAI_API_KEY 未设置，向量检索已禁用", service_type)
                 return None
             from infrastructure.ai.openai_embedding_service import OpenAIEmbeddingService
-            logger.info("Using OpenAI embedding service")
-            return OpenAIEmbeddingService()
+            model = os.getenv("EMBEDDING_API_MODEL", "text-embedding-3-small")
+            base_url = os.getenv("EMBEDDING_API_BASE_URL") or os.getenv("OPENAI_BASE_URL")
+            dimension_raw = (os.getenv("EMBEDDING_API_DIMENSION") or "").strip()
+            dimension = int(dimension_raw) if dimension_raw else None
+            logger.info("Using external embedding service: model=%s, base_url=%s", model, base_url or "<default>")
+            return OpenAIEmbeddingService(
+                api_key=api_key,
+                base_url=base_url,
+                model=model,
+                dimension=dimension,
+            )
         else:
             logger.warning(f"Unknown EMBEDDING_SERVICE: {service_type}, 向量检索已禁用")
             return None
@@ -458,6 +485,39 @@ def get_triple_indexing_service():
     return TripleIndexingService(vs, es)
 
 
+@lru_cache
+def get_triple_repository():
+    """获取三元组仓储
+    
+    Returns:
+        TripleRepository 实例
+    """
+    from infrastructure.persistence.database.triple_repository import TripleRepository
+    return TripleRepository()
+
+
+def _optional_float_env(name: str) -> Optional[float]:
+    """读取可选浮点环境变量；非法值时记录警告并返回 None。"""
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, ignored", name, raw)
+        return None
+
+
+def _optional_bool_tri_env(name: str) -> Optional[bool]:
+    """读取 true/false 三态：未设置返回 None；非法值返回 None。"""
+    raw = (os.getenv(name) or "").strip().lower()
+    if raw in ("1", "true", "yes"):
+        return True
+    if raw in ("0", "false", "no"):
+        return False
+    return None
+
+
 def get_vector_store() -> Optional[VectorStore]:
     """获取向量存储
 
@@ -467,9 +527,12 @@ def get_vector_store() -> Optional[VectorStore]:
     - VECTOR_STORE_ENABLED: 是否启用向量存储（"true" 启用，默认 "true"）
     - VECTOR_STORE_TYPE: 向量存储类型（"chromadb" 或 "qdrant"，默认 "chromadb"）
     - VECTOR_STORE_PATH: ChromaDB 本地存储路径（默认 "./data/chromadb"）
-    - QDRANT_HOST: Qdrant 服务器地址（默认 "localhost"，仅 qdrant 类型）
-    - QDRANT_PORT: Qdrant 服务器端口（默认 6333，仅 qdrant 类型）
-    - QDRANT_API_KEY: Qdrant API 密钥（可选，仅 qdrant 类型）
+    - QDRANT_URL: Qdrant 完整 URL（可选；若设置则优先于 HOST+PORT，适合云端，如 https://xxx.cloud.qdrant.io:6333）
+    - QDRANT_HOST: Qdrant 服务器地址（默认 "localhost"；在 QDRANT_URL 未设置时使用）
+    - QDRANT_PORT: Qdrant REST 端口（默认 6333）
+    - QDRANT_API_KEY: Qdrant API 密钥（可选；云端通常必填）
+    - QDRANT_TIMEOUT: 客户端超时秒数（可选）
+    - QDRANT_HTTPS: 是否 HTTPS（可选，true/false；仅 host+port 模式；未设置则交给客户端默认）
 
     Returns:
         VectorStore 实例或 None
@@ -489,10 +552,25 @@ def get_vector_store() -> Optional[VectorStore]:
             return ChromaDBVectorStore(persist_directory=persist_dir)
         elif store_type == "qdrant":
             from infrastructure.ai.qdrant_vector_store import QdrantVectorStore
+            url = (os.getenv("QDRANT_URL") or "").strip() or None
             host = os.getenv("QDRANT_HOST", "localhost")
             port = int(os.getenv("QDRANT_PORT", "6333"))
-            api_key = os.getenv("QDRANT_API_KEY")
-            return QdrantVectorStore(host=host, port=port, api_key=api_key)
+            api_key_raw = os.getenv("QDRANT_API_KEY")
+            api_key = (
+                api_key_raw.strip()
+                if api_key_raw and api_key_raw.strip()
+                else None
+            )
+            timeout = _optional_float_env("QDRANT_TIMEOUT")
+            https = _optional_bool_tri_env("QDRANT_HTTPS")
+            return QdrantVectorStore(
+                host=host,
+                port=port,
+                api_key=api_key,
+                url=url,
+                timeout=timeout,
+                https=https,
+            )
         else:
             logger.warning(f"Unknown VECTOR_STORE_TYPE: {store_type}, vector store disabled")
             return None
@@ -528,6 +606,7 @@ def get_context_builder() -> ContextBuilder:
         embedding_service=get_embedding_service(),
         foreshadowing_repository=get_foreshadowing_repository(),
         chapter_element_repository=get_chapter_element_repository(),
+        triple_repository=get_triple_repository(),
     )
 
 

--- a/interfaces/api/v1/blueprint/continuous_planning_routes.py
+++ b/interfaces/api/v1/blueprint/continuous_planning_routes.py
@@ -63,26 +63,10 @@ def get_service() -> ContinuousPlanningService:
     story_node_repo = StoryNodeRepository(db_path)
     chapter_element_repo = ChapterElementRepository(db_path)
 
-    # 获取 LLM 服务
-    import os
-    from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
-    from infrastructure.ai.config.settings import Settings
-
-    llm_service = None
-    api_key = os.getenv("ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_AUTH_TOKEN")
-    if api_key:
-        settings = Settings(
-            api_key=api_key.strip(),
-            base_url=os.getenv("ANTHROPIC_BASE_URL")
-        )
-        try:
-            llm_service = AnthropicProvider(settings)
-        except Exception:
-            pass
-
     from application.world.services.bible_service import BibleService
-    from interfaces.api.dependencies import get_bible_repository
+    from interfaces.api.dependencies import get_bible_repository, get_llm_service
 
+    llm_service = get_llm_service()
     bible_service = BibleService(get_bible_repository())
 
     return ContinuousPlanningService(

--- a/interfaces/api/v1/blueprint/story_structure.py
+++ b/interfaces/api/v1/blueprint/story_structure.py
@@ -25,25 +25,10 @@ def get_planning_service() -> ContinuousPlanningService:
     story_node_repo = StoryNodeRepository(db_path)
     chapter_element_repo = ChapterElementRepository(db_path)
 
-    # 获取 LLM 服务
-    from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
-    from infrastructure.ai.config.settings import Settings
-
-    llm_service = None
-    api_key = os.getenv("ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_AUTH_TOKEN")
-    if api_key:
-        settings = Settings(
-            api_key=api_key.strip(),
-            base_url=os.getenv("ANTHROPIC_BASE_URL")
-        )
-        try:
-            llm_service = AnthropicProvider(settings)
-        except Exception:
-            pass
-
     from application.world.services.bible_service import BibleService
-    from interfaces.api.dependencies import get_bible_repository
+    from interfaces.api.dependencies import get_bible_repository, get_llm_service
 
+    llm_service = get_llm_service()
     bible_service = BibleService(get_bible_repository())
 
     return ContinuousPlanningService(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest>=7.0,<9.0
+pytest-asyncio>=0.24.0
 volcengine-python-sdk[ark]>=1.0.0
 anthropic>=0.40.0
 pydantic>=2.0.0
@@ -12,3 +13,4 @@ numpy>=1.21.0
 sentence-transformers>=2.2.0
 qdrant-client>=1.7.0,<2.0.0
 openai>=1.12.0,<2.0.0
+python-dotenv>=1.0.0

--- a/scripts/setup/start_daemon.py
+++ b/scripts/setup/start_daemon.py
@@ -16,8 +16,10 @@ from dotenv import load_dotenv
 # 加载环境变量
 load_dotenv()
 
-# 添加项目根目录到路径
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# 添加项目根目录到路径（start_daemon 位于 scripts/setup/）
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 from infrastructure.ai.llm_client import LLMClient
 from application.engine.services.autopilot_daemon import AutopilotDaemon
@@ -26,15 +28,18 @@ from application.engine.services.background_task_service import BackgroundTaskSe
 from infrastructure.persistence.database.connection import DatabaseConnection
 from infrastructure.persistence.database.sqlite_novel_repository import SqliteNovelRepository
 from infrastructure.persistence.database.sqlite_chapter_repository import SqliteChapterRepository
+from interfaces.api.middleware.logging_config import SafeUnicodeStreamHandler
 
-# 配置日志
+# 配置日志（文件 UTF-8；控制台在 Windows GBK 下安全写入）
+_DAEMON_LOG = _PROJECT_ROOT / "data" / "logs" / "autopilot_daemon.log"
+_DAEMON_LOG.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[
-        logging.FileHandler('data/logs/autopilot_daemon.log'),
-        logging.StreamHandler()
-    ]
+        logging.FileHandler(_DAEMON_LOG, encoding="utf-8"),
+        SafeUnicodeStreamHandler(),
+    ],
 )
 logger = logging.getLogger(__name__)
 
@@ -46,8 +51,7 @@ def main():
     logger.info("=" * 80)
 
     # 初始化数据库连接
-    project_root = Path(__file__).parent.parent
-    db_path = project_root / "data" / "novels.db"
+    db_path = _PROJECT_ROOT / "data" / "novels.db"
     db = DatabaseConnection(str(db_path))
     novel_repository = SqliteNovelRepository(db)
     chapter_repository = SqliteChapterRepository(db)

--- a/tests/integration/infrastructure/ai/test_qwen_openai_compat_no_think_live.py
+++ b/tests/integration/infrastructure/ai/test_qwen_openai_compat_no_think_live.py
@@ -1,0 +1,124 @@
+"""Qwen3.5 / OpenAI 兼容网关：实机验证「关思考」后响应不含思考围栏。
+
+运行前将仓库根目录 ``.env.example`` 复制为 ``.env`` 并按其中「Qwen3.5实机」一节填写
+（与示例保持一致，便于他人复现）。
+
+本测试**不会**默认执行：须显式 ``RUN_QWEN_NO_THINK_LIVE=1``，并满足``OPENAI_BASE_URL``、``OPENAI_API_KEY``、``OPENAI_MODEL``、``LLM_DISABLE_REASONING=true``。
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("dotenv")
+from dotenv import load_dotenv
+
+from domain.ai.services.llm_service import GenerationConfig
+from domain.ai.value_objects.prompt import Prompt
+from infrastructure.ai.config.settings import Settings
+from infrastructure.ai.llm_runtime_flags import is_llm_reasoning_disabled
+from infrastructure.ai.model_resolution import resolve_openai_chat_model
+from infrastructure.ai.providers.openai_provider import (
+    OpenAIProvider,
+    _build_chat_messages,
+    _openai_no_think_request_options,
+)
+from infrastructure.ai.think_leak_detection import (
+    message_dump_has_think_leak,
+    reasoning_channel_should_be_empty_when_disabled,
+)
+
+
+def _repo_root() -> Path:
+    p = Path(__file__).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / "pytest.ini").is_file():
+            return parent
+    return p.parents[4]
+
+
+@pytest.fixture(scope="module")
+def _load_project_dotenv():
+    env_path = _repo_root() / ".env"
+    if env_path.is_file():
+        load_dotenv(env_path, override=False)
+    else:
+        pytest.skip(f"未找到 {env_path}，请从 .env.example 复制并填写")
+
+
+def _truthy(name: str) -> bool:
+    return (os.getenv(name) or "").strip().lower() in ("1", "true", "yes")
+
+
+@pytest.mark.integration
+def test_live_qwen_openai_compat_no_think_markers_in_raw_response(
+    _load_project_dotenv,
+):
+    """直连 OpenAI 兼容 API：在 LLM_DISABLE_REASONING 下，原始 message 不得含 think 围栏。"""
+    if not _truthy("RUN_QWEN_NO_THINK_LIVE"):
+        pytest.skip("设置 RUN_QWEN_NO_THINK_LIVE=1 以对本机 .env 中的网关做实机校验")
+
+    base_url = (os.getenv("OPENAI_BASE_URL") or "").strip()
+    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    if not base_url or not api_key:
+        pytest.skip("需要 OPENAI_BASE_URL 与 OPENAI_API_KEY（见 .env.example）")
+
+    if (os.getenv("LLM_PROVIDER") or "anthropic").strip().lower() != "openai":
+        pytest.skip("本实机用例针对 LLM_PROVIDER=openai")
+
+    if not is_llm_reasoning_disabled():
+        pytest.fail(
+            "请在 .env 中设置 LLM_DISABLE_REASONING=true，以校验「关思考」行为；"
+            "并与 .env.example 中 Qwen3.5 推荐项保持一致。"
+        )
+
+    model = resolve_openai_chat_model(os.getenv("OPENAI_MODEL"))
+    if not _truthy("RUN_QWEN_NO_THINK_LIVE_SKIP_MODEL_CHECK"):
+        if "qwen" not in model.lower():
+            pytest.skip(
+                f"OPENAI_MODEL={model!r} 不含 qwen；测其它模型请设 RUN_QWEN_NO_THINK_LIVE_SKIP_MODEL_CHECK=1"
+            )
+
+    settings = Settings(api_key=api_key, base_url=base_url)
+
+    async def _call_provider():
+        provider = OpenAIProvider(settings)
+        prompt = Prompt(
+            system="你只输出 JSON，不要其它文字。",
+            user='只输出一个 JSON对象：{"ping":true}，不要 markdown。',
+        )
+        messages = _build_chat_messages(prompt, settings.base_url)
+        extras = _openai_no_think_request_options(settings.base_url)
+
+        resp = await provider.async_client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0.2,
+            max_tokens=256,
+            **extras,
+        )
+        assert resp.choices, "API 未返回 choices"
+        msg = resp.choices[0].message
+
+        assert not message_dump_has_think_leak(
+            msg
+        ), "原始响应仍含 think/redacted 标记，关思考可能未生效（检查模型版本、模板与 extra_body）"
+        
+        # 部分 Qwen 部署仍会把摘要写入 reasoning_content，与 content 并存；默认不强制该字段为空。
+        if _truthy("RUN_QWEN_REQUIRE_EMPTY_REASONING_CHANNEL"):
+            leak_reason = reasoning_channel_should_be_empty_when_disabled(msg)
+            assert (
+                leak_reason is None
+            ), f"{leak_reason}；原始片段: content={getattr(msg, 'content', None)!r}"
+
+        result = await provider.generate(
+            prompt, GenerationConfig(max_tokens=256, temperature=0.2, model=model)
+        )
+        assert result.content.strip().startswith(
+            "{"
+        ), f"期望 JSON 开头，实际: {result.content[:200]!r}"
+
+    asyncio.run(_call_provider())

--- a/tests/integration/infrastructure/ai/test_qwen_thinking_disabled.py
+++ b/tests/integration/infrastructure/ai/test_qwen_thinking_disabled.py
@@ -1,0 +1,263 @@
+"""测试 qwen3.5 思考过程是否被正确关闭
+
+运行前确保 .env 中已配置：
+- LLM_PROVIDER=openai
+- LLM_DISABLE_REASONING=true
+- OPENAI_BASE_URL、OPENAI_API_KEY、OPENAI_MODEL
+
+运行方式：
+    pytest tests/integration/infrastructure/ai/test_qwen_thinking_disabled.py -v -s
+"""
+import asyncio
+import os
+import re
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+from domain.ai.services.llm_service import GenerationConfig
+from domain.ai.value_objects.prompt import Prompt
+from infrastructure.ai.config.settings import Settings
+from infrastructure.ai.providers.openai_provider import OpenAIProvider
+
+
+def _repo_root() -> Path:
+    p = Path(__file__).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / "pytest.ini").is_file():
+            return parent
+    return p.parent
+
+
+load_dotenv(_repo_root() / ".env")
+
+
+THINKING_PATTERNS = [
+    re.compile(r"<think>.*?</think>", re.IGNORECASE | re.DOTALL),
+    re.compile(r"<<think>>.*?<</think>>", re.IGNORECASE | re.DOTALL),
+    re.compile(r"<think>.*?</think>", re.IGNORECASE | re.DOTALL),
+    re.compile(r"\[思考\].*?\[/思考\]", re.IGNORECASE | re.DOTALL),
+    re.compile(r"\[thinking\].*?\[/thinking\]", re.IGNORECASE | re.DOTALL),
+]
+
+
+def has_thinking_content(text: str) -> tuple[bool, list[str]]:
+    """检查文本中是否包含思考过程
+    
+    Args:
+        text: 要检查的文本
+        
+    Returns:
+        (是否包含思考内容, 匹配到的思考内容列表)
+    """
+    if not text:
+        return False, []
+    
+    matches = []
+    for pattern in THINKING_PATTERNS:
+        found = pattern.findall(text)
+        if found:
+            matches.extend(found)
+    
+    return len(matches) > 0, matches
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_qwen_thinking_disabled():
+    """测试 qwen3.5 调用后是否包含思考过程
+    
+    验证点：
+    1. LLM_DISABLE_REASONING 必须为 true
+    2. API 响应中不应包含思考标签
+    3. 响应内容应该是干净的输出
+    """
+    # 检查必要的环境变量
+    provider_type = os.getenv("LLM_PROVIDER", "").lower()
+    if provider_type != "openai":
+        pytest.skip(f"跳过测试：LLM_PROVIDER={provider_type}，需要 openai")
+    
+    disable_reasoning = os.getenv("LLM_DISABLE_REASONING", "").lower()
+    if disable_reasoning not in ("1", "true", "yes"):
+        pytest.fail("请在 .env 中设置 LLM_DISABLE_REASONING=true")
+    
+    base_url = os.getenv("OPENAI_BASE_URL")
+    api_key = os.getenv("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_MODEL")
+    
+    if not base_url or not api_key or not model:
+        pytest.skip("跳过测试：缺少 OPENAI_BASE_URL、OPENAI_API_KEY 或 OPENAI_MODEL 配置")
+    
+    if "qwen" not in model.lower():
+        # 如果不是 qwen 模型，仍然可以测试，但给出警告
+        print(f"\n⚠️  警告：当前模型 {model} 不是 qwen，但仍然会测试思考过程过滤")
+    
+    print(f"\n📋 测试配置:")
+    print(f"   - LLM Provider: {provider_type}")
+    print(f"   - Disable Reasoning: {disable_reasoning}")
+    print(f"   - Base URL: {base_url}")
+    print(f"   - Model: {model}")
+    
+    # 创建 LLM Provider
+    settings = Settings(
+        api_key=api_key,
+        base_url=base_url
+    )
+    provider = OpenAIProvider(settings)
+    
+    # 构造测试提示
+    prompt = Prompt(
+        system="你是一个助手，请直接回答问题，不要输出任何思考过程。",
+        user="请简单回答：1+1等于几？只输出答案，不要解释。"
+    )
+    
+    config = GenerationConfig(
+        model=model,
+        temperature=0.1,  # 低温度以获得确定性输出
+        max_tokens=256
+    )
+    
+    print(f"\n🚀 调用 LLM API...")
+    
+    # 调用 API
+    try:
+        result = await provider.generate(prompt, config)
+    except Exception as e:
+        pytest.fail(f"LLM API 调用失败: {e}")
+    
+    content = result.content
+    
+    print(f"\n📝 响应内容:")
+    print(f"   {content[:500]}")  # 打印前 500 字符
+    print(f"\n📊 Token 使用:")
+    print(f"   - Input: {result.token_usage.input_tokens}")
+    print(f"   - Output: {result.token_usage.output_tokens}")
+    
+    # 检查是否包含思考内容
+    has_thinking, thinking_matches = has_thinking_content(content)
+    
+    print(f"\n✅ 检查结果:")
+    if has_thinking:
+        print(f"   ❌ 发现思考过程内容！")
+        print(f"   匹配到的思考内容数量: {len(thinking_matches)}")
+        for i, match in enumerate(thinking_matches[:3], 1):  # 只显示前 3 个
+            preview = match[:100] + "..." if len(match) > 100 else match
+            print(f"   {i}. {preview}")
+        
+        pytest.fail(
+            f"响应中包含思考过程内容！发现 {len(thinking_matches)} 个思考标签。"
+            f"请检查 LLM_DISABLE_REASONING 配置是否正确。"
+        )
+    else:
+        print(f"   ✅ 未发现思考过程内容")
+        print(f"   响应内容干净，思考过程已成功关闭")
+    
+    # 额外检查：内容应该是简洁的答案
+    content_clean = content.strip()
+    print(f"\n📏 内容长度检查:")
+    print(f"   - 字符数: {len(content_clean)}")
+    print(f"   - 行数: {len(content_clean.splitlines())}")
+    
+    # 对于简单问题，响应应该比较简短
+    if len(content_clean) > 500:
+        print(f"   ⚠️  警告：响应内容较长，可能包含额外信息")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_qwen_thinking_disabled_with_complex_prompt():
+    """使用复杂提示测试思考过程关闭
+    
+    使用更容易触发思考的复杂问题来验证
+    """
+    # 检查必要的环境变量
+    provider_type = os.getenv("LLM_PROVIDER", "").lower()
+    if provider_type != "openai":
+        pytest.skip(f"跳过测试：LLM_PROVIDER={provider_type}，需要 openai")
+    
+    disable_reasoning = os.getenv("LLM_DISABLE_REASONING", "").lower()
+    if disable_reasoning not in ("1", "true", "yes"):
+        pytest.fail("请在 .env 中设置 LLM_DISABLE_REASONING=true")
+    
+    base_url = os.getenv("OPENAI_BASE_URL")
+    api_key = os.getenv("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_MODEL")
+    
+    if not base_url or not api_key or not model:
+        pytest.skip("跳过测试：缺少必要配置")
+    
+    print(f"\n📋 测试配置（复杂提示）:")
+    print(f"   - Model: {model}")
+    print(f"   - Disable Reasoning: {disable_reasoning}")
+    
+    # 创建 LLM Provider
+    settings = Settings(
+        api_key=api_key,
+        base_url=base_url
+    )
+    provider = OpenAIProvider(settings)
+    
+    # 构造更容易触发思考的复杂提示
+    prompt = Prompt(
+        system="""你是一个小说创作助手。请严格按照以下要求输出：
+1. 只输出 JSON 格式的内容
+2. 不要包含任何思考过程
+3. 不要使用任何 markdown 格式
+4. 直接输出 JSON 对象""",
+        user="""请为以下场景生成一个简短的故事大纲（JSON格式）：
+{
+  "genre": "科幻",
+  "theme": "时间旅行",
+  "characters": ["主角", "导师", "反派"],
+  "acts": 3
+}
+
+只输出 JSON，不要其他内容。"""
+    )
+    
+    config = GenerationConfig(
+        model=model,
+        temperature=0.2,
+        max_tokens=512
+    )
+    
+    print(f"\n🚀 调用 LLM API（复杂提示）...")
+    
+    try:
+        result = await provider.generate(prompt, config)
+    except Exception as e:
+        pytest.fail(f"LLM API 调用失败: {e}")
+    
+    content = result.content
+    
+    print(f"\n📝 响应内容（前 300 字符）:")
+    print(f"   {content[:300]}")
+    
+    # 检查是否包含思考内容
+    has_thinking, thinking_matches = has_thinking_content(content)
+    
+    print(f"\n✅ 检查结果:")
+    if has_thinking:
+        print(f"   ❌ 发现思考过程内容！")
+        print(f"   匹配到的思考内容数量: {len(thinking_matches)}")
+        pytest.fail(
+            f"复杂提示下响应中仍包含思考过程内容！"
+            f"发现 {len(thinking_matches)} 个思考标签。"
+        )
+    else:
+        print(f"   ✅ 未发现思考过程内容")
+        print(f"   复杂提示下思考过程也已成功关闭")
+    
+    # 检查响应是否以 JSON 开头（验证是否干净）
+    content_stripped = content.strip()
+    if content_stripped.startswith("{") or content_stripped.startswith("["):
+        print(f"   ✅ 响应以 JSON 格式开始，内容干净")
+    else:
+        print(f"   ⚠️  响应不是以 JSON 开始，可能包含前缀内容")
+        print(f"   前 50 字符: {content_stripped[:50]}")
+
+
+if __name__ == "__main__":
+    # 允许直接运行此文件
+    asyncio.run(test_qwen_thinking_disabled())

--- a/tests/unit/application/blueprint/services/test_continuous_planning_json.py
+++ b/tests/unit/application/blueprint/services/test_continuous_planning_json.py
@@ -1,0 +1,129 @@
+"""测试连续规划服务的 JSON 解析功能"""
+import json
+import pytest
+
+from application.blueprint.services.continuous_planning_service import (
+    ContinuousPlanningService,
+)
+
+
+class MockService:
+    """Mock service for testing"""
+    _repair_json = ContinuousPlanningService._repair_json
+    _parse_llm_response = ContinuousPlanningService._parse_llm_response
+
+
+@pytest.fixture
+def service():
+    return MockService()
+
+
+class TestContinuousPlanningJson:
+    """测试 JSON 解析功能"""
+
+    def test_normal_json(self, service):
+        """测试正常 JSON"""
+        normal_response = json.dumps({
+            "parts": [
+                {
+                    "title": "第一部分",
+                    "volumes": [
+                        {
+                            "title": "卷一",
+                            "theme": "觉醒",
+                            "estimated_chapters": 3
+                        }
+                    ]
+                }
+            ]
+        })
+        
+        result = service._parse_llm_response(normal_response)
+        assert result['parts'][0]['title'] == "第一部分"
+
+    def test_markdown_code_block(self, service):
+        """测试带 Markdown 代码块"""
+        markdown_response = '''这是一个故事规划：
+
+```json
+{
+  "parts": [
+    {
+      "title": "九零回响",
+      "volumes": [
+        {
+          "title": "卷一：破晓",
+          "theme": "觉醒",
+          "estimated_chapters": 3
+        }
+      ]
+    }
+  ]
+}
+```
+
+希望这个规划对你有帮助。'''
+        
+        result = service._parse_llm_response(markdown_response)
+        assert result['parts'][0]['title'] == "九零回响"
+
+    def test_truncated_json(self, service):
+        """测试截断的 JSON（真实错误场景）"""
+        truncated_response = '''{
+  "parts": [
+    {
+      "title": "九零回响：破晓工厂",
+      "volumes": [
+        {
+          "title": "卷一：广播台的暗雷",
+          "theme": "阶层压迫与觉醒",
+          "estimated_chapters": 3,
+          "acts": [
+            {
+              "title": "第一幕：暗流涌动",
+              "description": "工人发现广播台秘密"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+'''
+        
+        result = service._parse_llm_response(truncated_response)
+        assert result['parts'][0]['title'] == "九零回响：破晓工厂"
+        assert len(result['parts'][0]['volumes']) == 1
+
+    def test_trailing_commas(self, service):
+        """测试带尾部逗号"""
+        trailing_comma_response = '''{
+  "parts": [
+    {
+      "title": "test",
+      "volumes": [
+        {
+          "title": "volume1",
+          "theme": "theme1",
+        }
+      ],
+    }
+  ],
+}'''
+        
+        result = service._parse_llm_response(trailing_comma_response)
+        assert result['parts'][0]['title'] == "test"
+
+    def test_unclosed_string(self, service):
+        """测试未闭合的字符串（极端场景，可能失败）"""
+        unclosed_string_response = '''{
+  "parts": [
+    {
+      "title": "九零回响：破晓工厂",
+      "description": "这是一个关于工人觉醒的故事，
+      "volumes": []
+    }
+  ]
+}'''
+        
+        with pytest.raises((ValueError, json.JSONDecodeError)):
+            service._parse_llm_response(unclosed_string_response)

--- a/tests/unit/application/blueprint/services/test_json_repair.py
+++ b/tests/unit/application/blueprint/services/test_json_repair.py
@@ -1,0 +1,138 @@
+"""测试 JSON 修复功能"""
+import json
+import re
+import pytest
+
+
+def repair_json(content: str) -> str:
+    """尝试修复常见的 JSON 格式问题"""
+    if not content:
+        return content
+
+    content = re.sub(r',\s*}', '}', content)
+    content = re.sub(r',\s*]', ']', content)
+
+    lines = content.split('\n')
+    repaired_lines = []
+    
+    for line in lines:
+        quote_positions = []
+        i = 0
+        while i < len(line):
+            if line[i] == '\\' and i + 1 < len(line) and line[i+1] == '"':
+                i += 2
+                continue
+            if line[i] == '"':
+                quote_positions.append(i)
+            i += 1
+        
+        if len(quote_positions) % 2 != 0:
+            last_quote_pos = quote_positions[-1]
+            line = line[:last_quote_pos+1] + '"' + line[last_quote_pos+1:]
+        
+        repaired_lines.append(line)
+    
+    content = '\n'.join(repaired_lines)
+
+    stack = []
+    in_string = False
+    escape_next = False
+    
+    for i, char in enumerate(content):
+        if escape_next:
+            escape_next = False
+            continue
+        if char == '\\':
+            escape_next = True
+            continue
+        if char == '"' and not escape_next:
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if char in '{[':
+            stack.append(char)
+        elif char in '}]':
+            if stack:
+                open_char = stack.pop()
+                if (open_char == '{' and char != '}') or (open_char == '[' and char != ']'):
+                    break
+    
+    if stack:
+        closing_map = {'{': '}', '[': ']'}
+        content = content.rstrip()
+        for open_char in reversed(stack):
+            content += closing_map[open_char]
+
+    return content
+
+
+class TestJsonRepair:
+    """测试 JSON 修复功能"""
+
+    def test_trailing_commas(self):
+        """测试尾部逗号修复"""
+        json_str = '''{
+  "name": "test",
+  "items": [1, 2, 3,],
+  "value": 123,
+}'''
+        
+        repaired = repair_json(json_str)
+        result = json.loads(repaired)
+        assert result['name'] == "test"
+        assert result['items'] == [1, 2, 3]
+
+    def test_unclosed_brackets(self):
+        """测试未闭合括号修复"""
+        json_str = '''{
+  "parts": [
+    {
+      "title": "part1",
+      "volumes": [
+        {
+          "title": "volume1"
+        }
+      ]
+    }
+  ]
+'''
+        
+        repaired = repair_json(json_str)
+        result = json.loads(repaired)
+        assert result['parts'][0]['title'] == "part1"
+
+    def test_multiple_issues(self):
+        """测试多重问题修复"""
+        json_str = '''{
+  "title": "test",
+  "items": [
+    {"name": "item1",},
+    {"name": "item2",}
+  ],
+'''
+        
+        repaired = repair_json(json_str)
+        result = json.loads(repaired)
+        assert result['title'] == "test"
+        assert len(result['items']) == 2
+
+    def test_truncated_json(self):
+        """测试截断的 JSON"""
+        json_str = '''{
+  "parts": [
+    {
+      "title": "九零回响：破晓工厂",
+      "volumes": [
+        {
+          "title": "卷一：广播台的暗雷",
+          "theme": "阶层压迫与觉醒",
+          "estimated_chapters": 3,
+          "acts": [
+            {
+              "title": "act1",
+              "description": "工人发现广播台秘'''
+        
+        repaired = repair_json(json_str)
+        result = json.loads(repaired)
+        assert result['parts'][0]['title'] == "九零回响：破晓工厂"

--- a/tests/unit/domain/ai/services/test_llm_service.py
+++ b/tests/unit/domain/ai/services/test_llm_service.py
@@ -19,9 +19,9 @@ class TestGenerationConfig:
         assert config.temperature == 1.0
 
     def test_generation_config_default_values(self):
-        """测试默认值"""
+        """测试默认值（model 由具体 Provider 结合环境变量解析）"""
         config = GenerationConfig()
-        assert config.model == "claude-3-5-sonnet-20241022"
+        assert config.model is None
         assert config.max_tokens == 4096
         assert config.temperature == 1.0
 

--- a/tests/unit/infrastructure/ai/providers/test_anthropic_provider.py
+++ b/tests/unit/infrastructure/ai/providers/test_anthropic_provider.py
@@ -1,6 +1,6 @@
 """AnthropicProvider 测试"""
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from domain.ai.value_objects.prompt import Prompt
 from domain.ai.value_objects.token_usage import TokenUsage
 from domain.ai.services.llm_service import GenerationConfig
@@ -36,10 +36,12 @@ class TestAnthropicProvider:
             max_tokens=4096
         )
 
-        with patch.object(provider.client.messages, 'create') as mock_create:
+        with patch.object(
+            provider.async_client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
             mock_create.return_value = Mock(
                 content=[Mock(text="Hi there!")],
-                usage=Mock(input_tokens=10, output_tokens=5)
+                usage=Mock(input_tokens=10, output_tokens=5),
             )
 
             result = await provider.generate(prompt, config)
@@ -64,10 +66,12 @@ class TestAnthropicProvider:
             max_tokens=2048
         )
 
-        with patch.object(provider.client.messages, 'create') as mock_create:
+        with patch.object(
+            provider.async_client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
             mock_create.return_value = Mock(
                 content=[Mock(text="Response")],
-                usage=Mock(input_tokens=20, output_tokens=10)
+                usage=Mock(input_tokens=20, output_tokens=10),
             )
 
             result = await provider.generate(prompt, config)
@@ -83,10 +87,12 @@ class TestAnthropicProvider:
         prompt = Prompt(system="You are helpful", user="Hello")
         config = GenerationConfig()
 
-        with patch.object(provider.client.messages, 'create') as mock_create:
+        with patch.object(
+            provider.async_client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
             mock_create.return_value = Mock(
                 content=[],
-                usage=Mock(input_tokens=10, output_tokens=5)
+                usage=Mock(input_tokens=10, output_tokens=5),
             )
 
             with pytest.raises(RuntimeError, match="empty content"):
@@ -98,7 +104,9 @@ class TestAnthropicProvider:
         prompt = Prompt(system="You are helpful", user="Hello")
         config = GenerationConfig()
 
-        with patch.object(provider.client.messages, 'create') as mock_create:
+        with patch.object(
+            provider.async_client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
             mock_create.side_effect = Exception("Anthropic API Error")
 
             with pytest.raises(RuntimeError, match="Failed to generate text"):
@@ -110,7 +118,9 @@ class TestAnthropicProvider:
         prompt = Prompt(system="You are helpful", user="Hello")
         config = GenerationConfig()
 
-        with patch.object(provider.client.messages, 'create') as mock_create:
+        with patch.object(
+            provider.async_client.messages, "create", new_callable=AsyncMock
+        ) as mock_create:
             mock_create.side_effect = ConnectionError("Network unreachable")
 
             with pytest.raises(RuntimeError, match="Failed to generate text"):

--- a/tests/unit/infrastructure/ai/providers/test_openai_provider_extract.py
+++ b/tests/unit/infrastructure/ai/providers/test_openai_provider_extract.py
@@ -1,0 +1,105 @@
+"""OpenAIProvider 响应解析（reasoning 字段兼容）
+
+本文件是**单元测试**：用 ``monkeypatch`` 读写 ``os.environ``，模拟你在 shell / 系统里
+配好的环境变量；**不会**去加载项目根目录的 ``.env``（pytest 默认也不加载）。
+
+这样做的原因：
+- CI / 其他机器上没有你的 ``.env``，测试仍须可重复通过；
+- 只测「给定环境变量组合时，函数返回值是否符合预期」，与运行时 ``os.getenv`` 行为一致。
+
+实机校验见 ``tests/integration/infrastructure/ai/test_qwen_openai_compat_no_think_live.py``
+（需 ``RUN_QWEN_NO_THINK_LIVE=1`` 与根目录 ``.env``，与 ``.env.example`` 中 Qwen3.5 一节一致）。
+"""
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+from infrastructure.ai.providers.openai_provider import (
+    _extract_chat_message_text,
+    _extract_stream_delta_text,
+    _maybe_strip_for_no_think,
+    _openai_no_think_request_options,
+)
+
+
+def test_extract_prefers_content_over_reasoning():
+    m = ChatCompletionMessage.model_validate(
+        {"role": "assistant", "content": "visible", "reasoning": "hidden"}
+    )
+    assert _extract_chat_message_text(m) == "visible"
+
+
+def test_extract_reasoning_when_content_empty():
+    m = ChatCompletionMessage.model_validate(
+        {"role": "assistant", "content": None, "reasoning": '{"world": true}'}
+    )
+    assert _extract_chat_message_text(m) == '{"world": true}'
+
+
+def test_extract_stream_delta_reasoning():
+    d = ChoiceDelta.model_validate({"content": None, "reasoning": "x"})
+    assert _extract_stream_delta_text(d) == "x"
+
+
+def test_extract_skips_reasoning_when_llm_disable_reasoning(monkeypatch):
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "true")
+    m = ChatCompletionMessage.model_validate(
+        {"role": "assistant", "content": None, "reasoning": "not-for-json"}
+    )
+    assert _extract_chat_message_text(m) == ""
+
+
+def test_stream_delta_skips_reasoning_when_disabled(monkeypatch):
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "true")
+    d = ChoiceDelta.model_validate({"content": None, "reasoning": "x"})
+    assert _extract_stream_delta_text(d) is None
+
+
+def test_openai_no_think_options_requires_base_url(monkeypatch):
+    """验证 ``_openai_no_think_request_options`` 在 env + base_url 组合下的字典形状（不读 .env）。"""
+    monkeypatch.delenv("LLM_DISABLE_REASONING", raising=False)
+    monkeypatch.delenv("LLM_FORCE_COMPAT_NO_THINK_EXTRAS", raising=False)
+    monkeypatch.delenv("LLM_QWEN_ASSISTANT_PREFILL", raising=False)
+    assert _openai_no_think_request_options(None) == {}
+    assert _openai_no_think_request_options("") == {}
+
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "1")
+    assert _openai_no_think_request_options(None) == {}
+    assert _openai_no_think_request_options("http://127.0.0.1:1234/v1") == {
+        "extra_body": {
+            "reasoning": "off",
+            "chat_template_kwargs": {"enable_thinking": False},
+            "continue_assistant_turn": True,
+        }
+    }
+
+
+def test_openai_no_think_options_force_without_base_url(monkeypatch):
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "true")
+    monkeypatch.setenv("LLM_FORCE_COMPAT_NO_THINK_EXTRAS", "1")
+    monkeypatch.delenv("LLM_QWEN_ASSISTANT_PREFILL", raising=False)
+    assert _openai_no_think_request_options(None) == {
+        "extra_body": {
+            "reasoning": "off",
+            "chat_template_kwargs": {"enable_thinking": False},
+            "continue_assistant_turn": True,
+        }
+    }
+
+
+def test_maybe_strip_think_tags_when_disabled(monkeypatch):
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "true")
+    raw = "\x3cthink\x3e...internal...\x3c/think\x3e\n{\"a\": 1}"
+    assert _maybe_strip_for_no_think(raw) == '{"a": 1}'
+
+
+def test_maybe_strip_redacted_when_disabled(monkeypatch):
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "true")
+    raw = "<think>x</think>{\"b\": 2}"
+    assert _maybe_strip_for_no_think(raw) == '{"b": 2}'
+
+
+def test_openai_no_think_options_without_assistant_prefill(monkeypatch):
+    monkeypatch.setenv("LLM_DISABLE_REASONING", "true")
+    monkeypatch.setenv("LLM_QWEN_ASSISTANT_PREFILL", "false")
+    body = _openai_no_think_request_options("http://localhost:1/v1")["extra_body"]
+    assert "continue_assistant_turn" not in body

--- a/tests/unit/infrastructure/ai/test_model_resolution.py
+++ b/tests/unit/infrastructure/ai/test_model_resolution.py
@@ -1,0 +1,35 @@
+"""model_resolution 单元测试"""
+
+from infrastructure.ai.model_resolution import (
+    resolve_anthropic_model,
+    resolve_openai_chat_model,
+)
+
+
+class TestResolveOpenAIChatModel:
+    def test_empty_uses_env_or_gpt4o(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_MODEL", raising=False)
+        assert resolve_openai_chat_model(None) == "gpt-4o"
+        assert resolve_openai_chat_model("") == "gpt-4o"
+
+    def test_claude_id_replaced_with_openai_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_MODEL", "openai/gpt-oss-20b")
+        assert resolve_openai_chat_model("claude-sonnet-4-6") == "openai/gpt-oss-20b"
+
+    def test_explicit_openai_compatible_preserved(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
+        assert resolve_openai_chat_model("local-model-xyz") == "local-model-xyz"
+
+
+class TestResolveAnthropicModel:
+    def test_empty_uses_env_or_sonnet(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_MODEL", raising=False)
+        assert resolve_anthropic_model(None) == "claude-sonnet-4-6"
+
+    def test_gpt_style_replaced(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_MODEL", "claude-3-5-haiku-20241022")
+        assert resolve_anthropic_model("gpt-4o") == "claude-3-5-haiku-20241022"
+
+    def test_openai_slash_prefix_replaced(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_MODEL", "claude-opus-4-0")
+        assert resolve_anthropic_model("openai/gpt-oss-20b") == "claude-opus-4-0"

--- a/tests/unit/infrastructure/ai/test_think_leak_detection.py
+++ b/tests/unit/infrastructure/ai/test_think_leak_detection.py
@@ -1,0 +1,28 @@
+"""think_leak_detection 单元测试"""
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+from infrastructure.ai.think_leak_detection import (
+    message_dump_has_think_leak,
+    raw_text_contains_think_markers,
+    reasoning_channel_should_be_empty_when_disabled,
+)
+
+
+def test_raw_text_contains_think_markers():
+    assert raw_text_contains_think_markers("prefix\x3cthink\x3ex\x3c/think\x3esuffix")
+    assert raw_text_contains_think_markers("<think>x</think>")
+    assert not raw_text_contains_think_markers('{"a":1}')
+
+
+def test_message_dump_has_think_leak():
+    m = ChatCompletionMessage.model_validate(
+        {"role": "assistant", "content": "ok\x3cthink\x3eh\x3c/think\x3e"}
+    )
+    assert message_dump_has_think_leak(m)
+
+
+def test_reasoning_channel_should_be_empty():
+    m = ChatCompletionMessage.model_validate(
+        {"role": "assistant", "content": "{}", "reasoning": "hidden"}
+    )
+    assert reasoning_channel_should_be_empty_when_disabled(m) is not None

--- a/tests/unit/interfaces/api/test_dependencies.py
+++ b/tests/unit/interfaces/api/test_dependencies.py
@@ -8,27 +8,39 @@ from interfaces.api.dependencies import get_vector_store
 class TestGetVectorStore:
     """测试 get_vector_store 依赖注入函数"""
 
-    def test_get_vector_store_returns_none_when_no_env(self):
-        """未设置环境变量时返回 None"""
-        with patch.dict(os.environ, {}, clear=True):
-            result = get_vector_store()
-            assert result is None
+    _qdrant_env = {
+        "VECTOR_STORE_ENABLED": "true",
+        "VECTOR_STORE_TYPE": "qdrant",
+    }
+
+    def test_get_vector_store_returns_chromadb_by_default(self):
+        """默认类型为 chromadb（仅启用向量存储时）"""
+        with patch.dict(os.environ, {"VECTOR_STORE_ENABLED": "true"}, clear=True):
+            with patch(
+                "infrastructure.ai.chromadb_vector_store.ChromaDBVectorStore"
+            ) as mock_chroma:
+                mock_instance = MagicMock()
+                mock_chroma.return_value = mock_instance
+                result = get_vector_store()
+                assert result is mock_instance
+                mock_chroma.assert_called_once()
 
     def test_get_vector_store_returns_none_when_disabled(self):
-        """QDRANT_ENABLED 为 false 时返回 None"""
-        with patch.dict(os.environ, {"QDRANT_ENABLED": "false"}, clear=True):
+        """VECTOR_STORE_ENABLED=false 时返回 None"""
+        with patch.dict(os.environ, {"VECTOR_STORE_ENABLED": "false"}, clear=True):
             result = get_vector_store()
             assert result is None
 
-    def test_get_vector_store_returns_qdrant_when_env_set(self):
-        """设置环境变量时返回 QdrantVectorStore 实例"""
-        with patch.dict(os.environ, {
-            "QDRANT_ENABLED": "true",
-            "QDRANT_HOST": "localhost",
-            "QDRANT_PORT": "6333"
-        }, clear=True):
-            # Mock QdrantVectorStore to avoid actual connection
-            with patch("infrastructure.ai.qdrant_vector_store.QdrantVectorStore") as mock_qdrant:
+    def test_get_vector_store_returns_qdrant_when_type_set(self):
+        """VECTOR_STORE_TYPE=qdrant 时构造 QdrantVectorStore"""
+        with patch.dict(
+            os.environ,
+            {**self._qdrant_env, "QDRANT_HOST": "localhost", "QDRANT_PORT": "6333"},
+            clear=True,
+        ):
+            with patch(
+                "infrastructure.ai.qdrant_vector_store.QdrantVectorStore"
+            ) as mock_qdrant:
                 mock_instance = MagicMock()
                 mock_qdrant.return_value = mock_instance
 
@@ -40,17 +52,26 @@ class TestGetVectorStore:
                 mock_qdrant.assert_called_once_with(
                     host="localhost",
                     port=6333,
-                    api_key=None
+                    api_key=None,
+                    url=None,
+                    timeout=None,
+                    https=None,
                 )
 
-    def test_get_vector_store_with_custom_host_port(self):
-        """使用自定义 host 和 port"""
-        with patch.dict(os.environ, {
-            "QDRANT_ENABLED": "true",
-            "QDRANT_HOST": "qdrant.example.com",
-            "QDRANT_PORT": "6334"
-        }, clear=True):
-            with patch("infrastructure.ai.qdrant_vector_store.QdrantVectorStore") as mock_qdrant:
+    def test_get_vector_store_qdrant_custom_host_port(self):
+        """Qdrant 自定义 host / port"""
+        with patch.dict(
+            os.environ,
+            {
+                **self._qdrant_env,
+                "QDRANT_HOST": "qdrant.example.com",
+                "QDRANT_PORT": "6334",
+            },
+            clear=True,
+        ):
+            with patch(
+                "infrastructure.ai.qdrant_vector_store.QdrantVectorStore"
+            ) as mock_qdrant:
                 mock_instance = MagicMock()
                 mock_qdrant.return_value = mock_instance
 
@@ -59,18 +80,27 @@ class TestGetVectorStore:
                 mock_qdrant.assert_called_once_with(
                     host="qdrant.example.com",
                     port=6334,
-                    api_key=None
+                    api_key=None,
+                    url=None,
+                    timeout=None,
+                    https=None,
                 )
 
-    def test_get_vector_store_with_api_key(self):
-        """使用 API key"""
-        with patch.dict(os.environ, {
-            "QDRANT_ENABLED": "true",
-            "QDRANT_HOST": "localhost",
-            "QDRANT_PORT": "6333",
-            "QDRANT_API_KEY": "test-api-key"
-        }, clear=True):
-            with patch("infrastructure.ai.qdrant_vector_store.QdrantVectorStore") as mock_qdrant:
+    def test_get_vector_store_qdrant_with_api_key(self):
+        """Qdrant API Key"""
+        with patch.dict(
+            os.environ,
+            {
+                **self._qdrant_env,
+                "QDRANT_HOST": "localhost",
+                "QDRANT_PORT": "6333",
+                "QDRANT_API_KEY": "test-api-key",
+            },
+            clear=True,
+        ):
+            with patch(
+                "infrastructure.ai.qdrant_vector_store.QdrantVectorStore"
+            ) as mock_qdrant:
                 mock_instance = MagicMock()
                 mock_qdrant.return_value = mock_instance
 
@@ -79,23 +109,39 @@ class TestGetVectorStore:
                 mock_qdrant.assert_called_once_with(
                     host="localhost",
                     port=6333,
-                    api_key="test-api-key"
+                    api_key="test-api-key",
+                    url=None,
+                    timeout=None,
+                    https=None,
                 )
 
-    def test_get_vector_store_uses_default_values(self):
-        """只设置 QDRANT_ENABLED，使用默认值"""
-        with patch.dict(os.environ, {
-            "QDRANT_ENABLED": "true"
-        }, clear=True):
-            with patch("infrastructure.ai.qdrant_vector_store.QdrantVectorStore") as mock_qdrant:
+    def test_get_vector_store_qdrant_url_and_options(self):
+        """QDRANT_URL 与超时、HTTPS"""
+        with patch.dict(
+            os.environ,
+            {
+                **self._qdrant_env,
+                "QDRANT_URL": "https://cluster.example.cloud.qdrant.io:6333",
+                "QDRANT_TIMEOUT": "30",
+                "QDRANT_HTTPS": "true",
+                "QDRANT_API_KEY": "secret",
+            },
+            clear=True,
+        ):
+            with patch(
+                "infrastructure.ai.qdrant_vector_store.QdrantVectorStore"
+            ) as mock_qdrant:
                 mock_instance = MagicMock()
                 mock_qdrant.return_value = mock_instance
 
-                result = get_vector_store()
+                get_vector_store()
 
                 # 验证使用默认值
                 mock_qdrant.assert_called_once_with(
                     host="localhost",
                     port=6333,
-                    api_key=None
+                    api_key="secret",
+                    url="https://cluster.example.cloud.qdrant.io:6333",
+                    timeout=30.0,
+                    https=True,
                 )


### PR DESCRIPTION
## 变更说明

## UI 优化
### fix(ui)-4f6a0e8: 张力心电图刷新后不显示及面板宽度变化自适应修复
- loadTensionData 刷新前先 dispose 旧实例，避免 loading 切换销毁 chartRef DOM 后实例失效
- 新增 ResizeObserver 监听图表容器尺寸，面板拖拽调宽时自动调用 chartInstance.resize()
- detachResizeObserver 在刷新和组件卸载时均调用确保无内存泄漏

### feat(ui)-b7a393a: 写作进度流式文字改为打字机逐字显示效果
- 新增字符队列 typewriterQueue，每 28ms 取 2 字追加到显示文本
- trimToMaxLines 按视觉行数裁剪，保留最近 6 行
- 容器改为固定高度 128px + overflow:hidden + justify-content:flex-end
- 新章节/内容清空时调用 resetTypewriter 重置队列和定时器

### fix(ui)-7c64cf7: 统计栏最后更新时间格式改为 yyyy-MM-dd HH:mm:ss，字体 11px

### fix(ui)-14bfee3: 关系图工具栏按钮防换行布局修复
- toolbar 改为 align-items: center，提示文本设 flex:1; min-width:0
- 确保刷新、完整查看页两个按钮始终在同一行显示

### feat(ui)-0a1089a: 作品设定面板标题行与色块布局优化
- 标题、badge、操作按钮改为同一行 flex 布局，按钮组右对齐
- 角色/场景色块改为 grid 两列等宽排列，自适应面板宽度

### feat(ui)-375b4bd: 中间内容区滚动条默认隐藏，悬停时显示
- .managed-stack 使用 scrollbar-color transparent 隐藏默认滚动条
- 悬停时过渡显示半透明滚动条（Webkit + Firefox 双兼容）

### feat(ui)-a139c6c: 故事结构树在左侧面板过窄时隐藏节点后缀
- 使用 ResizeObserver 监测根容器宽度，宽度 < 280px 时为根元素添加 .narrow class
- .narrow 状态下通过 :deep(.node-range) display:none 隐藏字数和章节范围后缀

### feat(ui)-7741be0: 工作台左右面板支持拖拽调整宽度与折叠/展开
- 用自定义 flex 布局替代 n-split，实现左右侧栏可拖拽分割线调宽
- 左侧：默认 388px，范围 140~800px；右侧：默认 558px，范围 368~800px
- 分割线默认透明，悬停时显示绿色提示，折叠按钮居中浮于分割线上
- 折叠/展开通过 width 过渡动画平滑切换

### fix(bible)-ce3cce3: harden LLM JSON parsing in auto_bible_generator
- Use regex to extract longest markdown code block instead of splitting on first
- Rewrite _extract_outermost_json with while-loop to correctly handle escape
  sequences and avoid premature termination
- Add _close_truncated_json to repair JSON truncated by max_tokens limit:
  detects unclosed string literals, strips trailing commas, closes missing brackets
- Wrap bare LLM output (missing outer {}) by detecting leading quote character
- Normalize unwrapped worldbuilding dimensions into expected {worldbuilding:{...}} shape
- Guard style_content against empty string before saving StyleNote
- Wrap bare characters/locations arrays returned by LLM
- Add isinstance guard on parsed.keys() to handle list responses
- Raise default max_tokens from 2048 to 4096 in _call_llm_and_parse to reduce truncation

### fix(bible)-ff331db: 改进 JSON 提取逻辑，准确匹配最外层括号
问题：rfind('}') 可能匹配到内嵌对象的闭合括号，导致 'Extra data' 错误
修复：
- 新增 _extract_outermost_json() 方法，使用栈精确匹配最外层 }
- 增强错误日志，打印出错位置附近的内容上下文
- 正确处理字符串内的花括号，避免误判嵌套层级

### fix(bible)-5f64517: 增加 Bible 生成超时时间和 max_tokens
问题：本地 LLM 生成 Bible 数据时容易超时
修复：
- 后端：max_tokens 从 2048 增加到 4096
- 前端：超时时间从 2分钟 增加到 5分钟（300000ms）
本地 LLM 响应较慢，需要更长的等待时间

### fix(llm)-08a64fd: 修复 LLM 服务初始化未识别 OpenAI Provider 的问题
问题：当 LLM_PROVIDER=openai 时，多个文件仍硬编码只检查 ANTHROPIC_API_KEY，
导致 llm_service 为 None，引发 'NoneType' object has no attribute 'generate' 错误。

修复：
- continuous_planning_routes.py: 使用 get_llm_service() 统一入口
- story_structure.py: 使用 get_llm_service() 统一入口
- llm_client.py: 支持 OpenAI Provider，根据 LLM_PROVIDER 环境变量选择

### feat(ai)-08a64fd: 添加 qwen3.5 思考过程关闭功能与代码规范化整理
新增功能:
- 添加 llm_runtime_flags.py: LLM 运行时开关控制思考过程关闭
- 添加 model_resolution.py: OpenAI/Anthropic 模型标识解析
- 添加 think_leak_detection.py: 思考过程泄露检测工具
- OpenAI Provider 支持关闭思考过程（请求参数、assistant预填、响应过滤）

修复问题:
- 修复 ContextBudgetAllocator triple_repo 属性缺失
- 增强 LLM 响应 JSON 解析容错能力
- 修复截断 JSON 解析失败问题

代码重构:
- 移除代码中的部署工具特定表述（LM Studio）
- 规范化测试文件组织与代码整洁
- 测试文件移至正确目录，标准化 pytest 格式

新增文件:
- infrastructure/ai/llm_runtime_flags.py
- infrastructure/ai/model_resolution.py
- infrastructure/ai/think_leak_detection.py
- tests/unit/application/blueprint/services/test_*.py
- tests/integration/infrastructure/ai/test_qwen_*.py
-

