### PR TITLE
fix: 为“新书设置向导”增加右上角关闭按钮，避免网络卡顿时无法退出

### DIFF
--- a/frontend/src/components/onboarding/NovelSetupGuide.vue
+++ b/frontend/src/components/onboarding/NovelSetupGuide.vue
@@ -3,7 +3,7 @@
     v-model:show="modalOpen"
     :mask-closable="false"
     :close-on-esc="false"
-    :closable="false"
+    :closable="true"
     preset="card"
     title="新书设置向导"
     style="width: 90%; max-width: 600px; max-height: 90vh"
@@ -455,7 +455,13 @@ const emit = defineEmits<{
 /** 与父组件 show 单一数据源，避免本地 visible 与 props 打架导致误 emit(false) 把向导关掉 */
 const modalOpen = computed({
   get: () => props.show,
-  set: (v: boolean) => emit('update:show', v),
+  set: (v: boolean) => {
+    if (v) {
+      emit('update:show', true)
+      return
+    }
+    requestClose()
+  },
 })
 
 const currentStep = ref(1)
@@ -752,7 +758,13 @@ const handleNext = async () => {
 }
 
 const handleSkip = () => {
+  if (!confirm('确认退出向导？当前修改将不会保存。')) return
   emit('skip')
+  emit('update:show', false)
+}
+
+const requestClose = () => {
+  if (!confirm('确认退出向导？当前修改将不会保存。')) return
   emit('update:show', false)
 }
 


### PR DESCRIPTION
## 变更说明
- 为“新书设置向导”启用右上角关闭按钮
- 点击关闭时增加二次确认提示：确认退出后才关闭向导
- 点击“跳过向导”时同样增加二次确认提示，避免误退出导致未保存修改丢失

## 测试
- [x] 本地已跑核心用例（`npm run build`）
- [x] 关键路径手测通过（向导内点击关闭/跳过均会弹确认，取消后继续留在向导）

## 风险与回滚
- 风险：仅影响向导退出交互，无后端改动
- 回滚方式：回退 `frontend/src/components/onboarding/NovelSetupGuide.vue` 本次提交