### PR TITLE
feat: LLM & 嵌入模型可视化配置管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ scripts/evaluation/results/
 # Data directory (keep structure, ignore content)
 data/chromadb/
 data/logs/
+data/llm_configs.json

--- a/application/analyst/services/state_extractor.py
+++ b/application/analyst/services/state_extractor.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
 from domain.novel.value_objects.chapter_state import ChapterState
@@ -38,7 +39,7 @@ class StateExtractor:
 
         # 配置 LLM
         config = GenerationConfig(
-            model="claude-3-5-sonnet-20241022",
+            model=os.getenv("WRITING_MODEL", ""),
             max_tokens=4096,
             temperature=0.3
         )

--- a/application/analyst/services/tension_analyzer.py
+++ b/application/analyst/services/tension_analyzer.py
@@ -1,5 +1,6 @@
 """张力分析器服务"""
 import json
+import os
 from typing import Dict, List
 from application.workbench.dtos.writer_block_dto import TensionSlingshotRequest, TensionDiagnosis
 from domain.novel.repositories.narrative_event_repository import NarrativeEventRepository
@@ -40,7 +41,7 @@ class TensionAnalyzer:
         prompt = self._build_prompt(events, stats, request)
 
         # 4. 调用 LLM
-        response = await self.llm_client.generate(prompt, model="claude-3-5-haiku-20241022")
+        response = await self.llm_client.generate(prompt, model=os.getenv("SYSTEM_MODEL", ""))
 
         # 5. 解析响应
         diagnosis = self._parse_response(response)

--- a/application/audit/services/chapter_review_service.py
+++ b/application/audit/services/chapter_review_service.py
@@ -13,6 +13,7 @@ from typing import List, Dict, Any, Optional, TYPE_CHECKING
 from datetime import datetime
 import json
 import logging
+import os
 
 from domain.novel.entities.chapter import Chapter
 from domain.novel.repositories.chapter_repository import ChapterRepository
@@ -99,7 +100,7 @@ class ChapterReviewService:
         foreshadowing_repo: ForeshadowingRepository,
         vector_store: "ChromaDBVectorStore",
         llm_service: LLMService,
-        model: str = "claude-3-5-haiku-20241022"
+        model: str = ""
     ):
         self.chapter_repo = chapter_repo
         self.cast_repo = cast_repo
@@ -108,7 +109,7 @@ class ChapterReviewService:
         self.foreshadowing_repo = foreshadowing_repo
         self.vector_store = vector_store
         self.llm_service = llm_service
-        self.model = model
+        self.model = model or os.getenv("SYSTEM_MODEL", "")
 
     async def review_chapter(self, novel_id: str, chapter_number: int) -> ChapterReviewResult:
         """审稿章节"""

--- a/application/audit/services/macro_refactor_proposal_service.py
+++ b/application/audit/services/macro_refactor_proposal_service.py
@@ -1,5 +1,6 @@
 """Macro Refactor Proposal Service - 使用 LLM 生成重构建议"""
 import logging
+import os
 from typing import Dict, Any
 from application.audit.dtos.macro_refactor_dto import RefactorProposalRequest, RefactorProposal
 from application.ai.llm_json_extract import parse_llm_json_to_dict
@@ -33,9 +34,8 @@ class MacroRefactorProposalService:
             # 构建 LLM prompt
             prompt = self._build_prompt(request)
 
-            # 配置使用 claude-3-5-haiku（快速且经济）
             config = GenerationConfig(
-                model="claude-3-5-haiku-20241022",
+                model=os.getenv("SYSTEM_MODEL", ""),
                 max_tokens=2048,
                 temperature=0.7
             )

--- a/application/engine/services/scene_director_service.py
+++ b/application/engine/services/scene_director_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 from application.ai.llm_json_extract import parse_llm_json_to_dict
@@ -26,9 +27,9 @@ class SceneDirectorService:
     _DEFAULT_MAX_TOKENS = 1024
     _DEFAULT_TEMPERATURE = 0.2
 
-    def __init__(self, llm_service: LLMService, *, model: str = "claude-3-5-haiku-20241022"):
+    def __init__(self, llm_service: LLMService, *, model: str = ""):
         self._llm = llm_service
-        self._model = model
+        self._model = model or os.getenv("SYSTEM_MODEL", "")
 
     async def analyze(self, chapter_number: int, outline: str) -> SceneDirectorAnalysis:
         """分析章节大纲，提取场景信息

--- a/application/settings/llm_config_manager.py
+++ b/application/settings/llm_config_manager.py
@@ -1,0 +1,232 @@
+"""LLM 配置管理器 — 多配置存储 + 热重载"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+ProviderType = Literal["openai", "anthropic"]
+EmbeddingMode = Literal["local", "openai"]
+
+
+@dataclass
+class LLMConfigProfile:
+    id: str
+    name: str
+    provider: ProviderType
+    api_key: str
+    base_url: str = ""
+    model: str = ""
+    system_model: str = ""
+    writing_model: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+
+
+@dataclass
+class EmbeddingConfig:
+    mode: EmbeddingMode = "local"
+    api_key: str = ""
+    base_url: str = ""
+    model: str = "text-embedding-3-small"
+    use_gpu: bool = True
+    model_path: str = "BAAI/bge-small-zh-v1.5"
+
+
+@dataclass
+class LLMConfigStore:
+    active_id: Optional[str] = None
+    configs: List[LLMConfigProfile] = field(default_factory=list)
+    embedding: EmbeddingConfig = field(default_factory=EmbeddingConfig)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class LLMConfigManager:
+    def __init__(self, config_path: Path):
+        self._path = config_path
+        self._lock = threading.Lock()
+
+    # ── persistence ──────────────────────────────────────────
+
+    def _load(self) -> LLMConfigStore:
+        if not self._path.is_file():
+            return LLMConfigStore()
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+            configs = [LLMConfigProfile(**c) for c in raw.get("configs", [])]
+            emb_raw = raw.get("embedding")
+            embedding = EmbeddingConfig(**emb_raw) if emb_raw else EmbeddingConfig()
+            return LLMConfigStore(active_id=raw.get("active_id"), configs=configs, embedding=embedding)
+        except Exception as exc:
+            logger.warning("Failed to load LLM configs: %s", exc)
+            return LLMConfigStore()
+
+    def _save(self, store: LLMConfigStore) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(
+                {
+                    "active_id": store.active_id,
+                    "configs": [asdict(c) for c in store.configs],
+                    "embedding": asdict(store.embedding),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        tmp.replace(self._path)
+
+    # ── CRUD ─────────────────────────────────────────────────
+
+    def list_configs(self) -> dict:
+        with self._lock:
+            store = self._load()
+            return {"active_id": store.active_id, "configs": [asdict(c) for c in store.configs]}
+
+    def create_config(self, data: dict) -> dict:
+        with self._lock:
+            store = self._load()
+            now = _now_iso()
+            profile = LLMConfigProfile(
+                id=str(uuid.uuid4()),
+                name=data["name"],
+                provider=data["provider"],
+                api_key=data["api_key"],
+                base_url=data.get("base_url", ""),
+                model=data.get("model", ""),
+                system_model=data.get("system_model", ""),
+                writing_model=data.get("writing_model", ""),
+                created_at=now,
+                updated_at=now,
+            )
+            store.configs.append(profile)
+            if store.active_id is None:
+                store.active_id = profile.id
+                self._save(store)
+                self._apply_to_env(profile)
+            else:
+                self._save(store)
+            return asdict(profile)
+
+    def update_config(self, config_id: str, data: dict) -> dict:
+        with self._lock:
+            store = self._load()
+            for cfg in store.configs:
+                if cfg.id == config_id:
+                    for k in ("name", "provider", "api_key", "base_url", "model", "system_model", "writing_model"):
+                        if k in data:
+                            setattr(cfg, k, data[k])
+                    cfg.updated_at = _now_iso()
+                    self._save(store)
+                    if store.active_id == config_id:
+                        self._apply_to_env(cfg)
+                    return asdict(cfg)
+            raise KeyError(f"Config {config_id} not found")
+
+    def delete_config(self, config_id: str) -> None:
+        with self._lock:
+            store = self._load()
+            store.configs = [c for c in store.configs if c.id != config_id]
+            if store.active_id == config_id:
+                store.active_id = store.configs[0].id if store.configs else None
+            self._save(store)
+
+    def set_active(self, config_id: str) -> None:
+        with self._lock:
+            store = self._load()
+            profile = next((c for c in store.configs if c.id == config_id), None)
+            if profile is None:
+                raise KeyError(f"Config {config_id} not found")
+            store.active_id = config_id
+            self._save(store)
+            self._apply_to_env(profile)
+        logger.info("LLM config activated: %s (%s / %s)", profile.name, profile.provider, profile.model)
+
+    # ── embedding config ────────────────────────────────────
+
+    def get_embedding_config(self) -> dict:
+        with self._lock:
+            store = self._load()
+            return asdict(store.embedding)
+
+    def update_embedding_config(self, data: dict) -> dict:
+        with self._lock:
+            store = self._load()
+            for k in ("mode", "api_key", "base_url", "model", "use_gpu", "model_path"):
+                if k in data:
+                    setattr(store.embedding, k, data[k])
+            self._save(store)
+            self._apply_embedding_to_env(store.embedding)
+            return asdict(store.embedding)
+
+    # ── hot-reload ───────────────────────────────────────────
+
+    def _apply_embedding_to_env(self, cfg: EmbeddingConfig) -> None:
+        env = os.environ
+        env["EMBEDDING_SERVICE"] = cfg.mode
+        env["EMBEDDING_MODEL_PATH"] = cfg.model_path
+        env["EMBEDDING_USE_GPU"] = str(cfg.use_gpu).lower()
+
+        if cfg.mode == "openai":
+            if cfg.api_key:
+                env["EMBEDDING_API_KEY"] = cfg.api_key
+            if cfg.base_url:
+                env["EMBEDDING_BASE_URL"] = cfg.base_url
+            if cfg.model:
+                env["EMBEDDING_MODEL"] = cfg.model
+        else:
+            for k in ("EMBEDDING_API_KEY", "EMBEDDING_BASE_URL", "EMBEDDING_MODEL"):
+                env.pop(k, None)
+
+        logger.info("Embedding config applied: mode=%s", cfg.mode)
+
+    def _apply_to_env(self, profile: LLMConfigProfile) -> None:
+        env = os.environ
+        if profile.provider == "openai":
+            env["LLM_PROVIDER"] = "openai"
+            env["OPENAI_API_KEY"] = profile.api_key
+            env["OPENAI_BASE_URL"] = profile.base_url
+            env["ARK_API_KEY"] = profile.api_key
+            env["ARK_BASE_URL"] = profile.base_url
+            env["ARK_MODEL"] = profile.model
+            for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"):
+                env.pop(k, None)
+        else:
+            env["LLM_PROVIDER"] = "anthropic"
+            env["ANTHROPIC_API_KEY"] = profile.api_key
+            env["ANTHROPIC_BASE_URL"] = profile.base_url
+            for k in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "ARK_API_KEY", "ARK_BASE_URL", "ARK_MODEL"):
+                env.pop(k, None)
+
+        writing = profile.writing_model or profile.model
+        system = profile.system_model or profile.model
+        env["WRITING_MODEL"] = writing
+        env["SYSTEM_MODEL"] = system
+
+        try:
+            from interfaces.api.dependencies import get_background_task_service
+            get_background_task_service.cache_clear()
+        except Exception:
+            pass
+
+    def apply_active_on_startup(self) -> None:
+        store = self._load()
+        if store.active_id:
+            profile = next((c for c in store.configs if c.id == store.active_id), None)
+            if profile:
+                self._apply_to_env(profile)
+                logger.info("Startup: applied LLM config '%s' (%s)", profile.name, profile.provider)
+        self._apply_embedding_to_env(store.embedding)

--- a/domain/ai/services/llm_service.py
+++ b/domain/ai/services/llm_service.py
@@ -9,7 +9,7 @@ class GenerationConfig:
     """生成配置"""
     def __init__(
         self,
-        model: str = "claude-sonnet-4-6",
+        model: str = "",
         max_tokens: int = 4096,
         temperature: float = 1.0,
         response_format: Optional[Dict] = None,

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,0 +1,57 @@
+import { apiClient } from './config'
+
+export interface LLMConfigProfile {
+  id: string
+  name: string
+  provider: 'openai' | 'anthropic'
+  api_key: string
+  base_url: string
+  model: string
+  system_model: string
+  writing_model: string
+  created_at: string
+  updated_at: string
+}
+
+export interface LLMConfigStore {
+  active_id: string | null
+  configs: LLMConfigProfile[]
+}
+
+export interface EmbeddingConfig {
+  mode: 'local' | 'openai'
+  api_key: string
+  base_url: string
+  model: string
+  use_gpu: boolean
+  model_path: string
+}
+
+export const settingsApi = {
+  listLLMConfigs: () =>
+    apiClient.get<LLMConfigStore>('/settings/llm-configs'),
+
+  createLLMConfig: (data: Pick<LLMConfigProfile, 'name' | 'provider' | 'api_key' | 'base_url' | 'model'>) =>
+    apiClient.post<LLMConfigProfile>('/settings/llm-configs', data),
+
+  updateLLMConfig: (id: string, data: Partial<LLMConfigProfile>) =>
+    apiClient.put<LLMConfigProfile>(`/settings/llm-configs/${id}`, data),
+
+  deleteLLMConfig: (id: string) =>
+    apiClient.delete<void>(`/settings/llm-configs/${id}`),
+
+  activateLLMConfig: (id: string) =>
+    apiClient.post<void>(`/settings/llm-configs/${id}/activate`),
+
+  fetchModels: (data: { provider: string; api_key: string; base_url: string }) =>
+    apiClient.post<string[]>('/settings/llm-configs/fetch-models', data),
+
+  getEmbeddingConfig: () =>
+    apiClient.get<EmbeddingConfig>('/settings/embedding'),
+
+  updateEmbeddingConfig: (data: EmbeddingConfig) =>
+    apiClient.put<EmbeddingConfig>('/settings/embedding', data),
+
+  fetchEmbeddingModels: (data: { provider: string; api_key: string; base_url: string }) =>
+    apiClient.post<string[]>('/settings/embedding/fetch-models', data),
+}

--- a/frontend/src/components/LLMSettingsModal.vue
+++ b/frontend/src/components/LLMSettingsModal.vue
@@ -1,0 +1,670 @@
+<template>
+  <n-modal
+    v-model:show="show"
+    preset="card"
+    title="配置管理"
+    style="width: min(720px, 96vw)"
+    :mask-closable="false"
+    :segmented="{ content: true, footer: 'soft' }"
+  >
+    <n-tabs type="line" animated>
+      <!-- ═══ Tab 1: LLM 模型 ═══ -->
+      <n-tab-pane name="llm" tab="LLM 模型">
+        <!-- Config List -->
+        <div v-if="!editing" class="config-section">
+          <div class="config-toolbar">
+            <span class="config-count">{{ configs.length }} 个配置</span>
+            <n-button type="primary" size="small" @click="startCreate">
+              <template #icon><n-icon><IconAdd /></n-icon></template>
+              添加配置
+            </n-button>
+          </div>
+
+          <div v-if="listLoading" class="config-loading">
+            <n-spin size="medium" />
+          </div>
+
+          <div v-else-if="configs.length === 0" class="config-empty">
+            <p>尚未添加任何 LLM 配置</p>
+            <n-button type="primary" @click="startCreate">添加第一个配置</n-button>
+          </div>
+
+          <div v-else class="config-list">
+            <div
+              v-for="cfg in configs"
+              :key="cfg.id"
+              class="config-card"
+              :class="{ active: cfg.id === activeId }"
+            >
+              <div class="config-info">
+                <div class="config-name">
+                  {{ cfg.name }}
+                  <n-tag
+                    size="small"
+                    round
+                    :type="cfg.provider === 'openai' ? 'success' : 'info'"
+                  >
+                    {{ cfg.provider === 'openai' ? 'OpenAI' : 'Anthropic' }}
+                  </n-tag>
+                  <n-tag v-if="cfg.id === activeId" size="small" round type="warning">
+                    激活
+                  </n-tag>
+                </div>
+                <div class="config-detail">
+                  <span v-if="cfg.model" class="detail-item">{{ cfg.model }}</span>
+                  <span v-if="cfg.base_url" class="detail-item">{{ truncateUrl(cfg.base_url) }}</span>
+                  <span class="detail-item key-mask">{{ maskKey(cfg.api_key) }}</span>
+                </div>
+              </div>
+              <div class="config-actions">
+                <n-button
+                  v-if="cfg.id !== activeId"
+                  size="small"
+                  type="success"
+                  secondary
+                  @click="handleActivate(cfg.id)"
+                  :loading="activatingId === cfg.id"
+                >
+                  激活
+                </n-button>
+                <n-button size="small" quaternary @click="startEdit(cfg)">编辑</n-button>
+                <n-popconfirm @positive-click="handleDelete(cfg.id)">
+                  <template #trigger>
+                    <n-button size="small" quaternary type="error" :loading="deletingId === cfg.id">删除</n-button>
+                  </template>
+                  确定删除「{{ cfg.name }}」？
+                </n-popconfirm>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Add / Edit Form -->
+        <div v-else class="form-section">
+          <h3 class="form-title">{{ editingId ? '编辑配置' : '新建配置' }}</h3>
+
+          <n-form ref="formRef" :model="form" label-placement="left" label-width="80">
+            <n-form-item label="名称" path="name">
+              <n-input v-model:value="form.name" placeholder="如：ARK Qwen、Anthropic Claude" />
+            </n-form-item>
+
+            <n-form-item label="提供商" path="provider">
+              <n-select
+                v-model:value="form.provider"
+                :options="providerOptions"
+                @update:value="onProviderChange"
+              />
+            </n-form-item>
+
+            <n-form-item label="API Key" path="api_key">
+              <n-input
+                v-model:value="form.api_key"
+                type="password"
+                show-password-on="click"
+                placeholder="sk-..."
+              />
+            </n-form-item>
+
+            <n-form-item label="Base URL" path="base_url">
+              <n-input
+                v-model:value="form.base_url"
+                :placeholder="form.provider === 'anthropic' ? 'https://api.anthropic.com' : 'https://api.openai.com/v1'"
+              />
+            </n-form-item>
+
+            <n-form-item label="默认模型" path="model">
+              <div class="model-row">
+                <n-select
+                  v-model:value="form.model"
+                  filterable
+                  tag
+                  :options="modelOptions"
+                  placeholder="选择或输入模型名称"
+                  style="flex: 1"
+                />
+                <n-button
+                  size="small"
+                  :loading="fetchingModels"
+                  :disabled="!form.api_key || !form.base_url"
+                  @click="handleFetchModels"
+                >
+                  获取列表
+                </n-button>
+              </div>
+            </n-form-item>
+
+            <n-form-item label="写作模型" path="writing_model">
+              <n-select
+                v-model:value="form.writing_model"
+                filterable
+                tag
+                :options="modelOptions"
+                placeholder="留空则使用默认模型"
+              />
+            </n-form-item>
+
+            <n-form-item label="系统模型" path="system_model">
+              <n-select
+                v-model:value="form.system_model"
+                filterable
+                tag
+                :options="modelOptions"
+                placeholder="留空则使用默认模型（审稿/分析等轻量任务）"
+              />
+            </n-form-item>
+          </n-form>
+
+          <n-space justify="end">
+            <n-button @click="editing = false">取消</n-button>
+            <n-button
+              type="primary"
+              :loading="saving"
+              :disabled="!form.name.trim() || !form.api_key.trim()"
+              @click="handleSave"
+            >
+              保存
+            </n-button>
+          </n-space>
+        </div>
+      </n-tab-pane>
+
+      <!-- ═══ Tab 2: 嵌入模型 ═══ -->
+      <n-tab-pane name="embedding" tab="嵌入模型">
+        <div class="embedding-section">
+          <n-alert type="warning" style="margin-bottom: 16px" :bordered="false">
+            每本书的向量索引与嵌入模型绑定，一旦开始写作后切换模型将导致已有索引不可用。
+            如需更换，请先删除对应书籍的向量数据（data/chromadb/）再重新生成。
+          </n-alert>
+
+          <div v-if="embeddingLoading" class="config-loading">
+            <n-spin size="medium" />
+          </div>
+
+          <template v-else>
+            <div class="embedding-mode-switch">
+              <span class="mode-label" :class="{ active: embeddingForm.mode === 'local' }">本地模型</span>
+              <n-switch
+                :value="embeddingForm.mode === 'openai'"
+                @update:value="embeddingForm.mode = $event ? 'openai' : 'local'"
+              />
+              <span class="mode-label" :class="{ active: embeddingForm.mode === 'openai' }">云端模型</span>
+            </div>
+
+            <!-- Local mode -->
+            <div v-if="embeddingForm.mode === 'local'" class="embedding-local-info">
+              <div class="local-model-card">
+                <div class="local-model-name">BAAI/bge-small-zh-v1.5</div>
+                <div class="local-model-desc">本地中文嵌入模型，无需网络连接</div>
+              </div>
+
+              <n-form label-placement="left" label-width="100" style="margin-top: 16px">
+                <n-form-item label="模型路径">
+                  <n-input v-model:value="embeddingForm.model_path" placeholder="BAAI/bge-small-zh-v1.5" />
+                </n-form-item>
+                <n-form-item label="GPU 加速">
+                  <n-switch v-model:value="embeddingForm.use_gpu" />
+                </n-form-item>
+              </n-form>
+            </div>
+
+            <!-- Cloud mode -->
+            <div v-else class="embedding-cloud-form">
+              <n-form label-placement="left" label-width="100">
+                <n-form-item label="API Key">
+                  <n-input
+                    v-model:value="embeddingForm.api_key"
+                    type="password"
+                    show-password-on="click"
+                    placeholder="sk-..."
+                  />
+                </n-form-item>
+
+                <n-form-item label="Base URL">
+                  <n-input
+                    v-model:value="embeddingForm.base_url"
+                    placeholder="https://api.openai.com/v1"
+                  />
+                </n-form-item>
+
+                <n-form-item label="模型">
+                  <div class="model-row">
+                    <n-select
+                      v-model:value="embeddingForm.model"
+                      filterable
+                      tag
+                      :options="embeddingModelOptions"
+                      placeholder="选择或输入模型名称"
+                      style="flex: 1"
+                    />
+                    <n-button
+                      size="small"
+                      :loading="fetchingEmbeddingModels"
+                      :disabled="!embeddingForm.api_key || !embeddingForm.base_url"
+                      @click="handleFetchEmbeddingModels"
+                    >
+                      获取列表
+                    </n-button>
+                  </div>
+                </n-form-item>
+              </n-form>
+            </div>
+
+            <n-space justify="end" style="margin-top: 16px">
+              <n-button
+                type="primary"
+                :loading="embeddingSaving"
+                @click="handleSaveEmbedding"
+              >
+                保存
+              </n-button>
+            </n-space>
+          </template>
+        </div>
+      </n-tab-pane>
+    </n-tabs>
+  </n-modal>
+</template>
+
+<script setup lang="ts">
+import { h, ref, watch } from 'vue'
+import { useMessage } from 'naive-ui'
+import { settingsApi, type LLMConfigProfile, type EmbeddingConfig } from '@/api/settings'
+
+const show = defineModel<boolean>('show', { default: false })
+const message = useMessage()
+
+const IconAdd = () =>
+  h('svg', { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', width: '1em', height: '1em' },
+    h('path', { fill: 'currentColor', d: 'M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z' }))
+
+// ── LLM list state ─────────────────────────────────────────
+const configs = ref<LLMConfigProfile[]>([])
+const activeId = ref<string | null>(null)
+const listLoading = ref(false)
+const activatingId = ref<string | null>(null)
+const deletingId = ref<string | null>(null)
+
+async function loadConfigs() {
+  listLoading.value = true
+  try {
+    const store = await settingsApi.listLLMConfigs()
+    configs.value = store.configs
+    activeId.value = store.active_id
+  } catch {
+    message.error('加载配置失败')
+  } finally {
+    listLoading.value = false
+  }
+}
+
+// ── LLM form state ─────────────────────────────────────────
+const editing = ref(false)
+const editingId = ref<string | null>(null)
+const saving = ref(false)
+const fetchingModels = ref(false)
+const modelOptions = ref<Array<{ label: string; value: string }>>([])
+
+const form = ref({
+  name: '',
+  provider: 'openai' as 'openai' | 'anthropic',
+  api_key: '',
+  base_url: '',
+  model: '',
+  system_model: '',
+  writing_model: '',
+})
+
+const providerOptions = [
+  { label: 'OpenAI Compatible', value: 'openai' },
+  { label: 'Anthropic', value: 'anthropic' },
+]
+
+function startCreate() {
+  editingId.value = null
+  form.value = { name: '', provider: 'openai', api_key: '', base_url: '', model: '', system_model: '', writing_model: '' }
+  modelOptions.value = []
+  editing.value = true
+}
+
+function startEdit(cfg: LLMConfigProfile) {
+  editingId.value = cfg.id
+  form.value = {
+    name: cfg.name,
+    provider: cfg.provider,
+    api_key: cfg.api_key,
+    base_url: cfg.base_url,
+    model: cfg.model,
+    system_model: cfg.system_model || '',
+    writing_model: cfg.writing_model || '',
+  }
+  modelOptions.value = cfg.model ? [{ label: cfg.model, value: cfg.model }] : []
+  editing.value = true
+}
+
+function onProviderChange() {
+  modelOptions.value = []
+  form.value.model = ''
+}
+
+// ── LLM actions ────────────────────────────────────────────
+
+async function handleSave() {
+  saving.value = true
+  try {
+    if (editingId.value) {
+      await settingsApi.updateLLMConfig(editingId.value, { ...form.value })
+      message.success('配置已更新')
+    } else {
+      await settingsApi.createLLMConfig({ ...form.value })
+      message.success('配置已创建')
+    }
+    editing.value = false
+    await loadConfigs()
+  } catch {
+    message.error('保存失败')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function handleActivate(id: string) {
+  activatingId.value = id
+  try {
+    await settingsApi.activateLLMConfig(id)
+    activeId.value = id
+    message.success('配置已激活，立即生效')
+  } catch {
+    message.error('激活失败')
+  } finally {
+    activatingId.value = null
+  }
+}
+
+async function handleDelete(id: string) {
+  deletingId.value = id
+  try {
+    await settingsApi.deleteLLMConfig(id)
+    message.success('配置已删除')
+    await loadConfigs()
+  } catch {
+    message.error('删除失败')
+  } finally {
+    deletingId.value = null
+  }
+}
+
+async function handleFetchModels() {
+  fetchingModels.value = true
+  try {
+    const models = await settingsApi.fetchModels({
+      provider: form.value.provider,
+      api_key: form.value.api_key,
+      base_url: form.value.base_url,
+    })
+    modelOptions.value = models.map((m: string) => ({ label: m, value: m }))
+    if (models.length > 0) {
+      message.success(`获取到 ${models.length} 个模型`)
+    } else {
+      message.warning('未获取到模型列表')
+    }
+  } catch {
+    message.error('获取模型列表失败，请检查 API Key 和 Base URL')
+  } finally {
+    fetchingModels.value = false
+  }
+}
+
+// ── Embedding state ────────────────────────────────────────
+
+const embeddingLoading = ref(false)
+const embeddingSaving = ref(false)
+const fetchingEmbeddingModels = ref(false)
+const embeddingModelOptions = ref<Array<{ label: string; value: string }>>([])
+
+const embeddingForm = ref<EmbeddingConfig>({
+  mode: 'local',
+  api_key: '',
+  base_url: '',
+  model: 'text-embedding-3-small',
+  use_gpu: true,
+  model_path: 'BAAI/bge-small-zh-v1.5',
+})
+
+async function loadEmbeddingConfig() {
+  embeddingLoading.value = true
+  try {
+    const cfg = await settingsApi.getEmbeddingConfig()
+    embeddingForm.value = cfg
+    if (cfg.model) {
+      embeddingModelOptions.value = [{ label: cfg.model, value: cfg.model }]
+    }
+  } catch {
+    message.error('加载嵌入模型配置失败')
+  } finally {
+    embeddingLoading.value = false
+  }
+}
+
+async function handleSaveEmbedding() {
+  embeddingSaving.value = true
+  try {
+    const result = await settingsApi.updateEmbeddingConfig({ ...embeddingForm.value })
+    embeddingForm.value = result
+    message.success('嵌入模型配置已保存，立即生效')
+  } catch {
+    message.error('保存失败')
+  } finally {
+    embeddingSaving.value = false
+  }
+}
+
+async function handleFetchEmbeddingModels() {
+  fetchingEmbeddingModels.value = true
+  try {
+    const models = await settingsApi.fetchEmbeddingModels({
+      provider: 'openai',
+      api_key: embeddingForm.value.api_key,
+      base_url: embeddingForm.value.base_url,
+    })
+    embeddingModelOptions.value = models.map((m: string) => ({ label: m, value: m }))
+    if (models.length > 0) {
+      message.success(`获取到 ${models.length} 个模型`)
+    } else {
+      message.warning('未获取到模型列表')
+    }
+  } catch {
+    message.error('获取模型列表失败，请检查 API Key 和 Base URL')
+  } finally {
+    fetchingEmbeddingModels.value = false
+  }
+}
+
+// ── modal open ─────────────────────────────────────────────
+
+watch(show, (v) => {
+  if (v) {
+    editing.value = false
+    loadConfigs()
+    loadEmbeddingConfig()
+  }
+})
+
+// ── helpers ────────────────────────────────────────────────
+
+function maskKey(key: string): string {
+  if (!key) return ''
+  if (key.length <= 8) return '****'
+  return key.slice(0, 3) + '...' + key.slice(-4)
+}
+
+function truncateUrl(url: string): string {
+  if (url.length <= 35) return url
+  return url.slice(0, 32) + '...'
+}
+</script>
+
+<style scoped>
+.config-section {
+  min-height: 200px;
+}
+
+.config-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.config-count {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.config-loading {
+  display: flex;
+  justify-content: center;
+  padding: 40px;
+}
+
+.config-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: #64748b;
+}
+
+.config-empty p {
+  margin-bottom: 12px;
+}
+
+.config-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.config-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 16px;
+  background: #f8fafc;
+  border-radius: 10px;
+  border: 1.5px solid transparent;
+  transition: all 0.15s ease;
+}
+
+.config-card.active {
+  border-color: #4f46e5;
+  background: rgba(79, 70, 229, 0.04);
+}
+
+.config-card:hover {
+  background: #f1f5f9;
+}
+
+.config-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.config-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #1e293b;
+  margin-bottom: 4px;
+}
+
+.config-detail {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.detail-item {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.key-mask {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.config-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.form-section {
+  min-height: 200px;
+}
+
+.form-title {
+  margin: 0 0 20px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.model-row {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+/* ── Embedding tab ─────────────────────────────────────── */
+
+.embedding-section {
+  min-height: 200px;
+}
+
+.embedding-mode-switch {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 20px 0;
+}
+
+.mode-label {
+  font-size: 14px;
+  color: #94a3b8;
+  transition: color 0.2s;
+}
+
+.mode-label.active {
+  color: #1e293b;
+  font-weight: 600;
+}
+
+.embedding-local-info {
+  padding: 0 4px;
+}
+
+.local-model-card {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 10px;
+  padding: 16px 20px;
+}
+
+.local-model-name {
+  font-weight: 600;
+  font-size: 15px;
+  color: #166534;
+  margin-bottom: 4px;
+}
+
+.local-model-desc {
+  font-size: 13px;
+  color: #4ade80;
+}
+
+.embedding-cloud-form {
+  padding: 0 4px;
+}
+</style>

--- a/frontend/src/components/stats/StatsTopBar.vue
+++ b/frontend/src/components/stats/StatsTopBar.vue
@@ -23,6 +23,12 @@
         <span>{{ stat.tooltip }}</span>
       </n-tooltip>
     </div>
+
+    <div class="settings-trigger" @click="$emit('open-settings')" role="button" aria-label="LLM 设置">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20">
+        <path fill="currentColor" d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 0 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"/>
+      </svg>
+    </div>
   </div>
 </template>
 
@@ -33,6 +39,10 @@ import { useStatsStore } from '@/stores/statsStore'
 
 const props = defineProps<{
   slug: string
+}>()
+
+defineEmits<{
+  'open-settings': []
 }>()
 
 const statsStore = useStatsStore()
@@ -195,6 +205,24 @@ onMounted(async () => {
 .stat-item:hover .stat-value {
   transform: scale(1.05);
   transition: transform 0.2s;
+}
+
+.settings-trigger {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+  border-radius: 8px;
+}
+
+.settings-trigger:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.15);
 }
 
 /* Accessibility: Focus styles */

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -10,6 +10,11 @@
             <h1 class="title">书稿工作台</h1>
             <p class="subtitle">从一句梗概到完整书稿，结构规划与校阅一站完成</p>
           </div>
+          <button class="settings-btn" @click="showLLMSettings = true" aria-label="LLM 设置">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22">
+              <path fill="currentColor" d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 0 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"/>
+            </svg>
+          </button>
         </header>
 
         <!-- Create Card -->
@@ -253,6 +258,9 @@
       @complete="handleSetupComplete"
       @skip="handleSetupSkip"
     />
+
+    <!-- LLM Settings Modal -->
+    <LLMSettingsModal v-model:show="showLLMSettings" />
   </div>
 </template>
 
@@ -263,6 +271,7 @@ import { useMessage, NIcon } from 'naive-ui'
 import { novelApi, type NovelDTO } from '../api/novel'
 import StatsSidebar from '@/components/stats/StatsSidebar.vue'
 import NovelSetupGuide from '@/components/onboarding/NovelSetupGuide.vue'
+import LLMSettingsModal from '@/components/LLMSettingsModal.vue'
 import { useStatsStore } from '@/stores/statsStore'
 
 // Icons
@@ -308,6 +317,7 @@ const books = ref<BookListItem[]>([])
 const searchQuery = ref('')
 const deletingSlug = ref<string | null>(null)
 const showSetupGuide = ref(false)
+const showLLMSettings = ref(false)
 const newNovelId = ref('')
 const newNovelTargetChapters = ref(10)
 
@@ -567,6 +577,7 @@ onMounted(() => {
   text-align: center;
   margin-bottom: 40px;
   animation: fade-up 0.55s ease both;
+  position: relative;
 }
 
 .title {
@@ -582,6 +593,30 @@ onMounted(() => {
   color: #475569;
   margin: 0;
   font-weight: 400;
+}
+
+.settings-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  transition: all 0.18s ease;
+  backdrop-filter: blur(8px);
+}
+
+.settings-btn:hover {
+  background: #fff;
+  color: #4f46e5;
+  box-shadow: 0 2px 10px rgba(79, 70, 229, 0.15);
 }
 
 .create-card {

--- a/frontend/src/views/Workbench.vue
+++ b/frontend/src/views/Workbench.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="workbench">
-    <StatsTopBar :slug="slug" />
+    <StatsTopBar :slug="slug" @open-settings="showLLMSettings = true" />
 
     <n-spin :show="pageLoading" class="workbench-spin" description="加载工作台…">
       <div class="workbench-inner">
@@ -56,6 +56,9 @@
       :act-title="actPlanningTitle"
       @confirmed="handleChapterUpdated"
     />
+
+    <!-- LLM Settings Modal -->
+    <LLMSettingsModal v-model:show="showLLMSettings" />
   </div>
 </template>
 
@@ -71,6 +74,7 @@ import ChapterList from '../components/workbench/ChapterList.vue'
 import WorkArea from '../components/workbench/WorkArea.vue'
 import SettingsPanel from '../components/workbench/SettingsPanel.vue'
 import ActPlanningModal from '../components/workbench/ActPlanningModal.vue'
+import LLMSettingsModal from '../components/LLMSettingsModal.vue'
 
 const route = useRoute()
 const message = useMessage()
@@ -97,6 +101,7 @@ const handleChapterUpdated = async () => {
 
 // 幕→章 规划弹层
 const showActPlanning = ref(false)
+const showLLMSettings = ref(false)
 const actPlanningId = ref('')
 const actPlanningTitle = ref('')
 

--- a/infrastructure/ai/claude_chapter_summarizer.py
+++ b/infrastructure/ai/claude_chapter_summarizer.py
@@ -64,7 +64,7 @@ Requirements:
 
             # 配置生成参数
             config = GenerationConfig(
-                model="claude-3-5-sonnet-20241022",
+                model=os.getenv("WRITING_MODEL", ""),
                 max_tokens=1024,
                 temperature=0.7
             )

--- a/infrastructure/ai/config/settings.py
+++ b/infrastructure/ai/config/settings.py
@@ -10,7 +10,7 @@ class Settings:
     管理 LLM 提供商的配置参数。
     """
 
-    default_model: str = "claude-3-5-sonnet-20241022"
+    default_model: str = ""
     default_temperature: float = 0.7
     default_max_tokens: int = 4096
     api_key: Optional[str] = None

--- a/infrastructure/ai/llm_client.py
+++ b/infrastructure/ai/llm_client.py
@@ -2,6 +2,7 @@
 import os
 from typing import Optional, AsyncIterator
 from infrastructure.ai.providers.anthropic_provider import AnthropicProvider
+from infrastructure.ai.providers.openai_provider import OpenAIProvider
 from infrastructure.ai.providers.mock_provider import MockProvider
 from infrastructure.ai.config.settings import Settings
 from domain.ai.value_objects.prompt import Prompt
@@ -20,11 +21,20 @@ class LLMClient:
         if provider:
             self.provider = provider
         else:
-            # 自动检测 API key 并选择提供者
-            api_key = self._get_api_key()
-            if api_key:
+            # 优先 ARK (OpenAI 兼容)，其次 Anthropic，最后 Mock
+            ark_key = os.getenv("ARK_API_KEY", "").strip()
+            anthropic_key = (os.getenv("ANTHROPIC_API_KEY") or os.getenv("ANTHROPIC_AUTH_TOKEN") or "").strip()
+
+            if ark_key:
                 settings = Settings(
-                    api_key=api_key,
+                    api_key=ark_key,
+                    base_url=os.getenv("ARK_BASE_URL", "").strip() or None,
+                    default_model=os.getenv("ARK_MODEL", ""),
+                )
+                self.provider = OpenAIProvider(settings)
+            elif anthropic_key:
+                settings = Settings(
+                    api_key=anthropic_key,
                     base_url=self._get_base_url()
                 )
                 self.provider = AnthropicProvider(settings)
@@ -62,7 +72,7 @@ class LLMClient:
 
         # 创建 GenerationConfig 对象
         config = GenerationConfig(
-            model=kwargs.get("model", "claude-sonnet-4-6"),
+            model=kwargs.get("model") or os.getenv("WRITING_MODEL", ""),
             max_tokens=kwargs.get("max_tokens", 4096),
             temperature=kwargs.get("temperature", 1.0)
         )

--- a/infrastructure/ai/openai_embedding_service.py
+++ b/infrastructure/ai/openai_embedding_service.py
@@ -15,23 +15,25 @@ class OpenAIEmbeddingService(EmbeddingService):
         """初始化 OpenAI 嵌入服务
 
         Raises:
-            ValueError: 如果 OPENAI_API_KEY 环境变量未设置
+            ValueError: 如果 API Key 环境变量未设置
         """
-        api_key = os.getenv("OPENAI_API_KEY")
+        api_key = os.getenv("EMBEDDING_API_KEY") or os.getenv("OPENAI_API_KEY")
         if not api_key:
-            raise ValueError("OPENAI_API_KEY environment variable is required")
+            raise ValueError("EMBEDDING_API_KEY or OPENAI_API_KEY environment variable is required")
 
-        self.client = AsyncOpenAI(api_key=api_key)
-        self.model = "text-embedding-3-small"
-        self._dimension = 1536
+        base_url = os.getenv("EMBEDDING_BASE_URL") or None
+        self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        self.model = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+        self._dimension: int = 0
 
     def get_dimension(self) -> int:
-        """获取嵌入向量的维度
-
-        Returns:
-            1536 (text-embedding-3-small 模型的维度)
-        """
         return self._dimension
+
+    async def _probe_dimension(self) -> None:
+        if self._dimension > 0:
+            return
+        response = await self.client.embeddings.create(model=self.model, input="dim_probe")
+        self._dimension = len(response.data[0].embedding)
 
     async def embed(self, text: str) -> List[float]:
         """生成单个文本的嵌入向量
@@ -54,7 +56,10 @@ class OpenAIEmbeddingService(EmbeddingService):
                 model=self.model,
                 input=text
             )
-            return response.data[0].embedding
+            vec = response.data[0].embedding
+            if self._dimension == 0:
+                self._dimension = len(vec)
+            return vec
         except Exception as e:
             raise RuntimeError(f"Failed to generate embedding: {str(e)}") from e
 
@@ -82,6 +87,9 @@ class OpenAIEmbeddingService(EmbeddingService):
                 model=self.model,
                 input=texts
             )
-            return [item.embedding for item in response.data]
+            result = [item.embedding for item in response.data]
+            if self._dimension == 0 and result:
+                self._dimension = len(result[0])
+            return result
         except Exception as e:
             raise RuntimeError(f"Failed to generate embeddings: {str(e)}") from e

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -70,7 +70,7 @@ class OpenAIProvider(BaseProvider):
             ]
             
             response = await self.async_client.chat.completions.create(
-                model=config.model or DEFAULT_MODEL,
+                model=config.model or self.settings.default_model,
                 messages=messages,
                 temperature=config.temperature,
                 max_tokens=config.max_tokens,
@@ -119,7 +119,7 @@ class OpenAIProvider(BaseProvider):
             ]
             
             stream = await self.async_client.chat.completions.create(
-                model=config.model or DEFAULT_MODEL,
+                model=config.model or self.settings.default_model,
                 messages=messages,
                 temperature=config.temperature,
                 max_tokens=config.max_tokens,

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -84,7 +84,11 @@ def _anthropic_settings(require_key: bool = True) -> Optional[Settings]:
                 "Set ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN (optional: ANTHROPIC_BASE_URL)"
             )
         return None
-    return Settings(api_key=key, base_url=_anthropic_base_url())
+    return Settings(
+        api_key=key,
+        base_url=_anthropic_base_url(),
+        default_model=os.getenv("WRITING_MODEL", ""),
+    )
 
 
 def _openai_api_key() -> Optional[str]:
@@ -109,7 +113,11 @@ def _openai_settings(require_key: bool = True) -> Optional[Settings]:
                 "Set OPENAI_API_KEY (optional: OPENAI_BASE_URL)"
             )
         return None
-    return Settings(api_key=key, base_url=_openai_base_url())
+    return Settings(
+        api_key=key,
+        base_url=_openai_base_url(),
+        default_model=os.getenv("WRITING_MODEL") or os.getenv("ARK_MODEL", ""),
+    )
 
 
 def get_storage() -> FileStorage:
@@ -427,8 +435,8 @@ def get_embedding_service():
             logger.info(f"Using local embedding service: {model_path}, GPU: {use_gpu}")
             return LocalEmbeddingService(model_name=model_path, use_gpu=use_gpu)
         elif service_type == "openai":
-            if not os.getenv("OPENAI_API_KEY"):
-                logger.warning("EMBEDDING_SERVICE=openai 但 OPENAI_API_KEY 未设置，向量检索已禁用")
+            if not (os.getenv("EMBEDDING_API_KEY") or os.getenv("OPENAI_API_KEY")):
+                logger.warning("EMBEDDING_SERVICE=openai 但 EMBEDDING_API_KEY/OPENAI_API_KEY 未设置，向量检索已禁用")
                 return None
             from infrastructure.ai.openai_embedding_service import OpenAIEmbeddingService
             logger.info("Using OpenAI embedding service")

--- a/interfaces/api/v1/core/settings.py
+++ b/interfaces/api/v1/core/settings.py
@@ -1,0 +1,153 @@
+"""LLM 配置管理 API"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from application.paths import DATA_DIR
+from application.settings.llm_config_manager import LLMConfigManager
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/settings/llm-configs", tags=["settings"])
+
+_manager = LLMConfigManager(DATA_DIR / "llm_configs.json")
+
+
+# ── schemas ──────────────────────────────────────────────────
+
+class ConfigCreate(BaseModel):
+    name: str
+    provider: str  # "openai" | "anthropic"
+    api_key: str
+    base_url: str = ""
+    model: str = ""
+    system_model: str = ""
+    writing_model: str = ""
+
+
+class ConfigUpdate(BaseModel):
+    name: Optional[str] = None
+    provider: Optional[str] = None
+    api_key: Optional[str] = None
+    base_url: Optional[str] = None
+    model: Optional[str] = None
+    system_model: Optional[str] = None
+    writing_model: Optional[str] = None
+
+
+class FetchModelsRequest(BaseModel):
+    provider: str
+    api_key: str
+    base_url: str
+
+
+# ── endpoints ────────────────────────────────────────────────
+
+@router.get("/")
+def list_configs():
+    return _manager.list_configs()
+
+
+@router.post("/")
+def create_config(body: ConfigCreate):
+    return _manager.create_config(body.model_dump())
+
+
+@router.put("/{config_id}")
+def update_config(config_id: str, body: ConfigUpdate):
+    try:
+        return _manager.update_config(config_id, body.model_dump(exclude_none=True))
+    except KeyError:
+        raise HTTPException(404, "Config not found")
+
+
+@router.delete("/{config_id}")
+def delete_config(config_id: str):
+    try:
+        _manager.delete_config(config_id)
+    except KeyError:
+        raise HTTPException(404, "Config not found")
+    return {"ok": True}
+
+
+@router.post("/{config_id}/activate")
+def activate_config(config_id: str):
+    try:
+        _manager.set_active(config_id)
+    except KeyError:
+        raise HTTPException(404, "Config not found")
+    return {"ok": True}
+
+
+_ANTHROPIC_MODELS = [
+    "claude-sonnet-4-6",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-opus-20240229",
+    "claude-3-5-haiku-20241022",
+    "claude-3-haiku-20240307",
+]
+
+
+@router.post("/fetch-models")
+async def fetch_models(body: FetchModelsRequest):
+    if body.provider == "anthropic":
+        return body.base_url and await _fetch_openai_models(body.api_key, body.base_url) or _ANTHROPIC_MODELS
+
+    if not body.base_url:
+        return []
+
+    return await _fetch_openai_models(body.api_key, body.base_url)
+
+
+# ── embedding endpoints ─────────────────────────────────────
+
+embedding_router = APIRouter(prefix="/settings/embedding", tags=["settings"])
+
+
+class EmbeddingConfigUpdate(BaseModel):
+    mode: str = "local"
+    api_key: str = ""
+    base_url: str = ""
+    model: str = "text-embedding-3-small"
+    use_gpu: bool = True
+    model_path: str = "BAAI/bge-small-zh-v1.5"
+
+
+@embedding_router.get("/")
+def get_embedding_config():
+    return _manager.get_embedding_config()
+
+
+@embedding_router.put("/")
+def update_embedding_config(body: EmbeddingConfigUpdate):
+    return _manager.update_embedding_config(body.model_dump())
+
+
+@embedding_router.post("/fetch-models")
+async def fetch_embedding_models(body: FetchModelsRequest):
+    if not body.base_url:
+        return []
+    return await _fetch_openai_models(body.api_key, body.base_url)
+
+
+# ── helpers ─────────────────────────────────────────────────
+
+async def _fetch_openai_models(api_key: str, base_url: str) -> List[str]:
+    url = f"{base_url.rstrip('/')}/models"
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, headers={"Authorization": f"Bearer {api_key}"})
+            resp.raise_for_status()
+            data = resp.json()
+            models = data.get("data", [])
+            return sorted(m["id"] for m in models if "id" in m)
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(502, f"API returned {exc.response.status_code}")
+    except Exception as exc:
+        logger.warning("fetch-models failed: %s", exc)
+        raise HTTPException(502, f"Failed to fetch models: {exc}")

--- a/interfaces/main.py
+++ b/interfaces/main.py
@@ -44,7 +44,7 @@ import threading
 import multiprocessing
 
 # Core module
-from interfaces.api.v1.core import novels, chapters, scene_generation_routes
+from interfaces.api.v1.core import novels, chapters, scene_generation_routes, settings as llm_settings
 
 # World module
 from interfaces.api.v1.world import bible, cast, knowledge, knowledge_graph_routes, worldbuilding_routes
@@ -130,6 +130,13 @@ async def startup_event():
     logger.info("✅ FastAPI application started successfully")
     logger.info(f"📊 Registered {len(app.routes)} routes")
     
+    # 从 JSON 文件恢复上次激活的 LLM 配置
+    try:
+        from application.settings.llm_config_manager import LLMConfigManager
+        LLMConfigManager(DATA_DIR / "llm_configs.json").apply_active_on_startup()
+    except Exception as exc:
+        logger.warning("LLM config restore skipped: %s", exc)
+
     # 重启时将所有运行中的小说设置为停止状态
     _stop_all_running_novels()
     
@@ -325,6 +332,8 @@ app.add_middleware(
 app.include_router(novels.router, prefix="/api/v1")
 app.include_router(chapters.router, prefix="/api/v1/novels")
 app.include_router(scene_generation_routes.router)
+app.include_router(llm_settings.router, prefix="/api/v1")
+app.include_router(llm_settings.embedding_router, prefix="/api/v1")
 
 # World module routes
 app.include_router(bible.router, prefix="/api/v1")


### PR DESCRIPTION
Summary
新增设置弹窗（齿轮按钮），支持在 UI 中管理 LLM 和嵌入模型配置，无需手动编辑 .env 或重启服务
支持多配置切换、热重载、从 API 获取模型列表
新增「写作模型」和「系统模型」两个配置项，消除全部硬编码模型名称
嵌入模型支持本地/云端切换，自动探测向量维度
Changes
后端

新增 application/settings/llm_config_manager.py — JSON 配置存储 + 热重载（写入 os.environ）
新增 interfaces/api/v1/core/settings.py — 9 个 REST 端点（LLM CRUD + 嵌入配置）
移除 6 处硬编码模型名（claude-3-5-haiku、claude-3-5-sonnet 等），统一从 WRITING_MODEL / SYSTEM_MODEL 环境变量读取
OpenAIEmbeddingService 支持独立 EMBEDDING_API_KEY/EMBEDDING_BASE_URL/EMBEDDING_MODEL，向量维度自动探测
前端

新增 LLMSettingsModal.vue — 双 Tab（LLM 模型 / 嵌入模型）
Home 页 + Workbench 页添加齿轮按钮打开设置
新增 frontend/src/api/settings.ts API 客户端

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM configuration management with support for creating, updating, and activating multiple provider profiles
  * Integrated embedding model configuration settings with local and cloud-based modes
  * Added settings modal accessible from main navigation for profile and model management

* **Configuration**
  * Model selection now driven by environment variables instead of hardcoded defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->