### PR TITLE
fix: 切换/编辑 LLM/嵌入配置后重启守护进程以修复热重载失效

### DIFF
--- a/application/settings/llm_config_manager.py
+++ b/application/settings/llm_config_manager.py
@@ -153,6 +153,7 @@ class LLMConfigManager:
             store.active_id = config_id
             self._save(store)
             self._apply_to_env(profile)
+        self._invalidate_caches()
         logger.info("LLM config activated: %s (%s / %s)", profile.name, profile.provider, profile.model)
 
     # ── embedding config ────────────────────────────────────
@@ -170,7 +171,8 @@ class LLMConfigManager:
                     setattr(store.embedding, k, data[k])
             self._save(store)
             self._apply_embedding_to_env(store.embedding)
-            return asdict(store.embedding)
+        self._invalidate_caches()
+        return asdict(store.embedding)
 
     # ── hot-reload ───────────────────────────────────────────
 
@@ -216,9 +218,15 @@ class LLMConfigManager:
         env["WRITING_MODEL"] = writing
         env["SYSTEM_MODEL"] = system
 
+    def _invalidate_caches(self) -> None:
         try:
             from interfaces.api.dependencies import get_background_task_service
             get_background_task_service.cache_clear()
+        except Exception:
+            pass
+        try:
+            from interfaces.main import restart_autopilot_daemon
+            restart_autopilot_daemon()
         except Exception:
             pass
 

--- a/application/settings/llm_config_manager.py
+++ b/application/settings/llm_config_manager.py
@@ -113,13 +113,16 @@ class LLMConfigManager:
                 updated_at=now,
             )
             store.configs.append(profile)
-            if store.active_id is None:
+            became_active = store.active_id is None
+            if became_active:
                 store.active_id = profile.id
                 self._save(store)
                 self._apply_to_env(profile)
             else:
                 self._save(store)
-            return asdict(profile)
+        if became_active:
+            self._invalidate_caches()
+        return asdict(profile)
 
     def update_config(self, config_id: str, data: dict) -> dict:
         with self._lock:
@@ -131,10 +134,16 @@ class LLMConfigManager:
                             setattr(cfg, k, data[k])
                     cfg.updated_at = _now_iso()
                     self._save(store)
-                    if store.active_id == config_id:
+                    is_active = store.active_id == config_id
+                    if is_active:
                         self._apply_to_env(cfg)
-                    return asdict(cfg)
-            raise KeyError(f"Config {config_id} not found")
+                    result = asdict(cfg)
+                    break
+            else:
+                raise KeyError(f"Config {config_id} not found")
+        if is_active:
+            self._invalidate_caches()
+        return result
 
     def delete_config(self, config_id: str) -> None:
         with self._lock:

--- a/interfaces/main.py
+++ b/interfaces/main.py
@@ -289,11 +289,11 @@ def _start_autopilot_daemon_thread():
 def _stop_autopilot_daemon_thread():
     """停止守护进程"""
     global _daemon_process, _daemon_stop_event
-    
+
     if _daemon_stop_event:
         logger.info("🛑 正在停止守护进程...")
         _daemon_stop_event.set()
-        
+
     if _daemon_process and _daemon_process.is_alive():
         _daemon_process.join(timeout=5)  # 等待最多5秒
         if _daemon_process.is_alive():
@@ -302,9 +302,16 @@ def _stop_autopilot_daemon_thread():
             _daemon_process.join(timeout=2)
         else:
             logger.info("✅ 守护进程已成功停止")
-    
+
     _daemon_process = None
     _daemon_stop_event = None
+
+
+def restart_autopilot_daemon():
+    """重启守护进程以拾取新的 LLM / 嵌入配置（跨进程 env 不可共享，必须重启）。"""
+    _stop_autopilot_daemon_thread()
+    _start_autopilot_daemon_thread()
+    logger.info("🔄 守护进程已因配置变更重启")
 
 
 # 配置 CORS


### PR DESCRIPTION
修复网页端切换 LLM/嵌入模型配置后守护进程仍使用旧配置的问题
根因：自动驾驶守护进程运行在独立的 multiprocessing.Process 中，主进程通过 os.environ 修改的环境变量无法跨进程传递
新增 restart_autopilot_daemon() 函数，在配置激活或嵌入模型变更时自动停止旧进程并启动新进程（继承最新环境变量）
启动阶段 apply_active_on_startup() 不触发重启，避免守护进程重复创建

那么代价是什么呢，每次切换编辑都会重启进程守护。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autopilot daemon automatically restarts when LLM or embedding configurations are updated.
  * Enhanced cache invalidation for configuration changes.

* **Bug Fixes**
  * Improved configuration update handling to ensure changes take effect immediately across all components.
  * Fixed stale cache issues that could prevent configuration changes from being fully applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->