### PR TITLE
fix: 添加了第三方api中转对Anthropic格式的支持

### DIFF
--- a/infrastructure/ai/providers/anthropic_provider.py
+++ b/infrastructure/ai/providers/anthropic_provider.py
@@ -41,22 +41,26 @@ class AnthropicProvider(BaseProvider):
         if not settings.api_key:
             raise ValueError("API key is required for AnthropicProvider")
 
-        # 官方 SDK 客户端 - 不设置 base_url，直接走官方 API (HTTPS)
-        # 用于 generate() (规划/分析等场景)
+        # 归一化 base_url：去掉尾部 /v1（SDK 内部会自动拼 /v1/messages）
+        base = settings.base_url.rstrip("/") if settings.base_url else None
+        if base and base.endswith("/v1"):
+            base = base[:-3]
+
         official_client_kw = {
             "api_key": settings.api_key,
-            "timeout": 300.0,  # 5分钟超时
-            "max_retries": 5,  # 增加重试次数
+            "timeout": 300.0,
+            "max_retries": 5,
             "default_headers": {
                 "User-Agent": "claude-cli/2.1.87 (external, cli)",
             },
         }
+        if base:
+            official_client_kw["base_url"] = base
         self.client = Anthropic(**official_client_kw)
         self.async_client = AsyncAnthropic(**official_client_kw)
 
-        # 代理地址 - 用于 stream_generate() (正文生成)
-        # 如果设置了 base_url，则使用代理；否则回退到官方 API
-        self.proxy_base_url = settings.base_url
+        # 归一化后的 base_url，供 stream_generate() httpx 使用
+        self.proxy_base_url = base
 
     async def generate(
         self,
@@ -78,11 +82,11 @@ class AnthropicProvider(BaseProvider):
         try:
             # 构建请求参数
             create_kwargs = {
-                "model": config.model or DEFAULT_MODEL,
+                "model": config.model or self.settings.default_model or DEFAULT_MODEL,
                 "temperature": config.temperature,
                 "max_tokens": config.max_tokens,
                 "system": prompt.system,
-                "messages": prompt.to_messages(),
+                "messages": [{"role": "user", "content": prompt.user}],
             }
             # 如果指定了 response_format，传递给 API 强制 JSON 输出
             if config.response_format:
@@ -95,8 +99,13 @@ class AnthropicProvider(BaseProvider):
             if not response.content:
                 raise RuntimeError("API returned empty content")
 
-            # 提取响应内容
-            content = response.content[0].text
+            content = ""
+            for block in response.content:
+                if getattr(block, "type", None) == "text":
+                    content = block.text
+                    break
+            if not content:
+                raise RuntimeError("API returned no text content")
 
             # 创建 token 使用统计
             token_usage = TokenUsage(
@@ -136,7 +145,7 @@ class AnthropicProvider(BaseProvider):
         }
 
         payload = {
-            "model": config.model or DEFAULT_MODEL,
+            "model": config.model or self.settings.default_model or DEFAULT_MODEL,
             "max_tokens": config.max_tokens,
             "temperature": config.temperature,
             "system": prompt.system,

--- a/interfaces/api/v1/core/settings.py
+++ b/interfaces/api/v1/core/settings.py
@@ -84,19 +84,10 @@ def activate_config(config_id: str):
     return {"ok": True}
 
 
-_ANTHROPIC_MODELS = [
-    "claude-sonnet-4-6",
-    "claude-3-5-sonnet-20241022",
-    "claude-3-opus-20240229",
-    "claude-3-5-haiku-20241022",
-    "claude-3-haiku-20240307",
-]
-
-
 @router.post("/fetch-models")
 async def fetch_models(body: FetchModelsRequest):
     if body.provider == "anthropic":
-        return body.base_url and await _fetch_openai_models(body.api_key, body.base_url) or _ANTHROPIC_MODELS
+        return await _fetch_anthropic_models(body.api_key, body.base_url)
 
     if not body.base_url:
         return []
@@ -151,3 +142,30 @@ async def _fetch_openai_models(api_key: str, base_url: str) -> List[str]:
     except Exception as exc:
         logger.warning("fetch-models failed: %s", exc)
         raise HTTPException(502, f"Failed to fetch models: {exc}")
+
+
+async def _fetch_anthropic_models(api_key: str, base_url: str) -> List[str]:
+    base = (base_url or "https://api.anthropic.com").rstrip("/")
+    if base.endswith("/v1"):
+        url = f"{base}/models"
+    else:
+        url = f"{base}/v1/models"
+    headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, headers=headers, params={"limit": 1000})
+            resp.raise_for_status()
+            data = resp.json()
+            models = data.get("data", [])
+            return sorted(m["id"] for m in models if "id" in m)
+    except Exception as exc:
+        if not base_url:
+            raise HTTPException(502, f"Failed to fetch Anthropic models: {exc}")
+        logger.info("Anthropic-style fetch failed, trying OpenAI-style: %s", exc)
+        try:
+            fallback_base = base_url.rstrip("/")
+            if not fallback_base.endswith("/v1"):
+                fallback_base += "/v1"
+            return await _fetch_openai_models(api_key, fallback_base)
+        except Exception:
+            raise HTTPException(502, f"Failed to fetch models (tried both Anthropic and OpenAI format): {exc}")


### PR DESCRIPTION
增加了使用Anthropic格式调用第三方中转站的功能
但是有什么意义呢？谁会在中转站使用Anthropic格式调用模型？


Anthropic 提供商

generate() 的 messages 包含了 Anthropic 不支持的 "role": "system"，导致代理返回 500；改为仅传 user message，system prompt 走顶层参数
generate() 未传 base_url 给 SDK，自定义代理对调用不生效
兼容 Extended Thinking：遍历 response.content 找 TextBlock，不再硬取 index 0
base_url 统一归一化，strip 尾部 /v1，避免拼接出 /v1/v1/messages
model fallback chain：config.model → settings.default_model → DEFAULT_MODEL

模型列表获取

移除硬编码 _ANTHROPIC_MODELS，改为实时调用 /v1/models API
支持 Anthropic 原生认证（x-api-key）失败后自动 fallback 到 OpenAI Bearer 认证
fallback 时正确补全 /v1 路径



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic API endpoint normalization and configuration reliability
  * Enhanced response parsing to correctly identify and extract text content
  * Added fallback mechanism for model fetching to improve resilience

* **Refactor**
  * Optimized model selection to prioritize configured default models
  * Streamlined Anthropic integration initialization logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->