### PR TITLE
修复 LLM 规划与地图生成的 JSON 解析容错

### DIFF
--- a/application/blueprint/services/continuous_planning_service.py
+++ b/application/blueprint/services/continuous_planning_service.py
@@ -6,8 +6,10 @@
 import json
 import uuid
 import logging
+import re
 from typing import Dict, List, Optional
 from datetime import datetime
+from json_repair import repair_json
 
 from domain.structure.story_node import StoryNode, NodeType, PlanningStatus, PlanningSource
 from domain.structure.chapter_element import ChapterElement, ElementType, RelationType, Importance
@@ -22,6 +24,133 @@ from domain.ai.value_objects.prompt import Prompt
 from application.audit.services.macro_merge_engine import MacroMergeEngine, MergePlan, MergeConflictException
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_llm_json_output(raw: str) -> str:
+    content = (raw or "").strip()
+    content = re.sub(r"\x1b\[[0-9;]*m", "", content)
+    content = re.sub(r"<think\|?>.*?</think\|?>", "", content, flags=re.DOTALL)
+    content = re.sub(r"<thinking>.*?</thinking>", "", content, flags=re.DOTALL)
+    if "```json" in content:
+        content = content.split("```json", 1)[1].split("```", 1)[0]
+    elif "```" in content:
+        content = content.split("```", 1)[1].split("```", 1)[0]
+    return content.strip()
+
+
+def _extract_outer_json_value(text: str) -> str:
+    starts = [idx for idx in (text.find("{"), text.find("[")) if idx != -1]
+    if not starts:
+        return text
+    start = min(starts)
+
+    root_char = text[start]
+    root_close = "}" if root_char == "{" else "]"
+    depth = 0
+    in_string = False
+    escape = False
+
+    for idx in range(start, len(text)):
+        ch = text[idx]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\" and in_string:
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == root_char:
+            depth += 1
+            continue
+        if ch == root_close:
+            depth -= 1
+            if depth == 0:
+                return text[start : idx + 1]
+    return text[start:]
+
+
+def _repair_json_string(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return text
+
+    try:
+        json.loads(text)
+        return text
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    def _close_json(s: str) -> str:
+        s = s.strip()
+        if not s:
+            return "{}"
+
+        in_string = False
+        escape = False
+        stack = []
+        result = []
+
+        for ch in s:
+            if escape:
+                result.append(ch)
+                escape = False
+                continue
+            if ch == "\\" and in_string:
+                result.append(ch)
+                escape = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                result.append(ch)
+                continue
+            if in_string:
+                result.append(ch)
+                continue
+            if ch == "{":
+                stack.append("}")
+                result.append(ch)
+                continue
+            if ch == "[":
+                stack.append("]")
+                result.append(ch)
+                continue
+            if ch in "}]":
+                if stack and stack[-1] == ch:
+                    stack.pop()
+                result.append(ch)
+                continue
+            result.append(ch)
+
+        if in_string:
+            result.append('"')
+
+        repaired = "".join(result).rstrip()
+        while repaired.endswith(","):
+            repaired = repaired[:-1].rstrip()
+        while stack:
+            while repaired.endswith(","):
+                repaired = repaired[:-1].rstrip()
+            repaired += stack.pop()
+        return repaired
+
+    candidate = text
+    retries = 15
+    while retries > 0 and candidate:
+        repaired = _close_json(candidate)
+        try:
+            json.loads(repaired)
+            return repaired
+        except json.JSONDecodeError:
+            last_comma = candidate.rfind(",")
+            if last_comma == -1:
+                break
+            candidate = candidate[:last_comma]
+        retries -= 1
+    return _close_json(text)
 
 
 # 导出 MergeConflictException 供路由层使用
@@ -729,35 +858,32 @@ class ContinuousPlanningService:
         """解析 LLM 响应"""
         # 如果是 GenerationResult 对象，提取 content 属性
         if hasattr(response, 'content'):
-            content = response.content.strip()
+            content = response.content
         else:
-            content = response.strip()
+            content = response
 
-        # 查找 JSON 代码块
-        if "```json" in content:
-            # 提取 ```json 和 ``` 之间的内容
-            start = content.find("```json") + 7
-            end = content.find("```", start)
-            if end != -1:
-                content = content[start:end].strip()
-        elif "```" in content:
-            # 提取第一个 ``` 和最后一个 ``` 之间的内容
-            start = content.find("```") + 3
-            end = content.rfind("```")
-            if end != -1 and end > start:
-                content = content[start:end].strip()
+        cleaned = _sanitize_llm_json_output(content)
+        cleaned = _extract_outer_json_value(cleaned)
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError:
+            pass
 
-        # 如果还有前缀文字，尝试找到 JSON 开始的位置
-        if not content.startswith("{") and not content.startswith("["):
-            # 查找第一个 { 或 [
-            json_start = min(
-                content.find("{") if "{" in content else len(content),
-                content.find("[") if "[" in content else len(content)
-            )
-            if json_start < len(content):
-                content = content[json_start:]
+        try:
+            repaired = repair_json(cleaned)
+            return json.loads(repaired)
+        except Exception:
+            pass
 
-        return json.loads(content)
+        cleaned = _repair_json_string(cleaned)
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError as e:
+            logger.error("Failed to parse planning JSON: %s", e)
+            logger.error("Planning content length: %d", len(cleaned))
+            logger.error("Planning raw content (first 1000 chars): %s", cleaned[:1000])
+            logger.error("Planning raw content (last 500 chars): %s", cleaned[-500:])
+            raise
 
     def _calculate_chapter_distribution(self, total_chapters: int, parts: int) -> Dict[str, List[int]]:
         """计算黄金比例的章数分配

--- a/application/blueprint/services/continuous_planning_service.py
+++ b/application/blueprint/services/continuous_planning_service.py
@@ -39,10 +39,14 @@ def _sanitize_llm_json_output(raw: str) -> str:
 
 
 def _extract_outer_json_value(text: str) -> str:
-    starts = [idx for idx in (text.find("{"), text.find("[")) if idx != -1]
-    if not starts:
+    obj_start = text.find("{")
+    arr_start = text.find("[")
+    if obj_start != -1:
+        start = obj_start
+    elif arr_start != -1:
+        start = arr_start
+    else:
         return text
-    start = min(starts)
 
     root_char = text[start]
     root_close = "}" if root_char == "{" else "]"

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -455,54 +455,12 @@ JSON 格式（不要有其他文字）：
 
 只输出 JSON，不要有任何解释文字。"""
 
-        prompt = Prompt(system=system_prompt, user=user_prompt)
-        config = GenerationConfig(max_tokens=2048, temperature=0.7)
+        bible_data = await self._call_llm_and_parse(system_prompt, user_prompt)
+        if bible_data:
+            return bible_data
 
-        result = await self.llm_service.generate(prompt, config)
-
-        # 解析 JSON
-        try:
-            content = result.content.strip()
-
-            # 移除可能的 markdown 代码块标记
-            if "```json" in content:
-                content = content.split("```json")[1].split("```")[0]
-            elif "```" in content:
-                content = content.split("```")[1].split("```")[0]
-
-            content = content.strip()
-
-            # 尝试找到第一个 { 和最后一个 }
-            start = content.find('{')
-            end = content.rfind('}')
-            if start != -1 and end != -1:
-                content = content[start:end+1]
-
-            logger.info(f"Attempting to parse Bible JSON (length: {len(content)})")
-
-            # 尝试直接解析
-            try:
-                bible_data = json.loads(content)
-                logger.info(f"Successfully parsed Bible JSON")
-                return bible_data
-            except json.JSONDecodeError as e:
-                # 如果失败，尝试修复常见问题
-                logger.warning(f"First parse attempt failed: {e}, trying to repair JSON...")
-
-                # 使用 json.loads 的 strict=False 模式
-                import re
-                # 移除字符串中的控制字符和多余的空白
-                content = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', content)
-
-                bible_data = json.loads(content, strict=False)
-                logger.info(f"Successfully parsed Bible JSON after repair")
-                return bible_data
-
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse Bible JSON: {e}")
-            logger.error(f"Raw content (first 1000 chars): {content[:1000]}")
-            # 返回默认结构
-            return {
+        logger.error("Failed to generate Bible data, falling back to default structure")
+        return {
                 "characters": [
                     {
                         "name": "主角",

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -3,6 +3,7 @@ import logging
 import json
 import uuid
 import sys
+import re
 from typing import Dict, Any
 from datetime import datetime
 from domain.ai.services.llm_service import LLMService, GenerationConfig
@@ -14,6 +15,118 @@ from infrastructure.persistence.database.triple_repository import TripleReposito
 from domain.shared.exceptions import EntityNotFoundError
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_llm_json_output(raw: str) -> str:
+    content = (raw or "").strip()
+    content = re.sub(r"\x1b\[[0-9;]*m", "", content)
+    content = re.sub(r"<think\|?>.*?</think\|?>", "", content, flags=re.DOTALL)
+    content = re.sub(r"<thinking>.*?</thinking>", "", content, flags=re.DOTALL)
+    if "```json" in content:
+        content = content.split("```json", 1)[1].split("```", 1)[0]
+    elif "```" in content:
+        content = content.split("```", 1)[1].split("```", 1)[0]
+    return content.strip()
+
+
+def _extract_outer_json_object(text: str) -> str:
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1:
+        return text
+    if end != -1 and end > start:
+        return text[start : end + 1]
+    return text[start:]
+
+
+def _repair_json_string(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return text
+
+    try:
+        json.loads(text)
+        return text
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    def _close_json(s: str) -> str:
+        s = s.strip()
+        if not s:
+            return "{}"
+
+        in_string = False
+        escape = False
+        stack = []
+        result = []
+
+        for ch in s:
+            if escape:
+                result.append(ch)
+                escape = False
+                continue
+            if ch == "\\" and in_string:
+                result.append(ch)
+                escape = True
+                continue
+            if ch == '"':
+                in_string = not in_string
+                result.append(ch)
+                continue
+            if in_string:
+                result.append(ch)
+                continue
+            if ch == "{":
+                stack.append("}")
+                result.append(ch)
+                continue
+            if ch == "[":
+                stack.append("]")
+                result.append(ch)
+                continue
+            if ch in "}]":
+                if stack and stack[-1] == ch:
+                    stack.pop()
+                result.append(ch)
+                continue
+            result.append(ch)
+
+        if in_string:
+            result.append('"')
+
+        repaired = "".join(result).rstrip()
+        while repaired.endswith(","):
+            repaired = repaired[:-1].rstrip()
+        while stack:
+            while repaired.endswith(","):
+                repaired = repaired[:-1].rstrip()
+            repaired += stack.pop()
+        return repaired
+
+    candidate = text
+    retries = 15
+    while retries > 0 and candidate:
+        repaired = _close_json(candidate)
+        try:
+            json.loads(repaired)
+            return repaired
+        except json.JSONDecodeError:
+            last_comma = candidate.rfind(",")
+            if last_comma == -1:
+                break
+            candidate = candidate[:last_comma]
+        retries -= 1
+    return _close_json(text)
+
+
+def _parse_llm_json_to_dict(raw: str) -> Dict[str, Any]:
+    cleaned = _sanitize_llm_json_output(raw)
+    cleaned = _extract_outer_json_object(cleaned)
+    cleaned = _repair_json_string(cleaned)
+    data = json.loads(cleaned)
+    if not isinstance(data, dict):
+        raise json.JSONDecodeError("Root node is not a JSON object", cleaned, 0)
+    return data
 
 
 def _infer_character_importance(char_data: Dict[str, Any]) -> str:
@@ -739,31 +852,16 @@ JSON 格式：
     async def _call_llm_and_parse(self, system_prompt: str, user_prompt: str) -> Dict[str, Any]:
         """调用 LLM 并解析 JSON"""
         prompt = Prompt(system=system_prompt, user=user_prompt)
-        config = GenerationConfig(max_tokens=2048, temperature=0.7)
+        config = GenerationConfig(max_tokens=4096, temperature=0.7)
         result = await self.llm_service.generate(prompt, config)
 
+        content = ""
         try:
-            content = result.content.strip()
-
-            # 移除可能的 markdown 代码块标记
-            if "```json" in content:
-                content = content.split("```json")[1].split("```")[0]
-            elif "```" in content:
-                content = content.split("```")[1].split("```")[0]
-
-            content = content.strip()
-
-            # 尝试找到第一个 { 和最后一个 }
-            start = content.find('{')
-            end = content.rfind('}')
-            if start != -1 and end != -1:
-                content = content[start:end+1]
-
-            parsed = json.loads(content)
-            return parsed
+            content = _sanitize_llm_json_output(result.content)
+            return _parse_llm_json_to_dict(content)
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON: {e}")
             logger.error(f"Content length: {len(content)}")
+            logger.error(f"Failed to parse JSON: {e}")
             logger.error(f"Raw content (first 1000 chars): {content[:1000]}")
             logger.error(f"Raw content (last 500 chars): {content[-500:]}")
             return {}

--- a/tests/unit/application/services/test_auto_bible_generator.py
+++ b/tests/unit/application/services/test_auto_bible_generator.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+from application.world.services.auto_bible_generator import AutoBibleGenerator
+from domain.ai.services.llm_service import GenerationResult
+from domain.ai.value_objects.token_usage import TokenUsage
+
+
+@pytest.mark.asyncio
+async def test_call_llm_and_parse_repairs_truncated_locations_json():
+    llm = Mock()
+    llm.generate = AsyncMock(
+        return_value=GenerationResult(
+            content="""```json
+{
+  "locations": [
+    {
+      "id": "location_imperial_capital",
+      "name": "应天府",
+      "type": "城市",
+      "description": "大明王朝皇都",
+      "parent_id": null,
+      "connections": [
+        {
+          "target": "location_taoyuan_paradise",
+          "relation": "统辖",
+          "description": "皇室共管洞天"
+        }
+      ]
+    }
+  ]
+""",
+            token_usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+    )
+    svc = AutoBibleGenerator(llm_service=llm, bible_service=Mock())
+
+    result = await svc._call_llm_and_parse("system", "user")
+
+    assert result["locations"][0]["id"] == "location_imperial_capital"
+    assert result["locations"][0]["connections"][0]["relation"] == "统辖"
+    _, config = llm.generate.await_args.args
+    assert config.max_tokens == 4096
+
+
+@pytest.mark.asyncio
+async def test_call_llm_and_parse_returns_empty_dict_when_content_is_unrecoverable():
+    llm = Mock()
+    llm.generate = AsyncMock(
+        return_value=GenerationResult(
+            content="not json at all",
+            token_usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+    )
+    svc = AutoBibleGenerator(llm_service=llm, bible_service=Mock())
+
+    result = await svc._call_llm_and_parse("system", "user")
+
+    assert result == {}

--- a/tests/unit/application/services/test_auto_bible_generator.py
+++ b/tests/unit/application/services/test_auto_bible_generator.py
@@ -57,3 +57,21 @@ async def test_call_llm_and_parse_returns_empty_dict_when_content_is_unrecoverab
     result = await svc._call_llm_and_parse("system", "user")
 
     assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_generate_bible_data_uses_hardened_parser_path():
+    llm = Mock()
+    llm.generate = AsyncMock(
+        return_value=GenerationResult(
+            content='{"characters":[],"locations":[],"style":"s","worldbuilding":{}}',
+            token_usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+    )
+    svc = AutoBibleGenerator(llm_service=llm, bible_service=Mock())
+
+    result = await svc._generate_bible_data("premise", 10)
+
+    assert result["style"] == "s"
+    _, config = llm.generate.await_args.args
+    assert config.max_tokens == 4096

--- a/tests/unit/application/services/test_continuous_planning_service.py
+++ b/tests/unit/application/services/test_continuous_planning_service.py
@@ -1,0 +1,96 @@
+from unittest.mock import Mock
+
+from application.blueprint.services.continuous_planning_service import ContinuousPlanningService
+
+
+def _make_service() -> ContinuousPlanningService:
+    return ContinuousPlanningService(
+        story_node_repo=Mock(),
+        chapter_element_repo=Mock(),
+        llm_service=Mock(),
+    )
+
+
+def test_parse_llm_response_repairs_truncated_macro_plan_json():
+    svc = _make_service()
+
+    response = """```json
+{
+  "parts": [
+    {
+      "title": "第一部",
+      "volumes": [
+        {
+          "title": "卷一",
+          "acts": [
+            {
+              "title": "初入京城",
+              "description": "主角进入京城，卷入风暴",
+              "core_conflict": "必须在权斗中站稳脚跟"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "theme": "权谋成长"
+"""
+
+    result = svc._parse_llm_response(response)
+
+    assert result["theme"] == "权谋成长"
+    assert result["parts"][0]["volumes"][0]["acts"][0]["title"] == "初入京城"
+
+
+def test_parse_llm_response_repairs_unterminated_string():
+    svc = _make_service()
+
+    response = """{
+  "parts": [
+    {
+      "title": "第一部",
+      "volumes": [
+        {
+          "title": "卷一",
+          "acts": [
+            {
+              "title": "初入京城",
+              "description": "主角进入京城",
+              "core_conflict": "站稳脚跟"
+            },
+            {
+              "title": "风暴将至",
+              "description": "主角发现
+"""
+
+    result = svc._parse_llm_response(response)
+
+    acts = result["parts"][0]["volumes"][0]["acts"]
+    assert len(acts) == 2
+    assert acts[0]["title"] == "初入京城"
+    assert acts[1]["title"] == "风暴将至"
+
+
+def test_parse_llm_response_repairs_missing_comma_between_fields():
+    svc = _make_service()
+
+    response = """{
+  "parts": [
+    {
+      "title": "第一部"
+      "volumes": [
+        {
+          "title": "卷一",
+          "acts": []
+        }
+      ]
+    }
+  ],
+  "theme": "权谋成长"
+}"""
+
+    result = svc._parse_llm_response(response)
+
+    assert result["theme"] == "权谋成长"
+    assert result["parts"][0]["title"] == "第一部"
+    assert result["parts"][0]["volumes"][0]["title"] == "卷一"

--- a/tests/unit/application/services/test_continuous_planning_service.py
+++ b/tests/unit/application/services/test_continuous_planning_service.py
@@ -1,6 +1,9 @@
 from unittest.mock import Mock
 
-from application.blueprint.services.continuous_planning_service import ContinuousPlanningService
+from application.blueprint.services.continuous_planning_service import (
+    ContinuousPlanningService,
+    _extract_outer_json_value,
+)
 
 
 def _make_service() -> ContinuousPlanningService:
@@ -94,3 +97,11 @@ def test_parse_llm_response_repairs_missing_comma_between_fields():
     assert result["theme"] == "权谋成长"
     assert result["parts"][0]["title"] == "第一部"
     assert result["parts"][0]["volumes"][0]["title"] == "卷一"
+
+
+def test_extract_outer_json_value_prefers_object_root_over_leading_array():
+    text = '["noise"] {"parts": [], "theme": "x"}'
+
+    result = _extract_outer_json_value(text)
+
+    assert result == '{"parts": [], "theme": "x"}'


### PR DESCRIPTION
## 变更说明
- 为宏观规划 JSON 响应增加清洗、结构提取与 `json_repair` 修复流程
- 为 Bible 地图生成增加截断 JSON 自愈与更高的 `max_tokens` 配置
- 补充单元测试，覆盖截断、未闭合字符串、缺逗号等坏 JSON 场景

## 验证
- `python -m pytest tests/unit/application/services/test_auto_bible_generator.py tests/unit/application/services/test_continuous_planning_service.py -q`

## 备注
- 未包含工作区中的 `frontend/package-lock.json` 变更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened LLM/JSON response parsing to better handle ANSI escapes, code-fenced fragments, truncated or malformed JSON, and other noisy outputs; improved fallback repair and failure diagnostics.
* **Tests**
  * Added unit tests covering many malformed-response scenarios to validate parsing recovery and overall robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->