### PR TITLE
refine sidebar quick action button styles across themes

### DIFF
--- a/frontend/src/components/global/GlobalLLMEntryButton.vue
+++ b/frontend/src/components/global/GlobalLLMEntryButton.vue
@@ -10,21 +10,32 @@
       <span class="global-llm-glow"></span>
 
       <span class="global-llm-main-content">
-        <span class="global-llm-icon-core">
-          <span class="global-llm-icon-grid"></span>
-          <span class="global-llm-icon-chip">⚙️</span>
-          <span class="global-llm-icon-spark">✦</span>
-        </span>
+        <template v-if="appearance === 'sidebar'">
+          <span class="global-llm-plain-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="3.2" stroke="currentColor" stroke-width="1.8"/>
+              <path d="M12 3.5v2.2M12 18.3v2.2M20.5 12h-2.2M5.7 12H3.5M18.4 5.6l-1.6 1.6M7.2 16.8l-1.6 1.6M18.4 18.4l-1.6-1.6M7.2 7.2 5.6 5.6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+          </span>
+          <span class="global-llm-title">AI 控制台</span>
+        </template>
+        <template v-else>
+          <span class="global-llm-icon-core">
+            <span class="global-llm-icon-grid"></span>
+            <span class="global-llm-icon-chip">⚙️</span>
+            <span class="global-llm-icon-spark">✦</span>
+          </span>
 
-        <span class="global-llm-copy">
-          <span class="global-llm-title-row">
-            <span class="global-llm-title">AI 控制台</span>
-            <span class="global-llm-status"></span>
+          <span class="global-llm-copy">
+            <span class="global-llm-title-row">
+              <span class="global-llm-title">AI 控制台</span>
+              <span class="global-llm-status"></span>
+            </span>
+            <span class="global-llm-subtitle">
+              {{ drawerTab === 'embedding' ? '嵌入模型 · 向量检索配置' : 'LLM Gateway · OpenAI / Claude / Gemini' }}
+            </span>
           </span>
-          <span v-if="appearance !== 'sidebar'" class="global-llm-subtitle">
-            {{ drawerTab === 'embedding' ? '嵌入模型 · 向量检索配置' : 'LLM Gateway · OpenAI / Claude / Gemini' }}
-          </span>
-        </span>
+        </template>
       </span>
     </button>
 
@@ -380,10 +391,14 @@ function openPanel() {
 
 .global-llm-main.variant-sidebar {
   width: 100%;
-  min-height: 0;
-  padding: 14px 12px;
-  border-radius: 12px;
-  box-shadow: var(--app-shadow-sm), 0 1px 3px rgba(0, 0, 0, 0.05);
+  box-sizing: border-box;
+  min-height: 58px;
+  padding: 0 14px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--color-brand-hover, #6366f1) 0%, var(--color-brand, #4f46e5) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  color: var(--app-text-inverse, #ffffff);
+  border: 1px solid color-mix(in srgb, var(--color-brand, #4f46e5) 52%, transparent);
+  box-shadow: none;
 }
 
 .global-llm-main:hover {
@@ -393,7 +408,10 @@ function openPanel() {
 }
 
 .global-llm-main.variant-sidebar:hover {
-  box-shadow: var(--app-shadow-sm), 0 2px 8px var(--color-brand-border, rgba(79, 70, 229, 0.18));
+  filter: none;
+  transform: none;
+  background: linear-gradient(135deg, var(--color-brand, #4f46e5) 0%, var(--color-brand-hover, #6366f1) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  box-shadow: none;
 }
 
 .global-llm-glow {
@@ -413,8 +431,40 @@ function openPanel() {
   gap: 12px;
 }
 .global-llm-main.variant-sidebar .global-llm-main-content {
-  flex-direction: column;
-  gap: 6px;
+  flex-direction: row;
+  justify-content: center;
+  gap: 8px;
+}
+
+.global-llm-main.variant-sidebar .global-llm-glow {
+  display: none;
+}
+
+.global-llm-plain-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--app-text-inverse, #ffffff);
+}
+
+.global-llm-plain-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+[data-theme='anchor'] .global-llm-main.variant-sidebar {
+  background: linear-gradient(135deg, var(--color-brand-hover, #ddb930) 0%, var(--color-brand, #c9a227) 55%, var(--color-brand-pressed, #a88a1f) 100%);
+  border-color: color-mix(in srgb, var(--color-brand, #c9a227) 62%, transparent);
+  box-shadow: none;
+}
+
+[data-theme='anchor'] .global-llm-main.variant-sidebar:hover {
+  transform: none;
+  filter: none;
+  border-color: color-mix(in srgb, var(--color-brand, #c9a227) 74%, transparent);
+  box-shadow: none;
 }
 
 .global-llm-icon-core {
@@ -501,7 +551,10 @@ function openPanel() {
   letter-spacing: 0.02em;
 }
 .global-llm-main.variant-sidebar .global-llm-title { 
-  font-size: 12px; 
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .global-llm-status {

--- a/frontend/src/components/global/PromptPlazaEntryButton.vue
+++ b/frontend/src/components/global/PromptPlazaEntryButton.vue
@@ -11,21 +11,31 @@
       <span class="plaza-glow"></span>
 
       <span class="plaza-main-content">
-        <span class="plaza-icon-core">
-          <span class="plaza-icon-grid"></span>
-          <span class="plaza-icon-chip">P</span>
-          <span class="plaza-icon-spark"></span>
-        </span>
+        <template v-if="appearance === 'sidebar'">
+          <span class="plaza-plain-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M6 19h12M6 5h12M7 9h10M7 13h10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+          </span>
+          <span class="plaza-title">提示词广场</span>
+        </template>
+        <template v-else>
+          <span class="plaza-icon-core">
+            <span class="plaza-icon-grid"></span>
+            <span class="plaza-icon-chip">P</span>
+            <span class="plaza-icon-spark"></span>
+          </span>
 
-        <span class="plaza-copy">
-          <span class="plaza-title-row">
-            <span class="plaza-title">提示词广场</span>
-            <span v-if="promptCount > 0" class="plaza-count">{{ promptCount }}</span>
+          <span class="plaza-copy">
+            <span class="plaza-title-row">
+              <span class="plaza-title">提示词广场</span>
+              <span v-if="promptCount > 0" class="plaza-count">{{ promptCount }}</span>
+            </span>
+            <span class="plaza-subtitle">
+              浏览 · 编辑 · 版本管理
+            </span>
           </span>
-          <span v-if="appearance !== 'sidebar'" class="plaza-subtitle">
-            浏览 · 编辑 · 版本管理
-          </span>
-        </span>
+        </template>
       </span>
     </button>
 
@@ -248,10 +258,14 @@ onMounted(() => {
 
 .plaza-main.variant-sidebar {
   width: 100%;
-  min-height: 0;
-  padding: 14px 12px;
-  border-radius: 12px;
-  box-shadow: var(--app-shadow-sm), 0 1px 3px rgba(0, 0, 0, 0.05);
+  box-sizing: border-box;
+  min-height: 58px;
+  padding: 0 14px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--color-brand-hover, #6366f1) 0%, var(--color-brand, #4f46e5) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  color: var(--app-text-inverse, #ffffff);
+  border: 1px solid color-mix(in srgb, var(--color-brand, #4f46e5) 50%, transparent);
+  box-shadow: none;
 }
 
 .plaza-main:hover {
@@ -261,7 +275,10 @@ onMounted(() => {
 }
 
 .plaza-main.variant-sidebar:hover {
-  box-shadow: var(--app-shadow-sm), 0 2px 8px var(--color-plaza-border, rgba(5, 150, 105, 0.18));
+  filter: none;
+  transform: none;
+  background: linear-gradient(135deg, var(--color-brand, #4f46e5) 0%, var(--color-brand-hover, #6366f1) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  box-shadow: none;
 }
 
 /* ── 光晕层 ─────────────────────────────── */
@@ -283,8 +300,40 @@ onMounted(() => {
   gap: 12px;
 }
 .plaza-main.variant-sidebar .plaza-main-content { 
-  flex-direction: column; 
-  gap: 6px; 
+  flex-direction: row;
+  justify-content: center;
+  gap: 8px;
+}
+
+.plaza-main.variant-sidebar .plaza-glow {
+  display: none;
+}
+
+.plaza-plain-icon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--app-text-inverse, #ffffff);
+}
+
+.plaza-plain-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+[data-theme='anchor'] .plaza-main.variant-sidebar {
+  background: linear-gradient(135deg, var(--color-brand-hover, #ddb930) 0%, var(--color-brand, #c9a227) 55%, var(--color-brand-pressed, #a88a1f) 100%);
+  border-color: color-mix(in srgb, var(--color-brand, #c9a227) 62%, transparent);
+  box-shadow: none;
+}
+
+[data-theme='anchor'] .plaza-main.variant-sidebar:hover {
+  transform: none;
+  filter: none;
+  border-color: color-mix(in srgb, var(--color-brand, #c9a227) 74%, transparent);
+  box-shadow: none;
 }
 
 /* ── 图标核心 ───────────────────────────── */
@@ -373,7 +422,10 @@ onMounted(() => {
   letter-spacing: 0.02em;
 }
 .plaza-main.variant-sidebar .plaza-title { 
-  font-size: 12px; 
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .plaza-count {

--- a/frontend/src/components/stats/StatCard.vue
+++ b/frontend/src/components/stats/StatCard.vue
@@ -1,7 +1,18 @@
 <template>
   <article class="stat-card" :class="{ loading: loading }">
-    <div class="stat-icon-wrap">
-      <span v-if="icon" class="stat-icon">{{ icon }}</span>
+    <div v-if="icon" class="stat-icon-wrap" aria-hidden="true">
+      <svg v-if="icon === 'books'" class="stat-icon-svg" viewBox="0 0 24 24" fill="none">
+        <path d="M4 5.5A1.5 1.5 0 0 1 5.5 4H17a3 3 0 0 1 3 3v11a1 1 0 0 1-1.45.9A4 4 0 0 0 16.8 18H6a2 2 0 0 1-2-2V5.5Z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+        <path d="M8 8h8M8 11h8M8 14h5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+      </svg>
+      <svg v-else-if="icon === 'chapters'" class="stat-icon-svg" viewBox="0 0 24 24" fill="none">
+        <path d="M7 3.8h7.6L19 8.2V20H7V3.8Z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+        <path d="M14.5 3.8v4.4H19" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+        <path d="M10 11h6M10 14h6M10 17h4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+      </svg>
+      <svg v-else-if="icon === 'words'" class="stat-icon-svg" viewBox="0 0 24 24" fill="none">
+        <path d="M4 18.5h16M7 16l2.4-8 2.6 6 2.4-6 2.6 8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
     </div>
     <div class="stat-content">
       <span class="stat-title">{{ title }}</span>
@@ -32,7 +43,7 @@ interface TrendData {
 interface Props {
   title: string
   value: number | string
-  icon?: string
+  icon?: 'books' | 'chapters' | 'words'
   trend?: TrendData
   loading?: boolean
   unit?: string
@@ -53,11 +64,11 @@ const trendValue = computed(() => props.trend ? Math.abs(props.trend.value) : 0)
 <style scoped>
 .stat-card {
   background: var(--app-surface);
-  border-radius: 12px;
-  padding: 16px;
+  border-radius: 10px;
+  padding: 12px;
   display: flex;
   align-items: flex-start;
-  gap: 14px;
+  gap: 10px;
   box-shadow: var(--app-shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.04));
   transition: all 0.2s ease;
   position: relative;
@@ -91,26 +102,25 @@ const trendValue = computed(() => props.trend ? Math.abs(props.trend.value) : 0)
 }
 
 .stat-icon-wrap {
-  width: 40px;
-  height: 40px;
-  background: linear-gradient(135deg, var(--app-surface-subtle) 0%, var(--app-border) 100%);
-  border-radius: 10px;
+  width: 26px;
+  height: 26px;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  color: var(--app-text-secondary, #64748b);
 }
 
-.stat-icon {
-  font-size: 20px;
-  line-height: 1;
+.stat-icon-svg {
+  width: 22px;
+  height: 22px;
 }
 
 .stat-content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
   min-width: 0;
 }
 
@@ -128,7 +138,7 @@ const trendValue = computed(() => props.trend ? Math.abs(props.trend.value) : 0)
 }
 
 .stat-value {
-  font-size: 26px;
+  font-size: 22px;
   font-weight: 800;
   color: var(--app-text-primary, #1e293b);
   line-height: 1.1;

--- a/frontend/src/components/stats/StatsSidebar.vue
+++ b/frontend/src/components/stats/StatsSidebar.vue
@@ -15,7 +15,14 @@
     <section class="stats-section">
       <div class="section-header">
         <h2 class="section-title">
-          <span class="title-icon">📊</span>
+          <span class="title-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M4 19h16" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+              <rect x="6" y="11" width="3.5" height="6" rx="1.2" stroke="currentColor" stroke-width="1.6"/>
+              <rect x="10.5" y="8" width="3.5" height="9" rx="1.2" stroke="currentColor" stroke-width="1.6"/>
+              <rect x="15" y="5" width="3.5" height="12" rx="1.2" stroke="currentColor" stroke-width="1.6"/>
+            </svg>
+          </span>
           数据概览
         </h2>
         <button
@@ -33,21 +40,21 @@
         <StatCard
           title="总书籍数"
           :value="globalStats?.total_books ?? 0"
-          icon="📚"
+          icon="books"
           unit="本"
           :loading="loading"
         />
         <StatCard
           title="总章节数"
           :value="globalStats?.total_chapters ?? 0"
-          icon="📄"
+          icon="chapters"
           unit="章"
           :loading="loading"
         />
         <StatCard
           title="总字数"
           :value="formatNumber(globalStats?.total_words ?? 0)"
-          icon="✍️"
+          icon="words"
           unit="字"
           :loading="loading"
         />
@@ -73,20 +80,34 @@
     <!-- Quick Actions -->
     <section class="quick-actions">
       <h3 class="actions-title">
-        <span class="title-icon">⚡</span>
+        <span class="title-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none">
+            <path d="M13.5 3.5 7.8 12h4l-1.3 8.5 6.2-9h-4.3L13.5 3.5Z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+          </svg>
+        </span>
         快捷操作
       </h3>
       <div class="actions-grid">
-        <button class="action-btn" @click="$emit('create-book')">
-          <span class="action-icon">✨</span>
+        <button class="action-btn action-create" @click="$emit('create-book')">
+          <span class="action-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+          </span>
           <span>新建书目</span>
         </button>
-        <button class="action-btn" @click="$emit('refresh-list')">
-          <span class="action-icon">🔄</span>
+        <button class="action-btn action-refresh" @click="$emit('refresh-list')">
+          <span class="action-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M20 7v5h-5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M4 17v-5h5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M7.6 8.6a6 6 0 0 1 9.9 1.6M16.4 15.4a6 6 0 0 1-9.9-1.6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+          </span>
           <span>刷新列表</span>
         </button>
         <GlobalLLMEntryButton appearance="sidebar" />
-        <PromptPlazaEntryButton />
+        <PromptPlazaEntryButton appearance="sidebar" />
       </div>
     </section>
 
@@ -94,14 +115,24 @@
     <footer class="sidebar-footer">
       <div class="footer-info">
         <span class="update-time">
-          <span class="time-icon">🕐</span>
+          <span class="time-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="8.2" stroke="currentColor" stroke-width="1.8"/>
+              <path d="M12 8v4.2l2.6 1.8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
           {{ updateTimeText }}
         </span>
+        <a href="/architecture.html" target="_blank" class="footer-link">
+          <span class="link-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none">
+              <path d="M6.5 5.5h8.5a3 3 0 0 1 3 3v10H9.5a3 3 0 0 0-3 3V5.5Z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+              <path d="M6.5 5.5v16M9.5 21.5h8.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+            </svg>
+          </span>
+          架构文档
+        </a>
       </div>
-      <a href="/architecture.html" target="_blank" class="footer-link">
-        <span class="link-icon">📖</span>
-        架构文档
-      </a>
     </footer>
   </aside>
 </template>
@@ -206,30 +237,36 @@ const updateTimeText = computed(() => formatTime(lastUpdateTime.value))
   top: 0;
   width: 300px;
   height: 100vh;
+  box-sizing: border-box;
+  padding-top: env(safe-area-inset-top);
   background: linear-gradient(180deg, var(--app-surface-subtle) 0%, var(--app-border) 100%);
   border-right: 1px solid var(--app-border);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  overflow-x: hidden;
   z-index: 100;
 }
 
 /* Brand Header */
 .sidebar-brand {
-  padding: 28px 24px 24px;
+  min-height: 100px;
+  padding: 20px 24px;
   background: linear-gradient(135deg, var(--color-brand, #4f46e5) 0%, var(--color-brand-pressed, #7c3aed) 100%);
   position: relative;
-  overflow: hidden;
+  overflow: visible;
+  display: flex;
+  align-items: center;
 }
 
 .sidebar-brand::before {
   content: '';
   position: absolute;
-  top: -50%;
-  right: -30%;
-  width: 200px;
-  height: 200px;
-  background: radial-gradient(circle, var(--app-text-inverse, rgba(255,255,255,0.15)) 0%, transparent 70%);
+  top: -38%;
+  right: -46%;
+  width: 132px;
+  height: 132px;
+  background: radial-gradient(circle, var(--app-text-inverse, rgba(255,255,255,0.09)) 0%, transparent 72%);
   pointer-events: none;
 }
 
@@ -269,36 +306,47 @@ const updateTimeText = computed(() => formatTime(lastUpdateTime.value))
 
 .brand-slogan {
   font-size: 12px;
-  color: var(--app-text-secondary, rgba(255, 255, 255, 0.85));
+  color: rgba(255, 255, 255, 0.82);
   margin: 0;
   font-weight: 400;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.16);
 }
 
 /* Stats Section */
 .stats-section {
-  padding: 24px;
-  flex: 1;
+  padding: 16px;
+  flex: 0 0 auto;
 }
 
 .section-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 18px;
+  margin-bottom: 12px;
 }
 
 .section-title {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--app-text-primary);
   margin: 0;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .title-icon {
-  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  color: var(--app-text-secondary, #64748b);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.title-icon svg {
+  width: 16px;
+  height: 16px;
 }
 
 .refresh-btn {
@@ -342,8 +390,8 @@ const updateTimeText = computed(() => formatTime(lastUpdateTime.value))
 .stats-grid {
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  margin-bottom: 20px;
+  gap: 8px;
+  margin-bottom: 14px;
 }
 
 /* Stage Distribution */
@@ -403,58 +451,88 @@ const updateTimeText = computed(() => formatTime(lastUpdateTime.value))
 
 /* Quick Actions */
 .quick-actions {
-  padding: 0 24px 24px;
+  padding: 0 16px 10px;
 }
 
 .actions-title {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--app-text-primary);
-  margin: 0 0 14px;
+  margin: 0 0 10px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .actions-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 8px;
 }
 
 .action-btn {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 6px;
-  padding: 14px 12px;
-  background: var(--app-surface);
-  border: 1px solid var(--app-border, rgba(15, 23, 42, 0.06));
-  border-radius: 12px;
+  justify-content: center;
+  gap: 8px;
+  min-height: 58px;
+  padding: 0 14px;
+  background: linear-gradient(135deg, var(--color-brand-hover, #6366f1) 0%, var(--color-brand, #4f46e5) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  border: 1px solid color-mix(in srgb, var(--color-brand, #4f46e5) 52%, transparent);
+  border-radius: 16px;
   cursor: pointer;
   transition: all 0.2s ease;
-  font-size: 12px;
-  color: var(--app-text-secondary, #475569);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--app-text-inverse, #ffffff);
+  box-shadow: none;
+  white-space: nowrap;
+}
+
+.action-btn.action-create {
+  background: linear-gradient(135deg, var(--color-brand-hover, #6366f1) 0%, var(--color-brand, #4f46e5) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  border-color: color-mix(in srgb, var(--color-brand, #4f46e5) 52%, transparent);
+}
+
+.action-btn.action-refresh {
+  background: linear-gradient(135deg, var(--color-brand-hover, #6366f1) 0%, var(--color-brand, #4f46e5) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  border-color: color-mix(in srgb, var(--color-brand, #4f46e5) 52%, transparent);
 }
 
 .action-btn:hover {
-  background: var(--app-surface-subtle);
-  border-color: var(--color-brand, #4f46e5);
-  color: var(--color-brand, #4f46e5);
-  transform: translateY(-1px);
+  filter: none;
+  transform: none;
+  background: linear-gradient(135deg, var(--color-brand, #4f46e5) 0%, var(--color-brand-hover, #6366f1) 55%, var(--color-brand-pressed, #4338ca) 100%);
+  box-shadow: none;
 }
 
 .action-icon {
-  font-size: 20px;
+  width: 16px;
+  height: 16px;
+  color: var(--app-text-inverse, #ffffff);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.action-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+[data-theme='anchor'] .action-btn:hover {
+  transform: none;
+  box-shadow: none;
 }
 
 /* Footer */
 .sidebar-footer {
-  padding: 20px 24px;
+  margin-top: auto;
+  padding: 10px 16px 12px;
   border-top: 1px solid var(--app-divider, rgba(15, 23, 42, 0.06));
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+  display: block;
   background: var(--app-surface-subtle, rgba(248, 250, 252, 0.8));
 }
 
@@ -462,31 +540,41 @@ const updateTimeText = computed(() => formatTime(lastUpdateTime.value))
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 8px;
 }
 
 .update-time {
-  font-size: 12px;
-  color: var(--app-text-secondary, #94a3b8);
+  font-size: 11px;
+  color: var(--app-text-muted, #64748b);
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
 
 .time-icon {
-  font-size: 14px;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.time-icon svg {
+  width: 14px;
+  height: 14px;
 }
 
 .footer-link {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--app-text-muted, #64748b);
   text-decoration: none;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 12px;
-  background: var(--app-surface);
-  border-radius: 8px;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 6px;
   transition: all 0.2s ease;
+  white-space: nowrap;
 }
 
 .footer-link:hover {
@@ -495,6 +583,15 @@ const updateTimeText = computed(() => formatTime(lastUpdateTime.value))
 }
 
 .link-icon {
-  font-size: 14px;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.link-icon svg {
+  width: 14px;
+  height: 14px;
 }
 </style>


### PR DESCRIPTION
## 变更说明
- 统一左侧栏“快捷操作”四个按钮的视觉样式（尺寸、圆角、图标与文字对齐）。
- 对齐按钮在不同主题下的颜色表现，使其与“创建第一本书”按钮的主题色逻辑一致。
- 修复“提示词广场”文案换行导致的独字成行问题。
- 优化底部信息区与快捷操作区间距及布局，减少冗余留白。

## 测试
- [x] 手动验证亮色主题显示正常
- [x] 手动验证暗色主题显示正常
- [x] 手动验证黑金主题显示正常
- [x] 验证快捷操作四个按钮颜色、图标、字体风格一致
- [x] 验证“提示词广场”文案不再换行

## 风险与回滚
- 风险：仅涉及前端样式，主要风险为视觉回归。
- 回滚方式：回退本 PR 涉及的样式文件即可。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Sidebar buttons now feature enhanced visual styling with gradient backgrounds and refined layouts for improved appearance.

* **Icon Updates**
  * Replaced text-based and emoji icons with SVG icons across multiple components for better clarity and consistency.

* **Layout Refinements**
  * Adjusted spacing, padding, and layout in sidebar and stats display components for improved readability and visual hierarchy.

* **Theme Enhancements**
  * Added theme-specific styling improvements to ensure better visual consistency across different theme variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->