### PR TITLE
fix: 简单修复了主题设置界面字体不随着主题变色的bug  以及修复优雅降级过于严苛

### DIFF
--- a/application/ai/llm_control_service.py
+++ b/application/ai/llm_control_service.py
@@ -47,6 +47,7 @@ class LLMProfile(BaseModel):
     extra_query: Dict[str, Any] = Field(default_factory=dict)
     extra_body: Dict[str, Any] = Field(default_factory=dict)
     notes: str = ''
+    use_legacy_chat_completions: bool = False
 
     @field_validator('temperature')
     @classmethod
@@ -154,6 +155,7 @@ class LLMControlService:
             extra_query=json.loads(row.get('extra_query') or '{}'),
             extra_body=json.loads(row.get('extra_body') or '{}'),
             notes=row['notes'] or '',
+            use_legacy_chat_completions=bool(row.get('use_legacy_chat_completions', 0)),
         )
 
     def _profile_to_row(self, p: LLMProfile) -> dict:
@@ -172,6 +174,7 @@ class LLMControlService:
             extra_query=json.dumps(p.extra_query, ensure_ascii=False),
             extra_body=json.dumps(p.extra_body, ensure_ascii=False),
             notes=p.notes,
+            use_legacy_chat_completions=int(p.use_legacy_chat_completions),
         )
 
     # ---- 公共接口（保持与原文件版一致）----------------------------------
@@ -322,15 +325,16 @@ class LLMControlService:
                 row['base_url'], row['api_key'], row['model'],
                 row['temperature'], row['max_tokens'], row['timeout_seconds'],
                 row['extra_headers'], row['extra_query'], row['extra_body'],
-                row['notes'], row['sort_order'],
+                row['notes'], row['use_legacy_chat_completions'], row['sort_order'],
             ))
 
         db.execute_many(
             """INSERT INTO llm_profiles (
                 id, name, preset_key, protocol, base_url, api_key, model,
                 temperature, max_tokens, timeout_seconds,
-                extra_headers, extra_query, extra_body, notes, sort_order
-            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                extra_headers, extra_query, extra_body, notes,
+                use_legacy_chat_completions, sort_order
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             params_list,
         )
 

--- a/frontend/src/api/llmControl.ts
+++ b/frontend/src/api/llmControl.ts
@@ -27,6 +27,7 @@ export interface LLMProfile {
   extra_query: Record<string, unknown>
   extra_body: Record<string, unknown>
   notes: string
+  use_legacy_chat_completions: boolean
 }
 
 export interface LLMControlConfig {

--- a/frontend/src/components/LLMSettingsModal.vue
+++ b/frontend/src/components/LLMSettingsModal.vue
@@ -2,7 +2,7 @@
   <n-modal
     v-model:show="show"
     preset="card"
-    title="配置管理"
+    title="主题设置"
     style="width: min(560px, 96vw)"
     :mask-closable="false"
     :segmented="{ content: 'soft', footer: 'soft' }"
@@ -262,12 +262,12 @@ function handleThemeChange(newMode: ThemeMode) {
 .mode-card-name {
   font-size: 15px;
   font-weight: 600;
-  color: var(--color-text-primary, #0f172a);
+  color: var(--app-text-primary);
 }
 
 .mode-card-desc {
   font-size: 12.5px;
-  color: var(--color-text-secondary, #64748b);
+  color: var(--app-text-secondary);
   margin-top: 3px;
 }
 

--- a/frontend/src/components/settings/ModelSettingsModal.vue
+++ b/frontend/src/components/settings/ModelSettingsModal.vue
@@ -246,6 +246,7 @@ async function handleSave() {
       extra_body: {},
       notes: '',
       preset_key: 'custom-openai-compatible',
+      use_legacy_chat_completions: profiles[0]?.use_legacy_chat_completions ?? false,
     }
 
     if (profiles.length > 0 && profiles[0].id === mainProfile.id) {
@@ -273,6 +274,7 @@ async function handleSave() {
           extra_body: {},
           notes: '',
           preset_key: 'custom-openai-compatible',
+          use_legacy_chat_completions: existing >= 0 ? (profiles[existing].use_legacy_chat_completions ?? false) : false,
         }
         if (existing >= 0) {
           profiles[existing] = roleProfile

--- a/frontend/src/components/workbench/LLMControlPanel.vue
+++ b/frontend/src/components/workbench/LLMControlPanel.vue
@@ -199,6 +199,14 @@
               <n-input-number v-model:value="selectedProfile.timeout_seconds" :min="1" :step="10" style="width: 100%" />
             </div>
 
+            <div v-if="selectedProfile.protocol === 'openai'" class="llm-field span-2">
+              <label class="llm-label">使用旧协议（Chat Completions）</label>
+              <n-switch v-model:value="selectedProfile.use_legacy_chat_completions" />
+              <n-text depth="3" style="font-size: 12px">
+                关闭时走 Responses API（默认）；部分国产网关不支持新协议时请开启。
+              </n-text>
+            </div>
+
             <div class="llm-field span-2">
               <label class="llm-label">备注</label>
               <n-input v-model:value="selectedProfile.notes" type="textarea" :autosize="{ minRows: 2, maxRows: 4 }" placeholder="例如：公司网关、测试环境、带 reasoning 参数" />
@@ -407,6 +415,7 @@ function buildProfileFromPreset(preset?: LLMPreset): LLMProfile {
     extra_query: {},
     extra_body: {},
     notes: '',
+    use_legacy_chat_completions: false,
   }
 }
 

--- a/infrastructure/ai/config/settings.py
+++ b/infrastructure/ai/config/settings.py
@@ -22,6 +22,7 @@ class Settings:
     extra_body: dict[str, Any] = field(default_factory=dict)
     provider_name: Optional[str] = None
     protocol: Optional[str] = None
+    use_legacy_chat_completions: bool = False
 
     def __post_init__(self):
         """验证配置参数"""

--- a/infrastructure/ai/provider_factory.py
+++ b/infrastructure/ai/provider_factory.py
@@ -61,6 +61,7 @@ class LLMProviderFactory:
             extra_body=profile.extra_body,
             provider_name=profile.name,
             protocol=profile.protocol,
+            use_legacy_chat_completions=profile.use_legacy_chat_completions,
         )
 
 

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -2,7 +2,6 @@
 import logging
 from typing import Any, AsyncIterator
 
-import openai
 from openai import AsyncOpenAI
 
 from domain.ai.services.llm_service import GenerationConfig, GenerationResult
@@ -18,28 +17,20 @@ DEFAULT_MODEL = "gpt-4o"
 
 class OpenAIProvider(BaseProvider):
     """OpenAI LLM 提供商实现
-    
-    能够自动探活并兼容最新的 Responses API (优先) 和传统的 Chat Completions API (降级)。
+
+    通过 use_legacy_chat_completions 显式选择协议：
+    - False（默认）：走 Responses API
+    - True：走 Chat Completions API
     """
-    
-    # 静态类级别缓存：记录哪些 base_url 不支持 Responses API，从而避免重复降级带来的延迟开销
-    _fallback_to_chat_cache: set[str] = set()
 
     def __init__(self, settings: Settings):
-        """初始化 OpenAI 提供商
-        
-        Args:
-            settings: AI 配置设置
-            
-        Raises:
-            ValueError: 如果 API key 未设置
-        """
         super().__init__(settings)
-        
+
         if not settings.api_key:
             raise ValueError("API key is required for OpenAIProvider")
-            
-        # 初始化 AsyncOpenAI 客户端
+
+        self._use_legacy = settings.use_legacy_chat_completions
+
         client_kwargs = {
             "api_key": settings.api_key,
             "timeout": settings.timeout_seconds,
@@ -48,7 +39,7 @@ class OpenAIProvider(BaseProvider):
         }
         if settings.base_url:
             client_kwargs["base_url"] = settings.base_url
-            
+
         self.async_client = AsyncOpenAI(**client_kwargs)
 
     async def generate(
@@ -56,122 +47,59 @@ class OpenAIProvider(BaseProvider):
         prompt: Prompt,
         config: GenerationConfig
     ) -> GenerationResult:
-        """生成文本
-        
-        Args:
-            prompt: 提示词
-            config: 生成配置
-            
-        Returns:
-            生成结果
-            
-        Raises:
-            RuntimeError: 当 API 调用失败或返回空内容时
-        """
         try:
-            base_url = self.settings.base_url or "https://api.openai.com/v1"
-            use_responses = base_url not in self.__class__._fallback_to_chat_cache
-            
-            if use_responses:
-                try:
-                    return await self._generate_via_responses(prompt, config)
-                except openai.NotFoundError as e:
-                    logger.info(f"Responses API unsupported for {base_url}, falling back to chat completions: {str(e)}")
-                    self.__class__._fallback_to_chat_cache.add(base_url)
-                except self.EmptyResponseError as e:
-                    logger.warning(f"Responses API returned empty content for {base_url}, falling back to chat completions: {str(e)}")
-                    self.__class__._fallback_to_chat_cache.add(base_url)
-                except Exception as e:
-                    # 某些网关在路径错误时可能不抛严格的 404 而是抛出其他错误，如果消息含有明确路径错误也尝试降级
-                    if "404" in str(e) or "Not Found" in str(e):
-                        logger.info(f"Gateway returned 404 for Responses API ({base_url}), falling back: {str(e)}")
-                        self.__class__._fallback_to_chat_cache.add(base_url)
-                    else:
-                        raise
-            
-            # 使用降级的 Chat Completions API
-            messages = self._build_messages(prompt)
-            request_kwargs = self._build_chat_request_kwargs(messages, config)
-
-            response = await self.async_client.chat.completions.create(**request_kwargs)
-            content = self._extract_text_from_response(response)
-
-            if not content:
-                logger.warning(
-                    "OpenAI-compatible response returned empty non-stream content; "
-                    "falling back to streaming aggregation"
-                )
-                content, token_usage = await self._generate_via_stream(request_kwargs)
-                return GenerationResult(content=content, token_usage=token_usage)
-
-            input_tokens = response.usage.prompt_tokens if response.usage else 0
-            output_tokens = response.usage.completion_tokens if response.usage else 0
-            token_usage = TokenUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens
-            )
-            
-            return GenerationResult(content=content, token_usage=token_usage)
-            
+            if self._use_legacy:
+                return await self._generate_via_chat(prompt, config)
+            return await self._generate_via_responses(prompt, config)
         except RuntimeError:
             raise
         except Exception as e:
             raise RuntimeError(f"Failed to generate text: {str(e)}") from e
+
+    async def _generate_via_chat(self, prompt: Prompt, config: GenerationConfig) -> GenerationResult:
+        """Chat Completions API 非流式生成"""
+        messages = self._build_messages(prompt)
+        request_kwargs = self._build_chat_request_kwargs(messages, config)
+
+        response = await self.async_client.chat.completions.create(**request_kwargs)
+        content = self._extract_text_from_response(response)
+
+        if not content:
+            logger.warning(
+                "OpenAI-compatible response returned empty non-stream content; "
+                "falling back to streaming aggregation"
+            )
+            content, token_usage = await self._generate_via_stream(request_kwargs)
+            return GenerationResult(content=content, token_usage=token_usage)
+
+        input_tokens = response.usage.prompt_tokens if response.usage else 0
+        output_tokens = response.usage.completion_tokens if response.usage else 0
+        return GenerationResult(
+            content=content,
+            token_usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+        )
 
     async def stream_generate(
         self,
         prompt: Prompt,
         config: GenerationConfig
     ) -> AsyncIterator[str]:
-        """流式生成内容
-        
-        Args:
-            prompt: 提示词
-            config: 生成配置
-            
-        Yields:
-            生成的文本片段
-            
-        Raises:
-            RuntimeError: 当流式生成失败时
-        """
         try:
-            base_url = self.settings.base_url or "https://api.openai.com/v1"
-            use_responses = base_url not in self.__class__._fallback_to_chat_cache
-            
-            if use_responses:
-                try:
-                    # 尝试走 Responses 流式 API
-                    request_kwargs = self._build_responses_request_kwargs(prompt, config, stream=True)
-                    stream = await self.async_client.responses.create(**request_kwargs)
-                    async for chunk in stream:
-                        content = self._extract_text_from_responses_chunk(chunk)
-                        if content:
-                            yield content
-                    return  # 正常完成则结束 generator
-                except openai.NotFoundError:
-                    self.__class__._fallback_to_chat_cache.add(base_url)
-                    logger.info(f"Stream: Responses API unsupported for {base_url}, falling back.")
-                except self.EmptyResponseError:
-                    self.__class__._fallback_to_chat_cache.add(base_url)
-                    logger.warning(f"Stream: Responses API returned empty for {base_url}, falling back.")
-                except Exception as e:
-                    if "404" in str(e) or "Not Found" in str(e):
-                        self.__class__._fallback_to_chat_cache.add(base_url)
-                    else:
-                        logger.error(f"[Responses Stream] Failed: {e}")
-                        raise
-
-            # 降级：走原来的 Chat Completions 流式 API
-            messages = self._build_messages(prompt)
-            request_kwargs = self._build_chat_request_kwargs(messages, config, stream=True)
-            stream = await self.async_client.chat.completions.create(**request_kwargs)
-            
-            async for chunk in stream:
-                content = self._extract_text_from_stream_chunk(chunk)
-                if content:
-                    yield content
-                    
+            if self._use_legacy:
+                messages = self._build_messages(prompt)
+                request_kwargs = self._build_chat_request_kwargs(messages, config, stream=True)
+                stream = await self.async_client.chat.completions.create(**request_kwargs)
+                async for chunk in stream:
+                    content = self._extract_text_from_stream_chunk(chunk)
+                    if content:
+                        yield content
+            else:
+                request_kwargs = self._build_responses_request_kwargs(prompt, config, stream=True)
+                stream = await self.async_client.responses.create(**request_kwargs)
+                async for chunk in stream:
+                    content = self._extract_text_from_responses_chunk(chunk)
+                    if content:
+                        yield content
         except Exception as e:
             logger.error(f"[Stream] Failed: {e}")
             raise RuntimeError(f"Failed to stream text: {str(e)}") from e
@@ -225,15 +153,11 @@ class OpenAIProvider(BaseProvider):
             kwargs["stream"] = True
         return kwargs
 
-    class EmptyResponseError(RuntimeError):
-        """Responses API 返回空内容时的异常"""
-        pass
-
     async def _generate_via_responses(self, prompt: Prompt, config: GenerationConfig) -> GenerationResult:
-        """原生 Responses API 生成调用封装"""
+        """Responses API 非流式生成"""
         request_kwargs = self._build_responses_request_kwargs(prompt, config)
         response = await self.async_client.responses.create(**request_kwargs)
-        
+
         output = getattr(response, "output", None)
         content = ""
         if output:
@@ -244,7 +168,7 @@ class OpenAIProvider(BaseProvider):
                             content = str(getattr(part, "text", "")).strip()
                             break
         if not content:
-            raise self.EmptyResponseError("Responses API returned empty content")
+            raise RuntimeError("Responses API returned empty content")
             
         input_tokens = response.usage.prompt_tokens if response.usage else 0
         output_tokens = response.usage.completion_tokens if response.usage else 0

--- a/infrastructure/persistence/database/connection.py
+++ b/infrastructure/persistence/database/connection.py
@@ -220,6 +220,7 @@ def _apply_migration_files(conn: sqlite3.Connection) -> None:
         "add_macro_diagnosis_results.sql",
         "add_micro_beats_to_chapter_summaries.sql",
         "add_tension_dimensions.sql",
+        "add_use_legacy_chat_completions.sql",
     ]
     
     for migration_file in migration_files:

--- a/infrastructure/persistence/database/migrations/add_use_legacy_chat_completions.sql
+++ b/infrastructure/persistence/database/migrations/add_use_legacy_chat_completions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE llm_profiles ADD COLUMN use_legacy_chat_completions INTEGER NOT NULL DEFAULT 0;

--- a/infrastructure/persistence/database/schema.sql
+++ b/infrastructure/persistence/database/schema.sql
@@ -611,6 +611,7 @@ CREATE TABLE IF NOT EXISTS llm_profiles (
     extra_query TEXT NOT NULL DEFAULT '{}',
     extra_body TEXT NOT NULL DEFAULT '{}',
     notes TEXT NOT NULL DEFAULT '',
+    use_legacy_chat_completions INTEGER NOT NULL DEFAULT 0,
     sort_order INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/tests/unit/infrastructure/ai/providers/test_openai_provider.py
+++ b/tests/unit/infrastructure/ai/providers/test_openai_provider.py
@@ -24,10 +24,12 @@ class _FakeStream:
             raise StopAsyncIteration from exc
 
 
-class TestOpenAIProvider:
+class TestOpenAIProviderLegacy:
+    """use_legacy_chat_completions=True → Chat Completions API"""
+
     @pytest.fixture
     def settings(self):
-        return Settings(api_key="test-api-key")
+        return Settings(api_key="test-api-key", use_legacy_chat_completions=True)
 
     @pytest.fixture
     def provider(self, settings):
@@ -36,9 +38,10 @@ class TestOpenAIProvider:
     def test_initialization(self, provider, settings):
         assert provider.settings == settings
         assert provider.async_client is not None
+        assert provider._use_legacy is True
 
     @pytest.mark.anyio
-    async def test_generate_with_default_config(self, provider):
+    async def test_generate_non_stream(self, provider):
         prompt = Prompt(system="You are helpful", user="Hello")
         config = GenerationConfig(model="gpt-4o", temperature=0.7, max_tokens=4096)
         response = SimpleNamespace(
@@ -132,3 +135,99 @@ class TestOpenAIProvider:
     def test_missing_api_key(self):
         with pytest.raises(ValueError, match="API key is required"):
             OpenAIProvider(Settings(api_key=None))
+
+
+class TestOpenAIProviderResponses:
+    """use_legacy_chat_completions=False（默认）→ Responses API"""
+
+    @pytest.fixture
+    def settings(self):
+        return Settings(api_key="test-api-key", use_legacy_chat_completions=False)
+
+    @pytest.fixture
+    def provider(self, settings):
+        return OpenAIProvider(settings)
+
+    def test_default_uses_responses(self, provider):
+        assert provider._use_legacy is False
+
+    @pytest.mark.anyio
+    async def test_generate_non_stream(self, provider):
+        prompt = Prompt(system="You are helpful", user="Hello")
+        config = GenerationConfig(model="gpt-4o", temperature=0.5, max_tokens=2048)
+        response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="text", text="Hi from responses!")],
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=8, completion_tokens=4),
+        )
+
+        with patch.object(provider.async_client.responses, "create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = response
+
+            result = await provider.generate(prompt, config)
+
+            assert result.content == "Hi from responses!"
+            assert result.token_usage.input_tokens == 8
+            assert result.token_usage.output_tokens == 4
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["model"] == "gpt-4o"
+            assert call_kwargs["temperature"] == 0.5
+            assert call_kwargs["max_output_tokens"] == 2048
+
+    @pytest.mark.anyio
+    async def test_stream_generate(self, provider):
+        prompt = Prompt(system="You are helpful", user="Hello")
+        config = GenerationConfig(model="gpt-4o", temperature=0.7, max_tokens=32)
+        stream = _FakeStream([
+            SimpleNamespace(
+                type="response.content_part.added",
+                part=SimpleNamespace(type="text", text="Hello"),
+            ),
+            SimpleNamespace(type="response.completed"),
+        ])
+
+        with patch.object(provider.async_client.responses, "create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = stream
+
+            chunks = [chunk async for chunk in provider.stream_generate(prompt, config)]
+
+            assert chunks == ["Hello"]
+            assert mock_create.await_args.kwargs["stream"] is True
+
+    @pytest.mark.anyio
+    async def test_generate_empty_responses_raises(self, provider):
+        prompt = Prompt(system="You are helpful", user="Hello")
+        config = GenerationConfig()
+        response = SimpleNamespace(
+            output=[],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=0),
+        )
+
+        with patch.object(provider.async_client.responses, "create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = response
+
+            with pytest.raises(RuntimeError, match="empty content"):
+                await provider.generate(prompt, config)
+
+
+class TestProfilePassthrough:
+    """profile 的 use_legacy_chat_completions 正确透传到 OpenAIProvider"""
+
+    def test_legacy_flag_passed_through(self):
+        settings_legacy = Settings(api_key="k", use_legacy_chat_completions=True)
+        provider_legacy = OpenAIProvider(settings_legacy)
+        assert provider_legacy._use_legacy is True
+
+        settings_new = Settings(api_key="k", use_legacy_chat_completions=False)
+        provider_new = OpenAIProvider(settings_new)
+        assert provider_new._use_legacy is False
+
+    def test_default_is_responses(self):
+        settings = Settings(api_key="k")
+        provider = OpenAIProvider(settings)
+        assert provider._use_legacy is False


### PR DESCRIPTION
## 变更说明
- 简单修复了主题设置界面字体不随着主题变色的bug

## 测试
前端修改无需测试

## 风险与回滚
- 风险：无

## 变更说明
 main.css中实际定义的变量名为
亮色：--app-text-primary: #0f172a
深色：--app-text-primary: #e2e8f0
黑金：--app-text-primary: #f0ead6
LLMSettingsModal.vue中传的参数是--color-text-primary 不存在，简单修复
但是为什么这个文件还叫LLMSettingsModal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a profile setting (toggle) to choose legacy Chat Completions vs. Responses for OpenAI profiles, with contextual help explaining the default Responses behavior.
  * New profiles now include this setting (default: off).

* **Style**
  * Renamed modal title to "主题设置".
  * Updated theme card text colors to use centralized CSS variables for visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## 变更说明
为 OpenAI 协议链路增加 use_legacy_chat_completions 布尔字段，用户可在 UI 上显式选择走 Responses API（默认）还是 Chat Completions API。删除原有的自动探活降级逻辑。因为大部分不支持新协议的第三方中转站返回的错误可能是500、501、502等错误，不在优雅降级条件内
改为显式控制后，协议选择由用户决定，行为透明可预期。

## 测试
use_legacy=True 非流式 | 调用 chat.completions.create
use_legacy=True 流式 | 调用 chat.completions.create(stream=True)
use_legacy=True 空内容 | 同协议流式兜底正常
use_legacy=False 非流式 | 调用 responses.create
use_legacy=False 流式 | 调用 responses.create(stream=True)
use_legacy=False 空内容 | 抛出 RuntimeError
透传 | Settings.use_legacy_chat_completions → provider._use_legacy


## 风险与回滚
- 风险：修改了数据库schema.sql 加列、新建 migration SQL、connection.py 注册迁移
可能导致老库缺列导致读取报错    但是已经_row_to_profile 使用 row.get('use_legacy_chat_completions', 0) 兜底
依赖自动降级的用户升级后会直接报错而非静默降级。这是有意为之（我也没辙）

## 变更说明
后端模型层 — LLMProfile 加字段，_row_to_profile / _profile_to_row / save_config 同步读写
持久化层 — schema.sql 加列、新建 migration SQL、connection.py 注册迁移
透传层 — Settings + provider_factory 各加一行
Provider — openai_provider.py 删除 _fallback_to_chat_cache、EmptyResponseError、所有跨协议 try/except，改为 if self._use_legacy 二选一
前端 — 类型接口加字段、LLMControlPanel 加开关（仅 protocol === 'openai' 可见）、ModelSettingsModal 两处构建对象补字段并继承原值


