### PR TITLE
[codex] Add MiniMax preset support and OpenAI OAuth login

### DIFF
--- a/application/ai/llm_control_service.py
+++ b/application/ai/llm_control_service.py
@@ -17,7 +17,7 @@ from infrastructure.ai.url_utils import (
 
 logger = logging.getLogger(__name__)
 
-LLMProtocol = Literal['openai', 'anthropic', 'gemini']
+LLMProtocol = Literal['openai', 'anthropic', 'gemini', 'minimax']
 
 
 class LLMPreset(BaseModel):
@@ -39,6 +39,7 @@ class LLMProfile(BaseModel):
     protocol: LLMProtocol = 'openai'
     base_url: str = ''
     api_key: str = ''
+    auth_mode: Literal['api_key', 'oauth'] = 'api_key'
     model: str = ''
     temperature: float = 0.7
     max_tokens: int = 4096
@@ -120,6 +121,7 @@ class LLMControlService:
     _DEFAULT_ANTHROPIC_MODEL = os.getenv('ANTHROPIC_MODEL', 'claude-sonnet-4-6')
     _DEFAULT_GEMINI_MODEL = os.getenv('GEMINI_MODEL', 'gemini-2.0-flash')
     _DEFAULT_ARK_MODEL = os.getenv('ARK_MODEL', 'doubao-seed-2-0-mini-260215')
+    _DEFAULT_MINIMAX_MODEL = os.getenv('MINIMAX_MODEL', 'MiniMax-M2.7')
 
     # ---- 内部 DB 辅助 ------------------------------------------------
 
@@ -146,6 +148,7 @@ class LLMControlService:
             protocol=row['protocol'],
             base_url=row['base_url'] or '',
             api_key=row['api_key'] or '',
+            auth_mode=(row['auth_mode'] if 'auth_mode' in row.keys() else 'api_key') or 'api_key',
             model=row['model'] or '',
             temperature=row['temperature'],
             max_tokens=row['max_tokens'],
@@ -164,6 +167,7 @@ class LLMControlService:
             protocol=p.protocol,
             base_url=p.base_url,
             api_key=p.api_key,
+            auth_mode=p.auth_mode,
             model=p.model,
             temperature=p.temperature,
             max_tokens=p.max_tokens,
@@ -195,6 +199,15 @@ class LLMControlService:
                 default_model=self._DEFAULT_OPENAI_MODEL,
                 description='OpenAI 官方接口（自动兼容底层 Responses API 与 Chat Completions）。',
                 tags=['official'],
+            ),
+            LLMPreset(
+                key='minimax',
+                label='MiniMax',
+                protocol='minimax',
+                default_base_url='https://api.minimaxi.com/v1',
+                default_model=self._DEFAULT_MINIMAX_MODEL,
+                description='MiniMax 官方 OpenAI-compatible 接口。',
+                tags=['official', 'domestic', 'preset'],
             ),
             LLMPreset(
                 key='claude-official',
@@ -319,7 +332,7 @@ class LLMControlService:
             row['sort_order'] = idx
             params_list.append((
                 row['id'], row['name'], row['preset_key'], row['protocol'],
-                row['base_url'], row['api_key'], row['model'],
+                row['base_url'], row['api_key'], row['auth_mode'], row['model'],
                 row['temperature'], row['max_tokens'], row['timeout_seconds'],
                 row['extra_headers'], row['extra_query'], row['extra_body'],
                 row['notes'], row['sort_order'],
@@ -327,10 +340,10 @@ class LLMControlService:
 
         db.execute_many(
             """INSERT INTO llm_profiles (
-                id, name, preset_key, protocol, base_url, api_key, model,
-                temperature, max_tokens, timeout_seconds,
+                id, name, preset_key, protocol, base_url, api_key, auth_mode,
+                model, temperature, max_tokens, timeout_seconds,
                 extra_headers, extra_query, extra_body, notes, sort_order
-            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
             params_list,
         )
 
@@ -380,6 +393,18 @@ class LLMControlService:
             )
 
         if not profile.api_key.strip() or not profile.model.strip():
+            if not (profile.protocol == 'openai' and profile.auth_mode == 'oauth'):
+                return LLMRuntimeSummary(
+                    source='mock',
+                    active_profile_id=profile.id,
+                    active_profile_name=profile.name,
+                    protocol=profile.protocol,
+                    model=profile.model or None,
+                    base_url=profile.base_url or None,
+                    using_mock=True,
+                    reason='当前激活配置缺少 API Key 或模型名，运行时将退回 MockProvider',
+                )
+        if not profile.model.strip():
             return LLMRuntimeSummary(
                 source='mock',
                 active_profile_id=profile.id,
@@ -388,7 +413,7 @@ class LLMControlService:
                 model=profile.model or None,
                 base_url=profile.base_url or None,
                 using_mock=True,
-                reason='当前激活配置缺少 API Key 或模型名，运行时将退回 MockProvider',
+                reason='当前激活配置缺少模型名，运行时将退回 MockProvider',
             )
 
         return LLMRuntimeSummary(
@@ -465,6 +490,7 @@ class LLMControlService:
                         'name': profile.name.strip() or f'配置 {index + 1}',
                         'base_url': profile.base_url.strip(),
                         'api_key': profile.api_key.strip(),
+                        'auth_mode': profile.auth_mode,
                         'model': profile.model.strip(),
                     }
                 )
@@ -495,6 +521,14 @@ class LLMControlService:
                 model='',
             ),
             LLMProfile(
+                id='minimax-default',
+                name='MiniMax',
+                preset_key='minimax',
+                protocol='minimax',
+                base_url='https://api.minimaxi.com/v1',
+                model=self._DEFAULT_MINIMAX_MODEL,
+            ),
+            LLMProfile(
                 id='claude-official-default',
                 name='Claude / Anthropic',
                 preset_key='claude-official',
@@ -518,6 +552,7 @@ class LLMControlService:
         anthropic_key = (os.getenv('ANTHROPIC_API_KEY') or os.getenv('ANTHROPIC_AUTH_TOKEN') or '').strip()
         openai_key = (os.getenv('OPENAI_API_KEY') or '').strip()
         gemini_key = (os.getenv('GEMINI_API_KEY') or '').strip()
+        minimax_key = (os.getenv('MINIMAX_API_KEY') or '').strip()
         ark_key = (os.getenv('ARK_API_KEY') or '').strip()
 
         if anthropic_key and (llm_provider == 'anthropic' or not llm_provider):
@@ -526,7 +561,7 @@ class LLMControlService:
                 'base_url': (os.getenv('ANTHROPIC_BASE_URL') or '').strip() or profiles[1].base_url,
                 'model': (os.getenv('ANTHROPIC_MODEL') or '').strip() or profiles[1].model,
             })
-            active_profile_id = profiles[1].id
+            active_profile_id = profiles[2].id
         elif openai_key and (llm_provider == 'openai' or not llm_provider):
             profiles[0] = profiles[0].model_copy(update={
                 'name': 'OpenAI / 兼容网关',
@@ -536,13 +571,20 @@ class LLMControlService:
                 'model': (os.getenv('OPENAI_MODEL') or '').strip() or self._DEFAULT_OPENAI_MODEL,
             })
             active_profile_id = profiles[0].id
-        elif gemini_key:
-            profiles[2] = profiles[2].model_copy(update={
-                'api_key': gemini_key,
-                'base_url': (os.getenv('GEMINI_BASE_URL') or '').strip() or profiles[2].base_url,
-                'model': (os.getenv('GEMINI_MODEL') or '').strip() or profiles[2].model,
+        elif minimax_key and llm_provider == 'minimax':
+            profiles[1] = profiles[1].model_copy(update={
+                'api_key': minimax_key,
+                'base_url': (os.getenv('MINIMAX_BASE_URL') or '').strip() or profiles[1].base_url,
+                'model': (os.getenv('MINIMAX_MODEL') or '').strip() or self._DEFAULT_MINIMAX_MODEL,
             })
-            active_profile_id = profiles[2].id
+            active_profile_id = profiles[1].id
+        elif gemini_key:
+            profiles[3] = profiles[3].model_copy(update={
+                'api_key': gemini_key,
+                'base_url': (os.getenv('GEMINI_BASE_URL') or '').strip() or profiles[3].base_url,
+                'model': (os.getenv('GEMINI_MODEL') or '').strip() or profiles[3].model,
+            })
+            active_profile_id = profiles[3].id
         elif ark_key:
             profiles[0] = profiles[0].model_copy(update={
                 'name': '豆包 / Ark',

--- a/application/codex/services/openai_oauth_service.py
+++ b/application/codex/services/openai_oauth_service.py
@@ -1,0 +1,219 @@
+import base64
+import hashlib
+import html
+import json
+import secrets
+import threading
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from wsgiref.simple_server import WSGIServer, make_server
+
+
+class OpenAiOauthService:
+    AUTH_URL = "https://auth.openai.com/oauth/authorize"
+    TOKEN_URL = "https://auth.openai.com/oauth/token"
+    CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    REDIRECT_URI = "http://localhost:1455/auth/callback"
+    SCOPES = "openid profile email offline_access"
+
+    def __init__(self, auth_file: Path | None = None):
+        self._auth_file = auth_file or (Path.home() / ".codex" / "auth.json")
+        self._lock = threading.Lock()
+        self._server: WSGIServer | None = None
+        self._server_thread: threading.Thread | None = None
+        self._state = {
+            "status": "disconnected",
+            "message": "",
+            "pkce_verifier": "",
+            "state": "",
+        }
+
+    def get_status(self) -> dict:
+        data = self._read_auth_file()
+        if data.get("tokens", {}).get("access_token"):
+            return {"status": "connected", "message": "Already logged in"}
+        return {"status": self._state["status"], "message": self._state["message"]}
+
+    def get_access_token(self) -> str | None:
+        return self._read_auth_file().get("tokens", {}).get("access_token")
+
+    def start_auth_flow(self) -> dict:
+        if self.get_access_token():
+            return {"status": "connected", "message": "Already logged in"}
+        verifier = self._generate_verifier()
+        challenge = self._build_challenge(verifier)
+        state = secrets.token_hex(16)
+        self._state.update(
+            {
+                "status": "pending",
+                "message": "Waiting for user login...",
+                "pkce_verifier": verifier,
+                "state": state,
+            }
+        )
+        self._ensure_server()
+        query = urllib.parse.urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.CLIENT_ID,
+                "redirect_uri": self.REDIRECT_URI,
+                "scope": self.SCOPES,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": state,
+            }
+        )
+        return {"status": "pending", "url": f"{self.AUTH_URL}?{query}"}
+
+    def logout(self) -> dict:
+        if self._auth_file.exists():
+            self._auth_file.unlink()
+        self._state.update(
+            {
+                "status": "disconnected",
+                "message": "Logged out",
+                "pkce_verifier": "",
+                "state": "",
+            }
+        )
+        return self.get_status()
+
+    def _read_auth_file(self) -> dict:
+        if not self._auth_file.exists():
+            return {}
+        try:
+            return json.loads(self._auth_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+
+    def _write_auth_file(self, payload: dict) -> None:
+        self._auth_file.parent.mkdir(parents=True, exist_ok=True)
+        self._auth_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    @staticmethod
+    def _generate_verifier() -> str:
+        return base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("utf-8").rstrip("=")
+
+    @staticmethod
+    def _build_challenge(verifier: str) -> str:
+        digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+        return base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
+
+    def _ensure_server(self) -> None:
+        if self._server_thread and self._server_thread.is_alive():
+            return
+        self._server_thread = threading.Thread(target=self._run_server, daemon=True)
+        self._server_thread.start()
+
+    def _run_server(self) -> None:
+        def app(environ, start_response):
+            if environ.get("PATH_INFO") != "/auth/callback":
+                start_response("404 Not Found", [("Content-Type", "text/plain; charset=utf-8")])
+                return [b"Not Found"]
+
+            query = urllib.parse.parse_qs(environ.get("QUERY_STRING", ""))
+            code = query.get("code", [None])[0]
+            state = query.get("state", [None])[0]
+            error = query.get("error", [None])[0]
+
+            try:
+                if error:
+                    raise RuntimeError(error)
+                if not code or state != self._state["state"]:
+                    raise RuntimeError("Invalid OAuth callback state")
+
+                tokens = self._exchange_code(code)
+                self._write_auth_file({"tokens": tokens})
+                self._state.update({"status": "connected", "message": "Login successful"})
+                body = self._build_callback_page("connected", "OpenAI OAuth login successful.")
+                status = "200 OK"
+            except Exception as exc:  # pragma: no cover
+                self._state.update({"status": "error", "message": str(exc)})
+                body = self._build_callback_page("error", f"OpenAI OAuth login failed: {exc}")
+                status = "500 Internal Server Error"
+
+            start_response(status, [("Content-Type", "text/html; charset=utf-8")])
+            return [body.encode("utf-8")]
+
+        with make_server("127.0.0.1", 1455, app) as server:
+            self._server = server
+            server.serve_forever()
+
+    def _exchange_code(self, code: str) -> dict:
+        data = urllib.parse.urlencode(
+            {
+                "grant_type": "authorization_code",
+                "client_id": self.CLIENT_ID,
+                "code": code,
+                "redirect_uri": self.REDIRECT_URI,
+                "code_verifier": self._state["pkce_verifier"],
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            self.TOKEN_URL,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    @staticmethod
+    def _build_callback_page(status: str, message: str) -> str:
+        escaped_message = html.escape(message)
+        payload = json.dumps(
+            {
+                "type": "openai-oauth-complete",
+                "status": status,
+                "message": message,
+            },
+            ensure_ascii=False,
+        ).replace("</", "<\\/")
+        return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenAI OAuth</title>
+    <style>
+      body {{
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0f172a;
+        color: #e2e8f0;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+      }}
+      main {{
+        width: min(92vw, 420px);
+        padding: 24px;
+        border-radius: 16px;
+        background: rgba(15, 23, 42, 0.92);
+        box-shadow: 0 18px 48px rgba(15, 23, 42, 0.25);
+      }}
+      h1 {{
+        margin: 0 0 12px;
+        font-size: 20px;
+      }}
+      p {{
+        margin: 0;
+        line-height: 1.6;
+      }}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>OpenAI OAuth</h1>
+      <p>{escaped_message}</p>
+    </main>
+    <script>
+      const payload = {payload};
+      if (window.opener && !window.opener.closed) {{
+        window.opener.postMessage(payload, "*");
+      }}
+      setTimeout(() => window.close(), 200);
+    </script>
+  </body>
+</html>"""

--- a/frontend/src/api/llmControl.ts
+++ b/frontend/src/api/llmControl.ts
@@ -1,6 +1,7 @@
 import { apiClient } from './config'
 
-export type LLMProtocol = 'openai' | 'anthropic' | 'gemini'
+export type LLMProtocol = 'openai' | 'anthropic' | 'gemini' | 'minimax'
+export type LLMAuthMode = 'api_key' | 'oauth'
 
 export interface LLMPreset {
   key: string
@@ -19,6 +20,7 @@ export interface LLMProfile {
   protocol: LLMProtocol
   base_url: string
   api_key: string
+  auth_mode: LLMAuthMode
   model: string
   temperature: number
   max_tokens: number
@@ -77,7 +79,14 @@ export interface FetchModelsPayload {
   protocol: string
   base_url: string
   api_key: string
+  auth_mode?: LLMAuthMode
   timeout_ms?: number
+}
+
+export interface OpenAiAuthStatus {
+  status: 'connected' | 'disconnected' | 'pending' | 'error'
+  message?: string
+  url?: string
 }
 
 export const llmControlApi = {
@@ -88,6 +97,12 @@ export const llmControlApi = {
     apiClient.post<LLMTestResult>('/llm-control/test', profile, { timeout: 120_000 }) as Promise<LLMTestResult>,
   fetchModels: (payload: FetchModelsPayload) =>
     apiClient.post<ModelListResponse>('/llm-control/models', payload, { timeout: 30_000 }) as Promise<ModelListResponse>,
+  getOpenAiStatus: () =>
+    apiClient.get<OpenAiAuthStatus>('/auth/openai/status') as Promise<OpenAiAuthStatus>,
+  startOpenAiAuth: () =>
+    apiClient.post<OpenAiAuthStatus>('/auth/openai/start', {}) as Promise<OpenAiAuthStatus>,
+  logoutOpenAiAuth: () =>
+    apiClient.post<OpenAiAuthStatus>('/auth/openai/logout', {}) as Promise<OpenAiAuthStatus>,
 }
 
 // ========== 提示词广场 API (Prompt Plaza) ==========

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -3,7 +3,7 @@ import { apiClient } from './config'
 export interface LLMConfigProfile {
   id: string
   name: string
-  provider: 'openai' | 'anthropic'
+  provider: 'openai' | 'anthropic' | 'gemini' | 'minimax'
   api_key: string
   base_url: string
   model: string

--- a/frontend/src/components/settings/ModelSettingsModal.vue
+++ b/frontend/src/components/settings/ModelSettingsModal.vue
@@ -152,6 +152,7 @@ const isUnifiedMode = ref(true)
 
 const providerOptions = [
   { label: 'OpenAI 兼容', value: 'openai' },
+  { label: 'MiniMax', value: 'minimax' },
   { label: 'Anthropic / Claude', value: 'anthropic' },
   { label: 'Gemini', value: 'gemini' },
 ]
@@ -185,6 +186,14 @@ const formData = reactive<ModelRoleConfig>({
   knowledge_model_base_url: '',
   knowledge_model: '',
 })
+
+function presetKeyForProvider(provider: string, baseUrl: string): string {
+  if (provider === 'minimax') return 'minimax'
+  if (provider === 'openai' && !baseUrl.trim()) return 'openai-official'
+  if (provider === 'anthropic') return 'claude-official'
+  if (provider === 'gemini') return 'gemini-official'
+  return 'custom-openai-compatible'
+}
 
 async function loadData() {
   try {
@@ -245,7 +254,8 @@ async function handleSave() {
       extra_query: {},
       extra_body: {},
       notes: '',
-      preset_key: 'custom-openai-compatible',
+      auth_mode: 'api_key',
+      preset_key: presetKeyForProvider(formData.default_model_provider, formData.default_model_base_url),
     }
 
     if (profiles.length > 0 && profiles[0].id === mainProfile.id) {
@@ -272,7 +282,8 @@ async function handleSave() {
           extra_query: {},
           extra_body: {},
           notes: '',
-          preset_key: 'custom-openai-compatible',
+          auth_mode: 'api_key',
+          preset_key: presetKeyForProvider(provider, url),
         }
         if (existing >= 0) {
           profiles[existing] = roleProfile

--- a/frontend/src/components/workbench/LLMControlPanel.vue
+++ b/frontend/src/components/workbench/LLMControlPanel.vue
@@ -144,6 +144,51 @@
               <n-select v-model:value="selectedProfile.protocol" :options="protocolOptions" />
             </div>
 
+            <div v-if="selectedProfileSupportsOauth" class="llm-field span-2">
+              <label class="llm-label">认证方式</label>
+              <n-radio-group v-model:value="selectedProfile.auth_mode">
+                <n-space :size="12">
+                  <n-radio value="api_key">API Key</n-radio>
+                  <n-radio value="oauth">OAuth</n-radio>
+                </n-space>
+              </n-radio-group>
+              <n-alert type="info" :show-icon="false" class="llm-tip" style="margin-top: 8px">
+                <n-space vertical :size="6">
+                  <n-space align="center" :size="8" wrap>
+                    <n-tag :type="openAiReady ? 'success' : 'warning'" size="small" round>
+                      OAuth {{ openAiReady ? '已就绪' : '未就绪' }}
+                    </n-tag>
+                    <n-tag :type="oauthStatusTagType" size="small" round>
+                      {{ oauthStatusMessage }}
+                    </n-tag>
+                  </n-space>
+                  <n-text depth="3" style="font-size: 12px">
+                    {{ openAiAuthHint }}
+                  </n-text>
+                  <n-space :size="8" wrap>
+                    <n-button
+                      v-if="selectedProfile.auth_mode === 'oauth'"
+                      type="primary"
+                      size="small"
+                      :loading="authLoading"
+                      @click="handleOpenAiLogin"
+                    >
+                      登录 OAuth
+                    </n-button>
+                    <n-button
+                      v-if="selectedProfile.auth_mode === 'oauth' && oauthStatus.status === 'connected'"
+                      secondary
+                      size="small"
+                      :loading="authLoading"
+                      @click="handleOpenAiLogout"
+                    >
+                      退出登录
+                    </n-button>
+                  </n-space>
+                </n-space>
+              </n-alert>
+            </div>
+
             <div class="llm-field span-2">
               <label class="llm-label">Base URL</label>
               <n-input v-model:value="selectedProfile.base_url" placeholder="可填官方地址，也可填兼容网关地址" />
@@ -155,6 +200,7 @@
                 v-model:value="selectedProfile.api_key"
                 type="password"
                 show-password-on="click"
+                :disabled="selectedProfileSupportsOauth && selectedProfile.auth_mode === 'oauth'"
                 placeholder="本地保存；仅用于当前项目"
               />
             </div>
@@ -173,7 +219,7 @@
                   secondary
                   size="small"
                   :loading="fetchingModels"
-                  :disabled="!selectedProfile.api_key"
+                  :disabled="!selectedProfile.api_key && !(selectedProfileSupportsOauth && selectedProfile.auth_mode === 'oauth')"
                   @click="handleFetchModels"
                 >
                   拉取模型
@@ -239,6 +285,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useMessage } from 'naive-ui'
 import {
   llmControlApi,
+  type OpenAiAuthStatus,
   type LLMControlPanelData,
   type LLMPreset,
   type LLMProfile,
@@ -271,7 +318,9 @@ const loading = ref(false)
 const saving = ref(false)
 const testing = ref(false)
 const fetchingModels = ref(false)
+const authLoading = ref(false)
 const fetchedModels = ref<ModelItem[]>([])
+const oauthStatus = ref<OpenAiAuthStatus>({ status: 'disconnected', message: '' })
 const selectedProfileId = ref('')
 const extraHeadersText = ref('{}')
 const extraQueryText = ref('{}')
@@ -281,6 +330,7 @@ const sidebarListRef = ref<HTMLElement | null>(null)
 
 const protocolOptions = [
   { label: 'OpenAI 兼容', value: 'openai' },
+  { label: 'MiniMax', value: 'minimax' },
   { label: 'Anthropic / Claude 兼容', value: 'anthropic' },
   { label: 'Gemini', value: 'gemini' },
 ]
@@ -303,6 +353,41 @@ const selectedProfile = computed(() =>
 const selectedPreset = computed<LLMPreset | null>(() => {
   if (!selectedProfile.value || !panelData.value) return null
   return panelData.value.presets.find((preset) => preset.key === selectedProfile.value?.preset_key) || null
+})
+
+const selectedProfileSupportsOauth = computed(() =>
+  selectedProfile.value?.protocol === 'openai' && selectedProfile.value?.preset_key === 'openai-official'
+)
+
+const openAiReady = computed(() =>
+  selectedProfile.value?.auth_mode !== 'oauth' || oauthStatus.value.status === 'connected'
+)
+
+const oauthStatusTagType = computed(() => {
+  switch (oauthStatus.value.status) {
+    case 'connected':
+      return 'success'
+    case 'pending':
+      return 'warning'
+    case 'error':
+      return 'error'
+    default:
+      return 'default'
+  }
+})
+
+const oauthStatusMessage = computed(() =>
+  oauthStatus.value.message || oauthStatus.value.status
+)
+
+const openAiAuthHint = computed(() => {
+  if (selectedProfile.value?.auth_mode !== 'oauth') {
+    return '当前为 API Key 模式。切换到 OAuth 后，登录状态会由后台自动校验。'
+  }
+  if (oauthStatus.value.status === 'connected') {
+    return 'OAuth 已连接。当前配置保存后会直接使用授权 token。'
+  }
+  return '点击登录会调用后台 OAuth 起始接口，并在必要时打开授权页面。'
 })
 
 const runtimeLabel = computed(() => {
@@ -328,6 +413,7 @@ async function handleFetchModels() {
       protocol: selectedProfile.value.protocol,
       base_url: selectedProfile.value.base_url,
       api_key: selectedProfile.value.api_key,
+      auth_mode: selectedProfile.value.auth_mode,
     })
     if (result.success && result.items.length > 0) {
       fetchedModels.value = result.items
@@ -399,6 +485,7 @@ function buildProfileFromPreset(preset?: LLMPreset): LLMProfile {
     protocol: (preset?.protocol || 'openai') as LLMProtocol,
     base_url: preset?.default_base_url || '',
     api_key: '',
+    auth_mode: preset?.key === 'openai-official' ? 'oauth' : 'api_key',
     model: preset?.default_model || '',
     temperature: 0.7,
     max_tokens: 4096,
@@ -451,8 +538,12 @@ function commitAdvancedEditors() {
 async function loadPanel() {
   loading.value = true
   try {
-    const data = await llmControlApi.getPanel()
+    const [data, oauth] = await Promise.all([
+      llmControlApi.getPanel(),
+      llmControlApi.getOpenAiStatus().catch(() => ({ status: 'disconnected', message: '' } as OpenAiAuthStatus)),
+    ])
     panelData.value = deepClone(data)
+    oauthStatus.value = oauth
     const persistedState = readUiState()
     const preferredId = persistedState.selectedProfileId || selectedProfileId.value
     const candidateId = preferredId && data.config.profiles.some((profile) => profile.id === preferredId)
@@ -538,6 +629,7 @@ function applyPresetToSelected() {
   const preset = panelData.value.presets.find((item) => item.key === selectedProfile.value?.preset_key)
   if (!preset) return
   selectedProfile.value.protocol = preset.protocol
+  selectedProfile.value.auth_mode = preset.key === 'openai-official' ? 'oauth' : 'api_key'
   if (preset.default_base_url) selectedProfile.value.base_url = preset.default_base_url
   if (preset.default_model) selectedProfile.value.model = preset.default_model
   if (!selectedProfile.value.name || selectedProfile.value.name === '新配置') {
@@ -609,16 +701,107 @@ async function testSelected() {
   }
 }
 
+let oauthPollTimer: number | null = null
+let oauthPollAttempts = 0
+
+async function refreshOauthStatus() {
+  oauthStatus.value = await llmControlApi.getOpenAiStatus()
+  if (oauthStatus.value.status !== 'pending') {
+    stopOauthPolling()
+  }
+  return oauthStatus.value
+}
+
+function startOauthPolling() {
+  stopOauthPolling()
+  oauthPollAttempts = 0
+  oauthPollTimer = window.setInterval(async () => {
+    oauthPollAttempts += 1
+    try {
+      const status = await refreshOauthStatus()
+      if (status.status === 'connected') {
+        stopOauthPolling()
+        return
+      }
+      if (status.status === 'error' || oauthPollAttempts >= 80) {
+        stopOauthPolling()
+      }
+    } catch {
+      if (oauthPollAttempts >= 80) {
+        stopOauthPolling()
+      }
+    }
+  }, 1500)
+}
+
+function stopOauthPolling() {
+  if (oauthPollTimer !== null) {
+    window.clearInterval(oauthPollTimer)
+    oauthPollTimer = null
+  }
+}
+
+async function handleOpenAiLogin() {
+  authLoading.value = true
+  try {
+    const result = await llmControlApi.startOpenAiAuth()
+    if (result.url) {
+      const opened = window.open(result.url, 'openai-oauth', 'popup=yes,width=540,height=720')
+      if (!opened) {
+        throw new Error('浏览器拦截了 OAuth 登录弹窗，请允许弹窗后重试')
+      }
+    }
+    await refreshOauthStatus().catch(() => {})
+    if (result.status === 'pending') {
+      startOauthPolling()
+    }
+    message.success('已发起 OpenAI OAuth 登录')
+  } catch (error) {
+    message.error(error instanceof Error ? error.message : 'OpenAI 登录失败')
+  } finally {
+    authLoading.value = false
+  }
+}
+
+async function handleOpenAiLogout() {
+  authLoading.value = true
+  try {
+    oauthStatus.value = await llmControlApi.logoutOpenAiAuth()
+    message.success('已退出 OpenAI OAuth')
+  } catch (error) {
+    message.error(error instanceof Error ? error.message : 'OpenAI 退出登录失败')
+  } finally {
+    stopOauthPolling()
+    authLoading.value = false
+  }
+}
+
+async function handleOauthMessage(event: MessageEvent) {
+  const payload = event.data
+  if (!payload || typeof payload !== 'object' || payload.type !== 'openai-oauth-complete') {
+    return
+  }
+  await refreshOauthStatus().catch(() => {})
+  if (payload.status === 'connected') {
+    message.success(payload.message || 'OpenAI OAuth 登录成功')
+    return
+  }
+  message.error(payload.message || 'OpenAI OAuth 登录失败')
+}
+
 watch(selectedProfileId, () => {
   syncJsonEditors()
   saveUiState()
 })
 
 onMounted(() => {
+  window.addEventListener('message', handleOauthMessage)
   void loadPanel()
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('message', handleOauthMessage)
+  stopOauthPolling()
   saveUiState()
 })
 </script>

--- a/infrastructure/ai/provider_factory.py
+++ b/infrastructure/ai/provider_factory.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 
 from application.ai.llm_control_service import LLMControlService, LLMProfile
+from application.codex.services.openai_oauth_service import OpenAiOauthService
 from domain.ai.services.llm_service import GenerationConfig, GenerationResult, LLMService
 from domain.ai.value_objects.prompt import Prompt
 from infrastructure.ai.config.settings import Settings
@@ -20,18 +21,33 @@ _DEFAULT_CONFIG = GenerationConfig()
 
 
 class LLMProviderFactory:
-    def __init__(self, control_service: Optional[LLMControlService] = None):
+    def __init__(
+        self,
+        control_service: Optional[LLMControlService] = None,
+        openai_oauth_service: Optional[OpenAiOauthService] = None,
+    ):
         self.control_service = control_service or LLMControlService()
+        self.openai_oauth_service = openai_oauth_service or OpenAiOauthService()
 
     def create_from_profile(self, profile: Optional[LLMProfile]) -> LLMService:
         if profile is None:
             return MockProvider()
 
         resolved = self.control_service.resolve_profile(profile)
-        if not resolved.api_key.strip() or not resolved.model.strip():
+        if not resolved.model.strip():
             return MockProvider()
 
-        settings = self._profile_to_settings(resolved)
+        api_key = resolved.api_key.strip()
+        if resolved.protocol == 'openai' and resolved.auth_mode == 'oauth':
+            oauth_status = self.openai_oauth_service.get_status()
+            if oauth_status.get('status') != 'connected':
+                return MockProvider()
+            api_key = (self.openai_oauth_service.get_access_token() or '').strip()
+
+        if not api_key:
+            return MockProvider()
+
+        settings = self._profile_to_settings(resolved, api_key=api_key)
         if resolved.protocol == 'anthropic':
             return AnthropicProvider(settings)
         if resolved.protocol == 'gemini':
@@ -41,7 +57,7 @@ class LLMProviderFactory:
     def create_active_provider(self) -> LLMService:
         return self.create_from_profile(self.control_service.resolve_active_profile())
 
-    def _profile_to_settings(self, profile: LLMProfile) -> Settings:
+    def _profile_to_settings(self, profile: LLMProfile, api_key: Optional[str] = None) -> Settings:
         if profile.protocol == 'anthropic':
             normalized_base_url = normalize_anthropic_base_url(profile.base_url)
         elif profile.protocol == 'gemini':
@@ -53,7 +69,7 @@ class LLMProviderFactory:
             default_model=profile.model,
             default_temperature=profile.temperature,
             default_max_tokens=profile.max_tokens,
-            api_key=profile.api_key,
+            api_key=api_key if api_key is not None else profile.api_key,
             base_url=normalized_base_url,
             timeout_seconds=profile.timeout_seconds,
             extra_headers=profile.extra_headers,

--- a/infrastructure/persistence/database/connection.py
+++ b/infrastructure/persistence/database/connection.py
@@ -245,6 +245,86 @@ def _apply_migration_files(conn: sqlite3.Connection) -> None:
             logger.warning(f"Migration file not found: {migration_path}")
 
 
+def _migrate_llm_profiles_schema(conn: sqlite3.Connection) -> None:
+    """补齐 llm_profiles 的 auth_mode，并放宽 protocol CHECK 以支持 minimax。"""
+    cur = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='llm_profiles' LIMIT 1"
+    )
+    if cur.fetchone() is None:
+        return
+
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(llm_profiles)").fetchall()}
+    needs_auth_mode = "auth_mode" not in cols
+
+    create_sql_row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='llm_profiles'"
+    ).fetchone()
+    create_sql = (create_sql_row[0] or "") if create_sql_row else ""
+    needs_protocol_upgrade = "'minimax'" not in create_sql
+
+    if not needs_auth_mode and not needs_protocol_upgrade:
+        return
+
+    conn.execute("ALTER TABLE llm_profiles RENAME TO llm_profiles_legacy")
+    conn.execute(
+        """
+        CREATE TABLE llm_profiles (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL DEFAULT '',
+            preset_key TEXT NOT NULL DEFAULT 'custom-openai-compatible',
+            protocol TEXT NOT NULL DEFAULT 'openai' CHECK(protocol IN ('openai', 'anthropic', 'gemini', 'minimax')),
+            base_url TEXT NOT NULL DEFAULT '',
+            api_key TEXT NOT NULL DEFAULT '',
+            auth_mode TEXT NOT NULL DEFAULT 'api_key' CHECK(auth_mode IN ('api_key', 'oauth')),
+            model TEXT NOT NULL DEFAULT '',
+            temperature REAL NOT NULL DEFAULT 0.7,
+            max_tokens INTEGER NOT NULL DEFAULT 4096,
+            timeout_seconds INTEGER NOT NULL DEFAULT 300,
+            extra_headers TEXT NOT NULL DEFAULT '{}',
+            extra_query TEXT NOT NULL DEFAULT '{}',
+            extra_body TEXT NOT NULL DEFAULT '{}',
+            notes TEXT NOT NULL DEFAULT '',
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO llm_profiles (
+            id, name, preset_key, protocol, base_url, api_key, auth_mode, model,
+            temperature, max_tokens, timeout_seconds, extra_headers, extra_query,
+            extra_body, notes, sort_order, created_at, updated_at
+        )
+        SELECT
+            id,
+            name,
+            preset_key,
+            protocol,
+            base_url,
+            api_key,
+            'api_key' AS auth_mode,
+            model,
+            temperature,
+            max_tokens,
+            timeout_seconds,
+            extra_headers,
+            extra_query,
+            extra_body,
+            notes,
+            sort_order,
+            created_at,
+            updated_at
+        FROM llm_profiles_legacy
+        """
+    )
+    conn.execute("DROP TABLE llm_profiles_legacy")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_profiles_sort ON llm_profiles(sort_order)")
+    conn.commit()
+    logger.info("llm_profiles migration: added auth_mode and minimax protocol support")
+
+
 def _ensure_triple_provenance_table(conn: sqlite3.Connection) -> None:
     """旧库补齐 triple_provenance 表（schema.sql 对新库已包含）。"""
     conn.execute(
@@ -320,6 +400,7 @@ class DatabaseConnection:
         _apply_last_chapter_audit_columns(conn)
         _apply_character_enhancements(conn)
         _apply_chapter_summaries_enhancements(conn)
+        _migrate_llm_profiles_schema(conn)
         _ensure_triple_provenance_table(conn)
         _apply_migration_files(conn)
         conn.close()

--- a/infrastructure/persistence/database/schema.sql
+++ b/infrastructure/persistence/database/schema.sql
@@ -600,9 +600,10 @@ CREATE TABLE IF NOT EXISTS llm_profiles (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL DEFAULT '',
     preset_key TEXT NOT NULL DEFAULT 'custom-openai-compatible',
-    protocol TEXT NOT NULL DEFAULT 'openai' CHECK(protocol IN ('openai', 'anthropic', 'gemini')),
+    protocol TEXT NOT NULL DEFAULT 'openai' CHECK(protocol IN ('openai', 'anthropic', 'gemini', 'minimax')),
     base_url TEXT NOT NULL DEFAULT '',
     api_key TEXT NOT NULL DEFAULT '',
+    auth_mode TEXT NOT NULL DEFAULT 'api_key' CHECK(auth_mode IN ('api_key', 'oauth')),
     model TEXT NOT NULL DEFAULT '',
     temperature REAL NOT NULL DEFAULT 0.7,
     max_tokens INTEGER NOT NULL DEFAULT 4096,
@@ -617,6 +618,5 @@ CREATE TABLE IF NOT EXISTS llm_profiles (
 );
 
 CREATE INDEX IF NOT EXISTS idx_llm_profiles_sort ON llm_profiles(sort_order);
-
 
 

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -32,6 +32,7 @@ from infrastructure.persistence.database.sqlite_timeline_repository import Sqlit
 from infrastructure.ai.config.settings import Settings
 from infrastructure.ai.provider_factory import DynamicLLMService, LLMProviderFactory
 from application.ai.llm_control_service import LLMControlService
+from application.codex.services.openai_oauth_service import OpenAiOauthService
 
 from application.core.services.novel_service import NovelService
 from application.core.services.chapter_service import ChapterService
@@ -128,8 +129,16 @@ def get_llm_control_service() -> LLMControlService:
 
 
 @lru_cache
+def get_openai_oauth_service() -> OpenAiOauthService:
+    return OpenAiOauthService()
+
+
+@lru_cache
 def get_llm_provider_factory() -> LLMProviderFactory:
-    return LLMProviderFactory(get_llm_control_service())
+    return LLMProviderFactory(
+        get_llm_control_service(),
+        get_openai_oauth_service(),
+    )
 
 
 def llm_runtime_is_mock(llm_service: Optional[LLMService] = None) -> bool:
@@ -954,4 +963,3 @@ def get_foreshadow_ledger_service():
     """
     from application.analyst.services.foreshadow_ledger_service import ForeshadowLedgerService
     return ForeshadowLedgerService(get_foreshadowing_repository())
-

--- a/interfaces/api/v1/system/openai_auth_routes.py
+++ b/interfaces/api/v1/system/openai_auth_routes.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+
+from interfaces.api.dependencies import get_openai_oauth_service
+
+
+router = APIRouter(prefix="/auth/openai", tags=["openai-auth"])
+
+
+@router.get("/status")
+def get_status(service=Depends(get_openai_oauth_service)):
+    return service.get_status()
+
+
+@router.post("/start")
+def start(service=Depends(get_openai_oauth_service)):
+    return service.start_auth_flow()
+
+
+@router.post("/logout")
+def logout(service=Depends(get_openai_oauth_service)):
+    return service.logout()

--- a/interfaces/api/v1/workbench/llm_control.py
+++ b/interfaces/api/v1/workbench/llm_control.py
@@ -5,7 +5,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from application.ai.llm_control_service import (
@@ -15,6 +15,7 @@ from application.ai.llm_control_service import (
     LLMTestResult,
     LLMControlService,
 )
+from interfaces.api.dependencies import get_openai_oauth_service
 from infrastructure.ai.provider_factory import LLMProviderFactory
 from infrastructure.ai.prompt_manager import get_prompt_manager
 
@@ -32,6 +33,7 @@ class ModelListRequest(BaseModel):
     protocol: str = 'openai'
     base_url: str = ''
     api_key: str = ''
+    auth_mode: str = 'api_key'
     timeout_ms: int = 30000
 
 
@@ -65,7 +67,10 @@ def _normalize_model_items(data: Dict[str, Any]) -> List[ModelItem]:
 
 
 @router.post('/models', response_model=ModelListResponse)
-async def list_models(payload: ModelListRequest) -> ModelListResponse:
+async def list_models(
+    payload: ModelListRequest,
+    oauth_service=Depends(get_openai_oauth_service),
+) -> ModelListResponse:
     """根据当前配置的 endpoint 拉取模型列表（OpenAI / Anthropic 兼容）。"""
     candidate = payload.model_dump()
     if not candidate.get('api_key'):
@@ -75,7 +80,10 @@ async def list_models(payload: ModelListRequest) -> ModelListResponse:
             candidate['api_key'] = active.api_key
 
     api_format = (candidate.get('protocol') or '').strip().lower()
+    auth_mode = (candidate.get('auth_mode') or 'api_key').strip().lower()
     api_key = (candidate.get('api_key') or '').strip()
+    if api_format == 'openai' and auth_mode == 'oauth' and not api_key:
+        api_key = (oauth_service.get_access_token() or '').strip()
     if not api_key:
         raise HTTPException(status_code=400, detail='API key is required to fetch model list')
 

--- a/interfaces/main.py
+++ b/interfaces/main.py
@@ -71,6 +71,7 @@ from interfaces.api.v1.analyst import voice, narrative_state, foreshadow_ledger
 
 # Workbench module
 from interfaces.api.v1.workbench import sandbox, writer_block, monitor, llm_control
+from interfaces.api.v1.system import openai_auth_routes
 from interfaces.api.stats.routers.stats import create_stats_router
 from interfaces.api.stats.services.stats_service import StatsService
 from interfaces.api.stats.repositories.sqlite_stats_repository_adapter import SqliteStatsRepositoryAdapter
@@ -390,6 +391,7 @@ app.include_router(writer_block.router, prefix="/api/v1")
 app.include_router(sandbox.router, prefix="/api/v1")
 app.include_router(monitor.router, prefix="/api/v1")
 app.include_router(llm_control.router, prefix="/api/v1")
+app.include_router(openai_auth_routes.router, prefix="/api/v1")
 
 # 注册统计路由（使用 SQLite 适配器）
 stats_repository = SqliteStatsRepositoryAdapter(get_database())

--- a/tests/integration/interfaces/api/v1/test_openai_auth_api.py
+++ b/tests/integration/interfaces/api/v1/test_openai_auth_api.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from interfaces.api.dependencies import get_openai_oauth_service
+from interfaces.api.v1.system.openai_auth_routes import router
+
+
+class _StubOauthService:
+    def get_status(self):
+        return {"status": "disconnected", "message": ""}
+
+    def start_auth_flow(self):
+        return {"status": "pending", "url": "https://auth.openai.com/example"}
+
+    def logout(self):
+        return {"status": "disconnected", "message": "Logged out"}
+
+
+def test_get_openai_auth_status_returns_disconnected():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_openai_oauth_service] = lambda: _StubOauthService()
+    client = TestClient(app)
+
+    try:
+        response = client.get("/api/v1/auth/openai/status")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["status"] in {"disconnected", "connected", "pending", "error"}
+
+
+def test_start_openai_auth_returns_url():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[get_openai_oauth_service] = lambda: _StubOauthService()
+    client = TestClient(app)
+
+    try:
+        response = client.post("/api/v1/auth/openai/start")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "pending",
+        "url": "https://auth.openai.com/example",
+    }

--- a/tests/unit/application/ai/test_llm_control_service_minimax.py
+++ b/tests/unit/application/ai/test_llm_control_service_minimax.py
@@ -1,0 +1,12 @@
+from application.ai.llm_control_service import LLMControlService
+
+
+def test_get_presets_includes_minimax_with_2_7_defaults():
+    service = LLMControlService()
+
+    presets = {preset.key: preset for preset in service.get_presets()}
+
+    assert "minimax" in presets
+    assert presets["minimax"].protocol == "minimax"
+    assert presets["minimax"].default_base_url == "https://api.minimaxi.com/v1"
+    assert presets["minimax"].default_model == "MiniMax-M2.7"

--- a/tests/unit/infrastructure/ai/test_provider_factory_oauth.py
+++ b/tests/unit/infrastructure/ai/test_provider_factory_oauth.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch
+
+from application.ai.llm_control_service import LLMProfile
+from infrastructure.ai.provider_factory import LLMProviderFactory
+from infrastructure.ai.providers.mock_provider import MockProvider
+
+
+class _StubControlService:
+    def resolve_profile(self, profile: LLMProfile) -> LLMProfile:
+        return profile
+
+
+class _StubOauthService:
+    def __init__(self, status: str, token: str | None):
+        self._status = status
+        self._token = token
+
+    def get_status(self) -> dict:
+        return {"status": self._status}
+
+    def get_access_token(self) -> str | None:
+        return self._token
+
+
+def test_create_from_profile_uses_oauth_token_for_openai_profile():
+    profile = LLMProfile(
+        id="openai-oauth",
+        name="OpenAI OAuth",
+        preset_key="openai-official",
+        protocol="openai",
+        api_key="",
+        model="gpt-5.4",
+        auth_mode="oauth",
+    )
+
+    factory = LLMProviderFactory(
+        control_service=_StubControlService(),
+        openai_oauth_service=_StubOauthService(status="connected", token="oauth-token"),
+    )
+
+    with patch("infrastructure.ai.provider_factory.OpenAIProvider") as mock_provider:
+        factory.create_from_profile(profile)
+
+    settings = mock_provider.call_args.args[0]
+    assert settings.api_key == "oauth-token"
+    assert settings.default_model == "gpt-5.4"
+
+
+def test_create_from_profile_returns_mock_when_oauth_not_connected():
+    profile = LLMProfile(
+        id="openai-oauth",
+        name="OpenAI OAuth",
+        preset_key="openai-official",
+        protocol="openai",
+        api_key="",
+        model="gpt-5.4",
+        auth_mode="oauth",
+    )
+
+    factory = LLMProviderFactory(
+        control_service=_StubControlService(),
+        openai_oauth_service=_StubOauthService(status="disconnected", token=None),
+    )
+
+    result = factory.create_from_profile(profile)
+
+    assert isinstance(result, MockProvider)


### PR DESCRIPTION
## What changed
- add a first-class `MiniMax` preset in the LLM control flow, including `MiniMax-M2.7` defaults and schema support for the new provider
- add `auth_mode` persistence for LLM profiles and wire `oauth` mode into the OpenAI official preset
- add local OpenAI OAuth start/status/logout endpoints plus workbench UI controls for login/logout and OAuth-based model fetching
- add database migration coverage and automated tests for MiniMax defaults, OAuth provider selection, and auth API routes

## Why
The current project requires manual API key entry for every provider and does not expose MiniMax as a first-class option. This PR makes MiniMax configurable out of the box and lets OpenAI official access reuse Codex-style local OAuth tokens instead of forcing users to manage keys manually.

## User impact
- users can pick MiniMax directly from the LLM presets and start from the correct default base URL/model
- users can switch the OpenAI official preset to OAuth mode and log in from the workbench UI
- existing SQLite installs migrate in place without losing saved LLM profiles

## Validation
- `/Users/mac/Desktop/codex/PlotPilot-独立部署/.venv/bin/python -m pytest -q tests/unit/application/ai/test_llm_control_service_minimax.py tests/unit/infrastructure/ai/test_provider_factory_oauth.py tests/integration/interfaces/api/v1/test_openai_auth_api.py`
- `cd /Users/mac/Desktop/codex/PlotPilot-独立部署/frontend && npm run build`

## Notes
- live browser OAuth round-trip against production OpenAI auth was not exercised in CI automation
- unrelated local debugging fixes remain unstaged in the working tree and are intentionally excluded from this PR