### PR TITLE
feat:简单的说就是有的模型不支持reponse API，张力API没办法使用，就设置一个flag，当他的不支持response，就用chat，全程用chat

### DIFF
--- a/application/ai/llm_control_service.py
+++ b/application/ai/llm_control_service.py
@@ -405,6 +405,19 @@ class LLMControlService:
             using_mock=False,
         )
 
+    def update_profile_legacy_flag(self, profile_id: str, use_legacy: bool) -> None:
+        """更新指定 profile 的 use_legacy_chat_completions 标志（持久化到数据库）。
+
+        当发现某个 base_url 不支持 Responses API 时调用此方法，
+        下次启动时会直接使用 Chat Completions API 而不再尝试 Responses API。
+        """
+        db = self._db()
+        db.execute(
+            "UPDATE llm_profiles SET use_legacy_chat_completions = ? WHERE id = ?",
+            (int(use_legacy), profile_id),
+        )
+        logger.info("已更新 profile %s 的 use_legacy_chat_completions 为 %s", profile_id, use_legacy)
+
     async def test_profile_model(
         self,
         profile: LLMProfile,

--- a/application/analyst/services/tension_analyzer.py
+++ b/application/analyst/services/tension_analyzer.py
@@ -1,9 +1,10 @@
 """张力分析器服务"""
 import json
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 from application.workbench.dtos.writer_block_dto import TensionSlingshotRequest, TensionDiagnosis
 from domain.novel.repositories.narrative_event_repository import NarrativeEventRepository
+from application.ai.llm_json_extract import parse_llm_json_to_dict
 
 
 class TensionAnalyzer:
@@ -146,13 +147,15 @@ class TensionAnalyzer:
 4. 建议必须是动作导向的，使用"引入"、"增加"、"设置"、"让"等动词开头
 5. 建议要具体，不要泛泛而谈
 
-请以 JSON 格式返回结果:
+请按照以下json格式进行输出，可以被Python json.loads函数解析。只给出JSON，不作解释，不作答：
+```json
 {{
     "diagnosis": "诊断结果（2-3句话）",
     "tension_level": "low/medium/high",
     "missing_elements": ["缺失元素1", "缺失元素2"],
     "suggestions": ["具体建议1", "具体建议2", "具体建议3"]
 }}
+```
 """
 
         return prompt
@@ -166,19 +169,25 @@ class TensionAnalyzer:
         Returns:
             TensionDiagnosis 对象
         """
-        try:
-            # 尝试解析 JSON
-            data = json.loads(response)
+        data, errors = parse_llm_json_to_dict(response)
+        if data is None:
             return TensionDiagnosis(
-                diagnosis=data["diagnosis"],
-                tension_level=data["tension_level"],
-                missing_elements=data["missing_elements"],
-                suggestions=data["suggestions"]
+                diagnosis=f"解析响应失败: {'; '.join(errors)}",
+                tension_level="low",
+                missing_elements=["parse_error"],
+                suggestions=["请检查 LLM 响应格式"]
             )
-        except (json.JSONDecodeError, KeyError) as e:
-            # 如果解析失败，返回默认结果
+
+        try:
             return TensionDiagnosis(
-                diagnosis=f"解析响应失败: {str(e)}",
+                diagnosis=str(data.get("diagnosis", "暂无诊断信息")),
+                tension_level=str(data.get("tension_level", "low")),
+                missing_elements=[str(x) for x in data.get("missing_elements", [])],
+                suggestions=[str(x) for x in data.get("suggestions", [])]
+            )
+        except KeyError as e:
+            return TensionDiagnosis(
+                diagnosis=f"解析响应失败: 缺少字段 {str(e)}",
                 tension_level="low",
                 missing_elements=["parse_error"],
                 suggestions=["请检查 LLM 响应格式"]

--- a/infrastructure/ai/config/settings.py
+++ b/infrastructure/ai/config/settings.py
@@ -23,6 +23,7 @@ class Settings:
     provider_name: Optional[str] = None
     protocol: Optional[str] = None
     use_legacy_chat_completions: bool = False
+    profile_id: Optional[str] = None
 
     def __post_init__(self):
         """验证配置参数"""

--- a/infrastructure/ai/provider_factory.py
+++ b/infrastructure/ai/provider_factory.py
@@ -62,6 +62,7 @@ class LLMProviderFactory:
             provider_name=profile.name,
             protocol=profile.protocol,
             use_legacy_chat_completions=profile.use_legacy_chat_completions,
+            profile_id=profile.id,
         )
 
 

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -1,7 +1,7 @@
 """OpenAI LLM 提供商实现"""
 import logging
 import openai
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Optional
 
 from openai import AsyncOpenAI
 
@@ -34,6 +34,7 @@ class OpenAIProvider(BaseProvider):
             raise ValueError("API key is required for OpenAIProvider")
 
         self._use_legacy = settings.use_legacy_chat_completions
+        self._profile_id = settings.profile_id
 
         client_kwargs = {
             "api_key": settings.api_key,
@@ -45,6 +46,17 @@ class OpenAIProvider(BaseProvider):
             client_kwargs["base_url"] = settings.base_url
 
         self.async_client = AsyncOpenAI(**client_kwargs)
+
+    def _persist_legacy_flag(self, use_legacy: bool) -> None:
+        """将 use_legacy_chat_completions 标志持久化到数据库（仅当有 profile_id 时）。"""
+        if not self._profile_id:
+            return
+        try:
+            from application.ai.llm_control_service import LLMControlService
+            control_service = LLMControlService()
+            control_service.update_profile_legacy_flag(self._profile_id, use_legacy)
+        except Exception as e:
+            logger.warning("Failed to persist legacy flag to database: %s", e)
 
     async def generate(
         self,
@@ -61,11 +73,13 @@ class OpenAIProvider(BaseProvider):
                 except (openai.NotFoundError, openai.BadRequestError, RuntimeError) as e:
                     logger.info(f"Responses API unsupported for {base_url}, falling back to chat completions: {str(e)}")
                     self.__class__._fallback_to_chat_cache.add(base_url)
+                    self._persist_legacy_flag(True)
                 except Exception as e:
                     # 某些网关在路径错误时可能不抛严格的 404 而是抛出其他错误，如果消息含有明确路径错误也尝试降级
                     if "404" in str(e) or "Not Found" in str(e) or "400" in str(e) or "Account invalid" in str(e) or "INVALID_ARGUMENT" in str(e):
                         logger.info(f"Gateway returned error for Responses API ({base_url}), falling back: {str(e)}")
                         self.__class__._fallback_to_chat_cache.add(base_url)
+                        self._persist_legacy_flag(True)
                     else:
                         raise
 
@@ -121,10 +135,12 @@ class OpenAIProvider(BaseProvider):
                 except (openai.NotFoundError, openai.BadRequestError):
                     self.__class__._fallback_to_chat_cache.add(base_url)
                     logger.info(f"Stream: Responses API unsupported for {base_url}, falling back.")
+                    self._persist_legacy_flag(True)
                 except Exception as e:
                     if "404" in str(e) or "Not Found" in str(e) or "400" in str(e) or "Account invalid" in str(e) or "INVALID_ARGUMENT" in str(e):
                         self.__class__._fallback_to_chat_cache.add(base_url)
                         logger.info(f"Stream: Gateway returned error for Responses API ({base_url}), falling back.")
+                        self._persist_legacy_flag(True)
                     else:
                         logger.error(f"[Responses Stream] Failed: {e}")
                         raise


### PR DESCRIPTION
…arsing

1. LLM Provider: Persist fallback flag to database
   - When Responses API is unsupported, auto-fallback to Chat Completions
   - Persist use_legacy_chat_completions flag to llm_profiles table
   - Next startup will use Chat API directly without retrying Responses API
   - Add LLMControlService.update_profile_legacy_flag() method
   - Add profile_id field to Settings for identifying current config

2. Tension analyzer: Improve JSON parsing
   - Use project-standard llm_json_extract.parse_llm_json_to_dict()
   - Update prompt to explicitly require ```json wrapper, consistent with project
   - Auto-handle markdown code blocks, extract outer JSON, auto-repair broken JSON

## 变更说明
- 

## 测试
- [ ] 本地已跑核心用例（如 `pytest ...` / `npm run test`）
- [ ] 关键路径手测通过（启动后端/前端、主要功能点）

## 风险与回滚
- 风险：
- 回滚方式：

## 变更说明
- 

## 测试
- [ ] 本地已跑核心用例（如 `pytest ...` / `npm test`）
- [ ] 关键路径手测通过（如启动后端/前端、主要功能点）

## 风险与回滚
- 风险：
- 回滚方式：



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-specific configuration support for LLM providers.
  * Automatic detection and persistence of fallback behavior when modern APIs are unavailable.

* **Bug Fixes**
  * Improved error handling for LLM response parsing with graceful fallback to default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->