### PR TITLE
feat(workbench): remove topbar prompt plaza and AI console buttons

### DIFF
--- a/frontend/src/components/global/GlobalLLMFloatingButton.vue
+++ b/frontend/src/components/global/GlobalLLMFloatingButton.vue
@@ -276,8 +276,8 @@ function applyDockPosition(shouldPersist = false) {
 
 function defaultState() {
   dockSide.value = 'right'
-  mode.value = 'expanded'
-  yRatio.value = 0.84
+  mode.value = 'minimized'
+  yRatio.value = 0.8
 }
 
 function restoreState() {

--- a/frontend/src/components/global/PromptPlazaFAB.vue
+++ b/frontend/src/components/global/PromptPlazaFAB.vue
@@ -1,19 +1,51 @@
 <template>
   <teleport to="body">
-    <div class="plaza-fab-shell">
+    <div
+      class="plaza-fab-shell"
+      :class="{ 'is-dragging': dragging, 'is-hovered': hovering }"
+      :style="shellStyle"
+    >
+      <div
+        class="plaza-fab-actions"
+        @mouseenter="setHovering(true)"
+        @mouseleave="scheduleHideHover"
+      >
+        <button
+          type="button"
+          class="plaza-fab-action"
+          :title="mode === 'expanded' ? '最小化' : '展开'"
+          @pointerdown.stop
+          @click.stop="toggleMinimize"
+        >
+          <svg v-if="mode === 'expanded'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+            <line x1="8" y1="12" x2="16" y2="12"></line>
+          </svg>
+          <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+            <line x1="8" y1="12" x2="16" y2="12"></line>
+            <line x1="12" y1="8" x2="12" y2="16"></line>
+          </svg>
+        </button>
+      </div>
+
       <!-- FAB 主按钮 -->
       <button
         ref="fabRef"
         type="button"
         class="plaza-fab-main"
-        :class="{ 'is-open': showDrawer }"
+        :class="[`mode-${mode}`, { 'is-open': showDrawer }]"
         aria-label="打开提示词广场"
-        @click="toggleDrawer"
+        @mouseenter="setHovering(true)"
+        @mouseleave="scheduleHideHover"
+        @pointerdown="onPointerDown"
+        @keydown.enter.prevent="toggleDrawer"
+        @keydown.space.prevent="toggleDrawer"
       >
         <span class="fab-glow"></span>
         <span class="fab-content">
           <span class="fab-icon">🏪</span>
-          <span v-if="showDrawer" class="fab-label">提示词广场</span>
+          <span v-if="mode === 'expanded'" class="fab-label">提示词广场</span>
         </span>
         <!-- 角标：提示词数量 -->
         <span v-if="promptCount > 0" class="fab-badge">{{ promptCount }}</span>
@@ -57,15 +89,163 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { NDrawer, NDrawerContent, NTag } from 'naive-ui'
 import PromptPlaza from '../workbench/PromptPlaza.vue'
 import { promptPlazaApi, type PromptStats } from '../../api/llmControl'
+
+type DockSide = 'left' | 'right'
+type FabMode = 'expanded' | 'minimized'
+
+interface PersistedFabState {
+  version: 1
+  dock: DockSide
+  yRatio: number
+  mode: FabMode
+}
+
+const STORAGE_KEY = 'plotpilot.prompt-plaza-fab.state.v1'
+const EDGE_GAP = 10
+const TOP_SAFE_GAP = 88
+const BOTTOM_SAFE_GAP = 24
+const CLICK_THRESHOLD = 6
 
 const fabRef = ref<HTMLButtonElement>()
 const showDrawer = ref(false)
 const promptCount = ref(0)
 const stats = ref<PromptStats | null>(null)
+const dragging = ref(false)
+const hovering = ref(false)
+const viewportWidth = ref(getViewportWidth())
+const viewportHeight = ref(getViewportHeight())
+const position = ref({ x: 0, y: 0 })
+const dockSide = ref<DockSide>('right')
+const mode = ref<FabMode>('expanded')
+const yRatio = ref(0.8)
+
+const dragState = {
+  active: false,
+  moved: false,
+  startX: 0,
+  startY: 0,
+  originX: 0,
+  originY: 0,
+}
+
+let hoverHideTimer: ReturnType<typeof setTimeout> | null = null
+
+function getViewportWidth(): number {
+  if (typeof window === 'undefined') return 1440
+  return document.documentElement?.clientWidth || window.innerWidth || 1440
+}
+
+function getViewportHeight(): number {
+  if (typeof window === 'undefined') return 900
+  return document.documentElement?.clientHeight || window.innerHeight || 900
+}
+
+const shellStyle = computed(() => ({
+  left: `${position.value.x}px`,
+  top: `${position.value.y}px`,
+}))
+
+function getFallbackSize() {
+  if (mode.value === 'minimized') return { width: 52, height: 52 }
+  return { width: 140, height: 52 }
+}
+
+function getButtonSize() {
+  const rect = fabRef.value?.getBoundingClientRect()
+  if (!rect || !rect.width || !rect.height) return getFallbackSize()
+  return {
+    width: rect.width,
+    height: rect.height,
+  }
+}
+
+function getVerticalBounds(height: number) {
+  const minY = TOP_SAFE_GAP
+  const maxY = Math.max(minY, viewportHeight.value - height - BOTTOM_SAFE_GAP)
+  return { minY, maxY }
+}
+
+function getDockedX(width: number) {
+  return dockSide.value === 'left'
+    ? EDGE_GAP
+    : Math.max(EDGE_GAP, viewportWidth.value - width - EDGE_GAP)
+}
+
+function getYFromRatio(height: number) {
+  const { minY, maxY } = getVerticalBounds(height)
+  if (maxY <= minY) return minY
+  const ratio = Math.min(Math.max(yRatio.value, 0), 1)
+  return minY + (maxY - minY) * ratio
+}
+
+function setRatioFromY(y: number, height: number) {
+  const { minY, maxY } = getVerticalBounds(height)
+  if (maxY <= minY) {
+    yRatio.value = 0
+    return
+  }
+  const safeY = Math.min(Math.max(minY, y), maxY)
+  yRatio.value = (safeY - minY) / (maxY - minY)
+}
+
+function clampFreePosition(nextX: number, nextY: number) {
+  const { width, height } = getButtonSize()
+  const maxX = Math.max(0, viewportWidth.value - width)
+  const { minY, maxY } = getVerticalBounds(height)
+  return {
+    x: Math.min(Math.max(0, nextX), maxX),
+    y: Math.min(Math.max(minY, nextY), maxY),
+  }
+}
+
+function saveState() {
+  const payload: PersistedFabState = {
+    version: 1,
+    dock: dockSide.value,
+    yRatio: Number(yRatio.value.toFixed(4)),
+    mode: mode.value,
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+}
+
+function applyDockPosition(shouldPersist = false) {
+  const { width, height } = getButtonSize()
+  position.value = {
+    x: getDockedX(width),
+    y: getYFromRatio(height),
+  }
+  if (shouldPersist) saveState()
+}
+
+function defaultState() {
+  dockSide.value = 'right'
+  mode.value = 'minimized'
+  yRatio.value = 0.8
+}
+
+function restoreState() {
+  defaultState()
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return
+    const parsed = JSON.parse(raw) as Partial<PersistedFabState> & { mode?: string }
+    if (parsed.dock === 'left' || parsed.dock === 'right') {
+      dockSide.value = parsed.dock
+    }
+    if (parsed.mode === 'expanded' || parsed.mode === 'minimized') {
+      mode.value = parsed.mode
+    }
+    if (typeof parsed.yRatio === 'number' && Number.isFinite(parsed.yRatio)) {
+      yRatio.value = Math.min(Math.max(parsed.yRatio, 0), 1)
+    }
+  } catch {
+    defaultState()
+  }
+}
 
 function toggleDrawer() {
   showDrawer.value = !showDrawer.value
@@ -86,8 +266,108 @@ async function loadStats() {
   }
 }
 
-onMounted(() => {
+function clearHoverHideTimer() {
+  if (hoverHideTimer) {
+    clearTimeout(hoverHideTimer)
+    hoverHideTimer = null
+  }
+}
+
+function setHovering(value: boolean) {
+  clearHoverHideTimer()
+  hovering.value = value
+}
+
+function scheduleHideHover() {
+  clearHoverHideTimer()
+  hoverHideTimer = setTimeout(() => {
+    hovering.value = false
+  }, 160)
+}
+
+function toggleMinimize() {
+  mode.value = mode.value === 'expanded' ? 'minimized' : 'expanded'
+}
+
+function syncViewport() {
+  viewportWidth.value = getViewportWidth()
+  viewportHeight.value = getViewportHeight()
+  applyDockPosition()
+}
+
+function stopDragging() {
+  dragState.active = false
+  dragging.value = false
+  window.removeEventListener('pointermove', onPointerMove)
+  window.removeEventListener('pointerup', onPointerUp)
+  window.removeEventListener('pointercancel', onPointerCancel)
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (!dragState.active) return
+  const dx = event.clientX - dragState.startX
+  const dy = event.clientY - dragState.startY
+  if (!dragState.moved && (Math.abs(dx) >= CLICK_THRESHOLD || Math.abs(dy) >= CLICK_THRESHOLD)) {
+    dragState.moved = true
+    dragging.value = true
+  }
+  if (!dragState.moved) return
+  position.value = clampFreePosition(dragState.originX + dx, dragState.originY + dy)
+}
+
+function snapToEdge() {
+  const { width, height } = getButtonSize()
+  const centerX = position.value.x + width / 2
+  dockSide.value = centerX < viewportWidth.value / 2 ? 'left' : 'right'
+  setRatioFromY(position.value.y, height)
+  applyDockPosition(true)
+}
+
+function onPointerUp() {
+  const moved = dragState.moved
+  stopDragging()
+  if (moved) {
+    snapToEdge()
+    return
+  }
+  toggleDrawer()
+}
+
+function onPointerCancel() {
+  stopDragging()
+  applyDockPosition()
+}
+
+function onPointerDown(event: PointerEvent) {
+  if (event.button !== 0) return
+  dragState.active = true
+  dragState.moved = false
+  dragState.startX = event.clientX
+  dragState.startY = event.clientY
+  dragState.originX = position.value.x
+  dragState.originY = position.value.y
+  window.addEventListener('pointermove', onPointerMove)
+  window.addEventListener('pointerup', onPointerUp)
+  window.addEventListener('pointercancel', onPointerCancel)
+}
+
+watch(mode, async () => {
+  await nextTick()
+  applyDockPosition(true)
+})
+
+onMounted(async () => {
+  restoreState()
+  await nextTick()
+  applyDockPosition()
+  window.addEventListener('resize', syncViewport)
   loadStats()
+})
+
+onBeforeUnmount(() => {
+  clearHoverHideTimer()
+  stopDragging()
+  window.removeEventListener('resize', syncViewport)
 })
 
 // 暴露方法供外部调用
@@ -101,18 +381,29 @@ defineExpose({
 .plaza-fab-shell {
   position: fixed;
   z-index: 890; /* 略低于 AI 控制台的 900 */
+  user-select: none;
+  touch-action: none;
+  will-change: left, top, transform;
+  transition:
+    left 0.34s cubic-bezier(0.22, 1, 0.36, 1),
+    top 0.34s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.18s ease;
+}
+
+.plaza-fab-shell.is-dragging {
+  transition: none;
 }
 
 /* ---- FAB 主按钮 ---- */
 .plaza-fab-main {
-  position: fixed;
-  bottom: 24px;
-  right: 80px; /* 在 AI 控制台左边 */
-  width: 52px;
+  position: relative;
+  display: block;
+  z-index: 1;
+  width: 140px;
   height: 52px;
   border-radius: 16px;
   border: none;
-  cursor: pointer;
+  cursor: grab;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -121,19 +412,41 @@ defineExpose({
   box-shadow:
     0 4px 14px rgba(99, 102, 241, 0.35),
     0 2px 6px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    opacity 0.18s ease,
+    border-color 0.18s ease,
+    width 0.22s ease,
+    height 0.22s ease,
+    border-radius 0.22s ease,
+    padding 0.22s ease;
   outline: none;
   overflow: visible;
 }
+
+.plaza-fab-main.mode-minimized {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+}
+
 .plaza-fab-main:hover {
   transform: translateY(-2px) scale(1.05);
   box-shadow:
     0 8px 24px rgba(99, 102, 241, 0.45),
     0 4px 10px rgba(0, 0, 0, 0.15);
 }
+
 .plaza-fab-main:active {
   transform: scale(0.96);
 }
+
+.plaza-fab-shell.is-dragging .plaza-fab-main {
+  cursor: grabbing;
+  transform: scale(1.02);
+}
+
 .plaza-fab-main.is-open {
   background: linear-gradient(135deg, #4f46e5, #7c3aed);
   box-shadow:
@@ -158,11 +471,13 @@ defineExpose({
   z-index: -1;
   animation: glow-spin 4s linear infinite paused;
 }
+
 .plaza-fab-main:hover .fab-glow,
 .plaza-fab-main.is-open .fab-glow {
   opacity: 1;
   animation-play-state: running;
 }
+
 @keyframes glow-spin {
   to { transform: rotate(360deg); }
 }
@@ -174,15 +489,18 @@ defineExpose({
   position: relative;
   z-index: 1;
 }
+
 .fab-icon {
   font-size: 22px;
   line-height: 1;
   transition: transform 0.3s;
 }
+
 .plaza-fab-main:hover .fab-icon,
 .plaza-fab-main.is-open .fab-icon {
   transform: scale(1.15) rotate(-5deg);
 }
+
 .fab-label {
   font-size: 13px;
   font-weight: 600;
@@ -190,6 +508,7 @@ defineExpose({
   letter-spacing: 0.3px;
   animation: fade-in 0.25s ease-out;
 }
+
 @keyframes fade-in {
   from { opacity: 0; transform: translateX(8px); }
   to { opacity: 1; transform: translateX(0); }
@@ -215,23 +534,77 @@ defineExpose({
   pointer-events: none;
 }
 
+/* 操作按钮 */
+.plaza-fab-actions {
+  position: absolute;
+  z-index: 2;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.56);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(14px);
+  transform: translate(-50%, 6px) scale(0.96);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.plaza-fab-shell.is-hovered .plaza-fab-actions,
+.plaza-fab-shell.is-dragging .plaza-fab-actions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0) scale(1);
+}
+
+.plaza-fab-action {
+  width: 36px;
+  height: 36px;
+  border: 0;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #e2e8f0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.16s ease, background 0.16s ease, color 0.16s ease;
+}
+
+.plaza-fab-action:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.16);
+  color: white;
+}
+
 /* ---- 抽屉头部 ---- */
 .drawer-header {
   width: 100%;
 }
+
 .drawer-title-row {
   display: flex;
   align-items: center;
   gap: 8px;
 }
+
 .drawer-icon {
   font-size: 22px;
 }
+
 .drawer-title {
   font-size: 17px;
   font-weight: 700;
   color: var(--n-text-color-1, #333);
 }
+
 .drawer-subtitle {
   margin: 4px 0 0;
   font-size: 12.5px;

--- a/frontend/src/components/stats/StatsTopBar.vue
+++ b/frontend/src/components/stats/StatsTopBar.vue
@@ -6,12 +6,6 @@
     <span>{{ error }}</span>
   </div>
   <div v-else class="stats-top-bar">
-    <!-- 左侧：AI 控制台 + 提示词广场 -->
-    <div class="topbar-left">
-      <GlobalLLMEntryButton appearance="topbar" />
-      <PromptPlazaEntryButton appearance="topbar" />
-    </div>
-
     <!-- 中间：统计数据 -->
     <div class="topbar-center">
       <div
@@ -64,8 +58,6 @@ import { computed, onMounted, ref } from 'vue'
 import { NTooltip, NSpin, NDropdown, useMessage } from 'naive-ui'
 import { useStatsStore } from '@/stores/statsStore'
 import { novelApi } from '@/api/novel'
-import GlobalLLMEntryButton from '@/components/global/GlobalLLMEntryButton.vue'
-import PromptPlazaEntryButton from '@/components/global/PromptPlazaEntryButton.vue'
 
 const props = defineProps<{
   slug: string
@@ -242,27 +234,6 @@ onMounted(async () => {
     0 4px 16px var(--color-brand-border, rgba(79, 70, 229, 0.08));
 }
 
-/* 左侧：AI 控制台入口 */
-.topbar-left {
-  flex-shrink: 0;
-  z-index: 2;
-}
-
-/* 覆盖 topbar 模式下的按钮尺寸以适应导航栏 */
-.topbar-left :deep(.global-llm-main.variant-topbar) {
-  width: auto;
-  min-height: 46px;
-  padding: 8px 14px;
-  border-radius: var(--app-radius-lg);
-}
-
-.topbar-left :deep(.plaza-main.variant-topbar) {
-  width: auto;
-  min-height: 46px;
-  padding: 8px 14px;
-  border-radius: var(--app-radius-lg);
-}
-
 /* 中间：统计数据 */
 .topbar-center {
   flex: 1;
@@ -398,26 +369,6 @@ onMounted(async () => {
     flex-wrap: wrap;
     padding: 12px 16px;
     gap: 10px;
-  }
-
-  .topbar-left {
-    order: -1;
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    gap: 8px;
-  }
-
-  .topbar-left :deep(.global-llm-main.variant-topbar) {
-    width: auto;
-    flex: 1;
-    max-width: 240px;
-  }
-
-  .topbar-left :deep(.plaza-main.variant-topbar) {
-    width: auto;
-    flex: 1;
-    max-width: 200px;
   }
 
   .topbar-center {

--- a/frontend/src/views/Workbench.vue
+++ b/frontend/src/views/Workbench.vue
@@ -59,6 +59,10 @@
 
     <!-- LLM Settings Modal -->
     <LLMSettingsModal v-model:show="showLLMSettings" />
+
+    <!-- 全局浮动按钮 -->
+    <GlobalLLMFloatingButton />
+    <PromptPlazaFAB />
   </div>
 </template>
 
@@ -75,6 +79,8 @@ import WorkArea from '../components/workbench/WorkArea.vue'
 import SettingsPanel from '../components/workbench/SettingsPanel.vue'
 import ActPlanningModal from '../components/workbench/ActPlanningModal.vue'
 import LLMSettingsModal from '../components/LLMSettingsModal.vue'
+import GlobalLLMFloatingButton from '../components/global/GlobalLLMFloatingButton.vue'
+import PromptPlazaFAB from '../components/global/PromptPlazaFAB.vue'
 
 const route = useRoute()
 const message = useMessage()


### PR DESCRIPTION
## 变更说明
- 移除workbench页面左上方排版异常的提示词广场和ai控制台
- 增加悬浮的图标可拖拽的提示词广场和ai控制台

## 测试
- [ ] 本地已跑核心用例（如 `pytest ...` / `npm run test`）
- [ ] 关键路径手测通过（启动后端/前端、主要功能点）

## 风险与回滚
- 风险：
- 回滚方式：

## 变更说明
- 

## 测试
- [x] 本地已跑核心用例（如 `pytest ...` / `npm test`）
- [x] 关键路径手测通过（如启动后端/前端、主要功能点）

## 风险与回滚
- 风险：
- 回滚方式：



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Floating buttons now support drag-and-drop repositioning with automatic edge snapping
  * Added minimize/maximize toggle for floating UI components
  * UI state (position, mode) persists across browser sessions

* **UI Changes**
  * Updated default visual positioning and modes for floating components
  * Restructured button placement within the interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->