### PR TITLE
fix(frontend): 修复故事线面板主题可见性

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test:storyline-theme": "node scripts/check-storyline-theme.mjs",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/frontend/scripts/check-storyline-theme.mjs
+++ b/frontend/scripts/check-storyline-theme.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const projectRoot = resolve(import.meta.dirname, '..')
+const mainCss = readFileSync(resolve(projectRoot, 'src/assets/styles/main.css'), 'utf8')
+const storylinePanel = readFileSync(resolve(projectRoot, 'src/components/workbench/StorylinePanel.vue'), 'utf8')
+
+const checks = [
+  {
+    description: 'main.css exposes theme-safe text color aliases',
+    pass:
+      mainCss.includes('--text-color-1: var(--app-text-primary);') &&
+      mainCss.includes('--text-color-2: var(--app-text-secondary);') &&
+      mainCss.includes('--text-color-3: var(--app-text-muted);'),
+  },
+  {
+    description: 'StorylinePanel uses theme-aware hover colors instead of hard-coded indigo',
+    pass:
+      storylinePanel.includes('border-color: var(--color-brand-border') &&
+      storylinePanel.includes('box-shadow: 0 6px 18px var(--color-brand-light'),
+  },
+  {
+    description: 'StorylinePanel info rows use a resilient two-column grid layout',
+    pass:
+      storylinePanel.includes('grid-template-columns: 88px minmax(0, 1fr);') &&
+      storylinePanel.includes('@media (max-width: 640px)'),
+  },
+]
+
+const failedChecks = checks.filter((check) => !check.pass)
+
+if (failedChecks.length > 0) {
+  console.error('Storyline theme regression checks failed:')
+  for (const check of failedChecks) {
+    console.error(`- ${check.description}`)
+  }
+  process.exit(1)
+}
+
+console.log('Storyline theme regression checks passed.')

--- a/frontend/src/assets/styles/main.css
+++ b/frontend/src/assets/styles/main.css
@@ -77,6 +77,9 @@ body {
   --app-text-secondary: #475569;
   --app-text-muted: #64748b;
   --app-text-inverse: #ffffff;
+  --text-color-1: var(--app-text-primary);
+  --text-color-2: var(--app-text-secondary);
+  --text-color-3: var(--app-text-muted);
 
   /* ── 背景色 ── */
   --app-page-bg: #eef1f6;

--- a/frontend/src/components/workbench/StorylinePanel.vue
+++ b/frontend/src/components/workbench/StorylinePanel.vue
@@ -89,21 +89,23 @@
             </template>
 
             <div class="collapse-body">
-              <div class="info-row">
-                <span class="info-label">章节范围</span>
-                <span class="info-value">第 {{ storyline.estimated_chapter_start }} – {{ storyline.estimated_chapter_end }} 章</span>
-              </div>
-              <div class="info-row" v-if="storyline.description">
-                <span class="info-label">描述</span>
-                <span class="info-value desc">{{ storyline.description }}</span>
-              </div>
-              <div class="info-row" v-if="storyline.progress_summary">
-                <span class="info-label">进度摘要</span>
-                <span class="info-value">{{ storyline.progress_summary }}</span>
-              </div>
-              <div class="info-row" v-if="storyline.last_active_chapter">
-                <span class="info-label">最后活跃</span>
-                <span class="info-value">第 {{ storyline.last_active_chapter }} 章</span>
+              <div class="storyline-details">
+                <div class="info-row">
+                  <span class="info-label">章节范围</span>
+                  <span class="info-value">第 {{ storyline.estimated_chapter_start }} – {{ storyline.estimated_chapter_end }} 章</span>
+                </div>
+                <div class="info-row" v-if="storyline.description">
+                  <span class="info-label">描述</span>
+                  <span class="info-value desc">{{ storyline.description }}</span>
+                </div>
+                <div class="info-row" v-if="storyline.progress_summary">
+                  <span class="info-label">进度摘要</span>
+                  <span class="info-value desc">{{ storyline.progress_summary }}</span>
+                </div>
+                <div class="info-row" v-if="storyline.last_active_chapter">
+                  <span class="info-label">最后活跃</span>
+                  <span class="info-value">第 {{ storyline.last_active_chapter }} 章</span>
+                </div>
               </div>
               <div class="collapse-milestones" v-if="storyline.milestones?.length">
                 <div class="ms-title">里程碑 ({{ storyline.milestones.length }})</div>
@@ -456,13 +458,17 @@ onMounted(() => {
   margin-bottom: 8px;
   background: var(--app-surface);
   border: 1px solid var(--aitext-split-border, rgba(0,0,0,0.06));
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.2s ease;
   overflow: hidden;
 }
 
 .sl-collapse :deep(.n-collapse-item:hover) {
-  border-color: rgba(99, 102, 241, 0.2);
-  box-shadow: 0 2px 12px rgba(99, 102, 241, 0.08);
+  border-color: var(--color-brand-border, rgba(99, 102, 241, 0.2));
+  box-shadow: 0 6px 18px var(--color-brand-light, rgba(99, 102, 241, 0.08));
+  transform: translateY(-1px);
 }
 
 .sl-collapse :deep(.n-collapse-item__header) {
@@ -493,36 +499,48 @@ onMounted(() => {
 }
 
 .collapse-body {
-  padding: 4px 14px 14px;
+  padding: 6px 14px 14px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 10px;
+}
+
+.storyline-details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--app-surface-subtle, rgba(15, 23, 42, 0.03));
+  border: 1px solid var(--aitext-split-border, rgba(0,0,0,0.06));
 }
 
 .info-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
   align-items: center;
   gap: 12px;
-  padding: 3px 0;
+  padding: 4px 0;
 }
 
 .info-label {
   font-size: 12px;
   color: var(--app-text-muted, var(--text-color-3, #94a3b8));
-  flex-shrink: 0;
-  min-width: 64px;
+  line-height: 1.5;
+  min-width: 0;
 }
 
 .info-value {
   font-size: 12px;
-  color: var(--text-color-1, #0f172a);
+  color: var(--app-text-primary, var(--text-color-1, #0f172a));
   text-align: right;
+  line-height: 1.5;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .info-value.desc {
   text-align: left;
-  line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -537,7 +555,7 @@ onMounted(() => {
 .ms-title {
   font-size: 11px;
   font-weight: 600;
-  color: var(--text-color-2, #475569);
+  color: var(--app-text-secondary, var(--text-color-2, #475569));
   margin-bottom: 5px;
 }
 
@@ -558,13 +576,14 @@ onMounted(() => {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #6366f1;
+  background: var(--color-brand, #6366f1);
+  box-shadow: 0 0 0 3px var(--color-brand-light, rgba(99, 102, 241, 0.12));
   flex-shrink: 0;
 }
 
 .ms-name {
   font-weight: 500;
-  color: var(--text-color-1, #0f172a);
+  color: var(--app-text-primary, var(--text-color-1, #0f172a));
   flex: 1;
 }
 
@@ -579,5 +598,17 @@ onMounted(() => {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .info-row {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .info-value {
+    text-align: left;
+  }
 }
 </style>


### PR DESCRIPTION
## 变更说明
- 修复故事线管理面板在深色/黑金模式下，“章节范围”“描述”等信息文字对比度过低、实际不可见的问题
<img width="808" height="576" alt="image" src="https://github.com/user-attachments/assets/3ddabe6d-c9b1-43db-83b3-c0bab62220fd" />
- 在全局主题变量中补齐 `--text-color-1/2/3` 映射，兼容依赖旧 token 的组件样式
- 优化 `StorylinePanel` 详情区样式：
  - 将信息区改为更稳定的双列布局
  - 描述/进度摘要改为更适合长文本的展示方式
  - hover、高亮点和里程碑装饰改为使用主题变量，避免暗色下失真
- 新增 `npm run test:storyline-theme` 回归检查，防止后续再出现主题下文字不可见问题

## 测试
- [x] 本地已跑核心用例（`npm run test:storyline-theme`、`npm run build`）
- [x] 关键路径手测通过（启动前端后切换浅色 / 深色 / 黑金主题检查故事线面板显示）

## 风险与回滚
- 风险：无
- 回滚方式：回退 `frontend/src/assets/styles/main.css`、`frontend/src/components/workbench/StorylinePanel.vue`、`frontend/scripts/check-storyline-theme.mjs` 和 `frontend/package.json` 的本次改动


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned StorylinePanel layout with improved grid structure for better information hierarchy
  * Added responsive design for small screens with optimized spacing and text alignment
  * Enhanced hover interactions with smooth transitions for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->