### PR TITLE
fix: 修复关系图英文 ID 展示

### DIFF
--- a/frontend/src/components/graphs/CastGraphCompact.vue
+++ b/frontend/src/components/graphs/CastGraphCompact.vue
@@ -38,6 +38,8 @@ interface KnowledgeTriple {
   subject: string
   predicate: string
   object: string
+  subject_entity_id?: string
+  object_entity_id?: string
   chapter_id?: number | null
   note?: string
   entity_type?: string
@@ -62,22 +64,30 @@ const graph = computed(() => {
     const a = tripleStringAttrs(t)
     const objImp = a.object_importance
     const noteFromDesc = t.description?.trim()
-    if (!characterMap.has(t.subject)) {
-      characterMap.set(t.subject, {
-        name: t.subject,
+    const subjectId = t.subject_entity_id || t.subject
+    const objectId = t.object_entity_id || t.object
+    const subjectLabel = a.subject_label || t.subject
+    const objectLabel = a.object_label || t.object
+
+    if (!characterMap.has(subjectId)) {
+      characterMap.set(subjectId, {
+        name: subjectLabel,
         importance: t.importance,
         note: [t.note, noteFromDesc].filter(Boolean).join('\n') || '',
       })
     }
-    if (!characterMap.has(t.object)) {
-      characterMap.set(t.object, {
-        name: t.object,
+    if (!characterMap.has(objectId)) {
+      characterMap.set(objectId, {
+        name: objectLabel,
         importance: objImp,
         note: '',
       })
-    } else if (objImp && !characterMap.get(t.object)?.importance) {
-      const cur = characterMap.get(t.object)!
-      characterMap.set(t.object, { ...cur, importance: objImp })
+    } else {
+      const cur = characterMap.get(objectId)!
+      const next = { ...cur }
+      if (objectLabel && (!cur.name || cur.name === objectId)) next.name = objectLabel
+      if (objImp && !cur.importance) next.importance = objImp
+      characterMap.set(objectId, next)
     }
   })
 
@@ -90,8 +100,8 @@ const graph = computed(() => {
 
   const relationships = characterTriples.map(t => ({
     id: t.id,
-    source_id: t.subject,
-    target_id: t.object,
+    source_id: t.subject_entity_id || t.subject,
+    target_id: t.object_entity_id || t.object,
     label: t.predicate,
     note: [t.note, t.description].filter(Boolean).join('\n') || '',
   }))

--- a/frontend/src/components/graphs/LocationGraphCompact.vue
+++ b/frontend/src/components/graphs/LocationGraphCompact.vue
@@ -39,6 +39,8 @@ interface KnowledgeTriple {
   subject: string
   predicate: string
   object: string
+  subject_entity_id?: string
+  object_entity_id?: string
   chapter_id?: number | null
   note?: string
   entity_type?: string
@@ -68,27 +70,33 @@ const graph = computed(() => {
     const a = tripleStringAttrs(t)
     const objImp = a.object_importance
     const objLt = a.object_location_type
-    if (!locationMap.has(t.subject)) {
-      locationMap.set(t.subject, {
-        name: t.subject,
+    const subjectId = t.subject_entity_id || t.subject
+    const objectId = t.object_entity_id || t.object
+    const subjectLabel = a.subject_label || t.subject
+    const objectLabel = a.object_label || t.object
+
+    if (!locationMap.has(subjectId)) {
+      locationMap.set(subjectId, {
+        name: subjectLabel,
         importance: t.importance,
         location_type: t.location_type,
         note: [t.note, t.description].filter(Boolean).join('\n') || '',
       })
     }
-    if (!locationMap.has(t.object)) {
-      locationMap.set(t.object, {
-        name: t.object,
+    if (!locationMap.has(objectId)) {
+      locationMap.set(objectId, {
+        name: objectLabel,
         importance: objImp,
         location_type: objLt,
         note: '',
       })
     } else {
-      const cur = locationMap.get(t.object)!
+      const cur = locationMap.get(objectId)!
       const next = { ...cur }
+      if (objectLabel && (!cur.name || cur.name === objectId)) next.name = objectLabel
       if (objImp && !cur.importance) next.importance = objImp
       if (objLt && !cur.location_type) next.location_type = objLt
-      locationMap.set(t.object, next)
+      locationMap.set(objectId, next)
     }
   })
 
@@ -102,8 +110,8 @@ const graph = computed(() => {
 
   const relationships = locationTriples.map(t => ({
     id: t.id,
-    source_id: t.subject,
-    target_id: t.object,
+    source_id: t.subject_entity_id || t.subject,
+    target_id: t.object_entity_id || t.object,
     label: t.predicate,
     note: [t.note, t.description].filter(Boolean).join('\n') || '',
   }))


### PR DESCRIPTION
## 目的

修复工作台关系图直接显示技术实体 ID 的问题，避免出现 city_shenzhen、rea_nanshan、
ovel-...-char-* 这类英文或内部标识，提升图谱可读性。

## 这次改动

涉及文件：
- rontend/src/components/graphs/CastGraphCompact.vue
- rontend/src/components/graphs/LocationGraphCompact.vue

处理方式：
- 节点内部仍使用实体 ID 做去重和连线，保证图谱关系稳定
- 展示名优先使用三元组里的 subject_label / object_label
- 没有中文 label 时，再回退到原始 subject / object
- 补充 subject_entity_id / object_entity_id 字段支持，避免显示层和关系层混用同一个值

## 结果

人物图和地点图将优先显示中文实体名，不再把技术 ID 直接暴露给用户。