### PR TITLE
fix: 修复关系图英文 ID 展示

### DIFF
--- a/frontend/src/components/graphs/CastGraphCompact.vue
+++ b/frontend/src/components/graphs/CastGraphCompact.vue
@@ -38,6 +38,8 @@ interface KnowledgeTriple {
   subject: string
   predicate: string
   object: string
+  subject_entity_id?: string
+  object_entity_id?: string
   chapter_id?: number | null
   note?: string
   entity_type?: string
@@ -62,22 +64,30 @@ const graph = computed(() => {
     const a = tripleStringAttrs(t)
     const objImp = a.object_importance
     const noteFromDesc = t.description?.trim()
-    if (!characterMap.has(t.subject)) {
-      characterMap.set(t.subject, {
-        name: t.subject,
+    const subjectId = t.subject_entity_id || t.subject
+    const objectId = t.object_entity_id || t.object
+    const subjectLabel = a.subject_label || t.subject
+    const objectLabel = a.object_label || t.object
+
+    if (!characterMap.has(subjectId)) {
+      characterMap.set(subjectId, {
+        name: subjectLabel,
         importance: t.importance,
         note: [t.note, noteFromDesc].filter(Boolean).join('\n') || '',
       })
     }
-    if (!characterMap.has(t.object)) {
-      characterMap.set(t.object, {
-        name: t.object,
+    if (!characterMap.has(objectId)) {
+      characterMap.set(objectId, {
+        name: objectLabel,
         importance: objImp,
         note: '',
       })
-    } else if (objImp && !characterMap.get(t.object)?.importance) {
-      const cur = characterMap.get(t.object)!
-      characterMap.set(t.object, { ...cur, importance: objImp })
+    } else {
+      const cur = characterMap.get(objectId)!
+      const next = { ...cur }
+      if (objectLabel && (!cur.name || cur.name === objectId)) next.name = objectLabel
+      if (objImp && !cur.importance) next.importance = objImp
+      characterMap.set(objectId, next)
     }
   })
 
@@ -90,8 +100,8 @@ const graph = computed(() => {
 
   const relationships = characterTriples.map(t => ({
     id: t.id,
-    source_id: t.subject,
-    target_id: t.object,
+    source_id: t.subject_entity_id || t.subject,
+    target_id: t.object_entity_id || t.object,
     label: t.predicate,
     note: [t.note, t.description].filter(Boolean).join('\n') || '',
   }))

--- a/frontend/src/components/graphs/LocationGraphCompact.vue
+++ b/frontend/src/components/graphs/LocationGraphCompact.vue
@@ -39,6 +39,8 @@ interface KnowledgeTriple {
   subject: string
   predicate: string
   object: string
+  subject_entity_id?: string
+  object_entity_id?: string
   chapter_id?: number | null
   note?: string
   entity_type?: string
@@ -68,27 +70,33 @@ const graph = computed(() => {
     const a = tripleStringAttrs(t)
     const objImp = a.object_importance
     const objLt = a.object_location_type
-    if (!locationMap.has(t.subject)) {
-      locationMap.set(t.subject, {
-        name: t.subject,
+    const subjectId = t.subject_entity_id || t.subject
+    const objectId = t.object_entity_id || t.object
+    const subjectLabel = a.subject_label || t.subject
+    const objectLabel = a.object_label || t.object
+
+    if (!locationMap.has(subjectId)) {
+      locationMap.set(subjectId, {
+        name: subjectLabel,
         importance: t.importance,
         location_type: t.location_type,
         note: [t.note, t.description].filter(Boolean).join('\n') || '',
       })
     }
-    if (!locationMap.has(t.object)) {
-      locationMap.set(t.object, {
-        name: t.object,
+    if (!locationMap.has(objectId)) {
+      locationMap.set(objectId, {
+        name: objectLabel,
         importance: objImp,
         location_type: objLt,
         note: '',
       })
     } else {
-      const cur = locationMap.get(t.object)!
+      const cur = locationMap.get(objectId)!
       const next = { ...cur }
+      if (objectLabel && (!cur.name || cur.name === objectId)) next.name = objectLabel
       if (objImp && !cur.importance) next.importance = objImp
       if (objLt && !cur.location_type) next.location_type = objLt
-      locationMap.set(t.object, next)
+      locationMap.set(objectId, next)
     }
   })
 
@@ -102,8 +110,8 @@ const graph = computed(() => {
 
   const relationships = locationTriples.map(t => ({
     id: t.id,
-    source_id: t.subject,
-    target_id: t.object,
+    source_id: t.subject_entity_id || t.subject,
+    target_id: t.object_entity_id || t.object,
     label: t.predicate,
     note: [t.note, t.description].filter(Boolean).join('\n') || '',
   }))


### PR DESCRIPTION
## Summary
- 修复工作台关系图直接显示技术实体 ID 的问题
- 节点展示名优先使用三元组的 subject_label / object_label，没有中文 label 时回退到原始 subject / object

## Test plan
- [ ] 人物图验证：确认显示中文实体名而非技术 ID
- [ ] 地点图验证：确认显示中文实体名而非技术 ID
- [ ] 关系图：验证节点连线关系稳定

## Files
- frontend/src/components/graphs/CastGraphCompact.vue
- frontend/src/components/graphs/LocationGraphCompact.vue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced graph visualizations with more accurate node identification and relationship mapping in cast and location graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->