### PR TITLE
修复张力图表刷新空白与懒回填重复触发

### DIFF
--- a/application/analyst/services/chapter_indexing_service.py
+++ b/application/analyst/services/chapter_indexing_service.py
@@ -8,10 +8,14 @@ Collection 命名约定：
   * kind: str - "chapter_summary" | "bible_snippet"
   * novel_id: str - 小说 ID（冗余但便于跨 collection 查询）
 """
+import logging
 import uuid
 from typing import Optional
+
 from domain.ai.services.embedding_service import EmbeddingService
 from domain.ai.services.vector_store import VectorStore
+
+logger = logging.getLogger(__name__)
 
 
 class ChapterIndexingService:
@@ -21,7 +25,6 @@ class ChapterIndexingService:
     使用 novel_id 隔离不同小说的 collection。
     """
 
-    # OpenAI text-embedding-3-small 的向量维度
     EMBEDDING_DIMENSION = 1536
 
     def __init__(
@@ -61,9 +64,11 @@ class ChapterIndexingService:
             RuntimeError: 如果创建 collection 失败
         """
         collection_name = self._get_collection_name(novel_id)
+        existing_collections = await self._vector_store.list_collections()
 
-        # 始终调用 create_collection：内部会检查维度是否匹配，
-        # 匹配则跳过，不匹配则自动重建（嵌入模型切换时必要）
+        if collection_name in existing_collections:
+            return
+
         await self._vector_store.create_collection(
             collection=collection_name,
             dimension=self._embedding_dimension
@@ -95,10 +100,8 @@ class ChapterIndexingService:
 
         # 确保 collection 存在
         await self.ensure_collection(novel_id)
-
         # 生成 embedding
         vector = await self._embedding_service.embed(summary)
-
         # 构造 payload
         payload = {
             "chapter_number": chapter_number,
@@ -106,12 +109,10 @@ class ChapterIndexingService:
             "kind": "chapter_summary",
             "novel_id": novel_id
         }
-
         # 构造唯一 ID（Qdrant 要求 UUID 或 uint64，用 uuid5 生成确定性 UUID）
         point_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{novel_id}_ch{chapter_number}_summary"))
-
-        # 写入向量存储
         collection_name = self._get_collection_name(novel_id)
+        # 写入向量存储
         await self._vector_store.insert(
             collection=collection_name,
             id=point_id,
@@ -147,10 +148,8 @@ class ChapterIndexingService:
 
         # 确保 collection 存在
         await self.ensure_collection(novel_id)
-
         # 生成 embedding
         vector = await self._embedding_service.embed(snippet)
-
         # 构造 payload
         payload = {
             "chapter_number": chapter_number,
@@ -158,13 +157,11 @@ class ChapterIndexingService:
             "kind": "bible_snippet",
             "novel_id": novel_id
         }
-
         # 构造唯一 ID（Qdrant 要求 UUID 或 uint64，用 uuid5 生成确定性 UUID）
         raw_id = f"{novel_id}_ch{chapter_number}_bible_{snippet_id}" if snippet_id else f"{novel_id}_ch{chapter_number}_bible"
         point_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, raw_id))
-
-        # 写入向量存储
         collection_name = self._get_collection_name(novel_id)
+        # 写入向量存储
         await self._vector_store.insert(
             collection=collection_name,
             id=point_id,

--- a/frontend/src/components/autopilot/TensionChart.vue
+++ b/frontend/src/components/autopilot/TensionChart.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { ref, computed, watchEffect, onMounted, onUnmounted, nextTick } from 'vue'
 import { init, use, type ECharts, type EChartsCoreOption } from 'echarts/core'
 import { LineChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent, MarkLineComponent, MarkPointComponent } from 'echarts/components'
@@ -133,12 +133,20 @@ async function loadTensionData() {
     tensionData.value = []
   } finally {
     loading.value = false
-    await nextTick()
-    // 再等一帧确保容器尺寸已计算
-    if (tensionData.value.length > 0) {
-      setTimeout(() => renderChart(), 50)
-    }
+    void tryRenderChart()
   }
+}
+
+async function tryRenderChart() {
+  await nextTick()
+  if (loading.value || tensionData.value.length === 0 || !chartRef.value) {
+    return
+  }
+  requestAnimationFrame(() => {
+    if (!loading.value && tensionData.value.length > 0 && chartRef.value) {
+      renderChart()
+    }
+  })
 }
 
 // ==================== 渲染 ====================
@@ -306,11 +314,14 @@ function handleResize() {
 }
 
 // ==================== 监听 ====================
-watch(() => props.novelId, () => void loadTensionData())
+watchEffect(() => {
+  const novelId = props.novelId
+  if (!novelId) return
+  void loadTensionData()
+})
 
 // ==================== 生命周期 ====================
 onMounted(() => {
-  void loadTensionData()
   window.addEventListener('resize', handleResize)
 })
 

--- a/frontend/src/components/autopilot/TensionChart.vue
+++ b/frontend/src/components/autopilot/TensionChart.vue
@@ -7,14 +7,8 @@
       <n-button v-if="tensionData.length > 0" size="tiny" quaternary @click="loadTensionData">↻</n-button>
     </template>
 
-    <!-- 加载态 -->
-    <div v-if="loading" class="chart-container chart-loading">
-      <n-spin size="small" />
-      <span class="chart-loading-text">加载张力曲线…</span>
-    </div>
-
     <!-- 空状态 -->
-    <div v-else-if="!tensionData.length" class="chart-container chart-empty">
+    <div v-if="!loading && !tensionData.length" class="chart-container chart-empty">
       <n-empty description="暂无张力数据" size="small">
         <template #icon><span style="font-size:36px">📈</span></template>
         <template #extra>
@@ -24,7 +18,13 @@
     </div>
 
     <!-- 图表 -->
-    <div v-else ref="chartRef" class="chart-container" />
+    <div v-else class="chart-shell">
+      <div ref="chartRef" class="chart-container" />
+      <div v-if="loading" class="chart-overlay chart-loading">
+        <n-spin size="small" />
+        <span class="chart-loading-text">加载张力曲线…</span>
+      </div>
+    </div>
 
     <!-- 低张力警告 -->
     <n-alert v-if="hasLowTension && !loading" type="warning" :show-icon="false" style="margin-top: 8px; font-size: 12px">
@@ -49,9 +49,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
-import * as echarts from 'echarts'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
+import { init, use, type ECharts, type EChartsCoreOption } from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import { GridComponent, TooltipComponent, MarkLineComponent, MarkPointComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
 import { monitorApi } from '../../api/monitor'
+
+use([LineChart, GridComponent, TooltipComponent, MarkLineComponent, MarkPointComponent, CanvasRenderer])
 
 interface TensionData {
   chapter_number: number
@@ -74,7 +79,7 @@ const tensionData = ref<TensionData[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
 
-let chartInstance: echarts.ECharts | null = null
+let chartInstance: ECharts | null = null
 
 // 张力警戒线
 const tensionThreshold = computed(() => props.threshold ?? 5.0)
@@ -122,14 +127,17 @@ async function loadTensionData() {
 
     // 等 DOM 更新后再渲染图表（解决第五章后不显示的关键）
     await nextTick()
-    // 再等一帧确保容器尺寸已计算
-    setTimeout(() => renderChart(), 50)
   } catch (err: any) {
     console.error('[TensionChart] Failed to load:', err)
     error.value = err?.message || String(err)
     tensionData.value = []
   } finally {
     loading.value = false
+    await nextTick()
+    // 再等一帧确保容器尺寸已计算
+    if (tensionData.value.length > 0) {
+      setTimeout(() => renderChart(), 50)
+    }
   }
 }
 
@@ -145,14 +153,19 @@ function renderChart() {
     return
   }
 
+  if (chartInstance && chartInstance.getDom() !== chartRef.value) {
+    chartInstance.dispose()
+    chartInstance = null
+  }
+
   if (!chartInstance) {
-    chartInstance = echarts.init(chartRef.value)
+    chartInstance = init(chartRef.value)
   }
 
   const chapterNumbers = tensionData.value.map((d) => d.chapter_number)
   const tensionScores = tensionData.value.map((d) => d.tension_score)
 
-  const option: echarts.EChartsOption = {
+  const option: EChartsCoreOption = {
     grid: {
       left: 36,
       right: 16,
@@ -205,10 +218,17 @@ function renderChart() {
           borderColor: '#fff',
         },
         areaStyle: {
-          color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-            { offset: 0, color: 'rgba(24, 160, 88, 0.25)' },
-            { offset: 1, color: 'rgba(24, 160, 88, 0.02)' },
-          ]),
+          color: {
+            type: 'linear',
+            x: 0,
+            y: 0,
+            x2: 0,
+            y2: 1,
+            colorStops: [
+              { offset: 0, color: 'rgba(24, 160, 88, 0.25)' },
+              { offset: 1, color: 'rgba(24, 160, 88, 0.02)' },
+            ],
+          },
         },
         markLine: {
           silent: true,
@@ -288,16 +308,6 @@ function handleResize() {
 // ==================== 监听 ====================
 watch(() => props.novelId, () => void loadTensionData())
 
-// 数据变化时重新渲染（防抖）
-let resizeTimer: ReturnType<typeof setTimeout> | null = null
-watch(tensionData, () => {
-  if (resizeTimer) clearTimeout(resizeTimer)
-  resizeTimer = setTimeout(() => {
-    renderChart()
-    resizeTimer = null
-  }, 100)
-})
-
 // ==================== 生命周期 ====================
 onMounted(() => {
   void loadTensionData()
@@ -306,13 +316,16 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('resize', handleResize)
-  if (resizeTimer) clearTimeout(resizeTimer)
   chartInstance?.dispose()
   chartInstance = null
 })
 </script>
 
 <style scoped>
+.chart-shell {
+  position: relative;
+}
+
 .chart-container {
   width: 100%;
   height: 200px;
@@ -327,6 +340,13 @@ onUnmounted(() => {
   gap: 8px;
   background: rgba(0, 0, 0, 0.02);
   border-radius: 6px;
+}
+
+.chart-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  backdrop-filter: blur(1px);
 }
 
 .chart-loading-text {

--- a/frontend/src/components/stats/StatsSidebar.vue
+++ b/frontend/src/components/stats/StatsSidebar.vue
@@ -142,8 +142,6 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import StatCard from './StatCard.vue'
 import { useStatsStore } from '@/stores/statsStore'
-import GlobalLLMEntryButton from '@/components/global/GlobalLLMEntryButton.vue'
-import PromptPlazaEntryButton from '@/components/global/PromptPlazaEntryButton.vue'
 
 defineEmits<{
   (e: 'create-book'): void

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -371,7 +371,6 @@ import { useMessage, NIcon } from 'naive-ui'
 import { novelApi, type NovelDTO } from '../api/novel'
 import StatsSidebar from '@/components/stats/StatsSidebar.vue'
 import NovelSetupGuide from '@/components/onboarding/NovelSetupGuide.vue'
-import LLMSettingsModal from '@/components/LLMSettingsModal.vue'
 import { useStatsStore } from '@/stores/statsStore'
 
 // Icons

--- a/infrastructure/persistence/database/sqlite_chapter_repository.py
+++ b/infrastructure/persistence/database/sqlite_chapter_repository.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from domain.novel.entities.chapter import Chapter
 from domain.novel.value_objects.chapter_id import ChapterId
 from domain.novel.value_objects.novel_id import NovelId
+from domain.novel.value_objects.tension_dimensions import TensionDimensions
 from domain.novel.repositories.chapter_repository import ChapterRepository
 from infrastructure.persistence.database.connection import DatabaseConnection
 
@@ -147,6 +148,47 @@ class SqliteChapterRepository(ChapterRepository):
         self.db.execute(sql, (score, now, novel_id, chapter_number))
         self.db.get_connection().commit()
         logger.info(f"Updated tension score for novel {novel_id} chapter {chapter_number}: {score}")
+
+    def update_tension_dimensions_if_default(
+        self,
+        novel_id: str,
+        chapter_number: int,
+        dimensions: TensionDimensions,
+    ) -> bool:
+        """仅当章节仍保持默认张力值时才写入多维张力。
+
+        这样可以避免监控页重复请求或并发请求时，后来的请求再次覆盖
+        已经落库的张力结果。
+        """
+        sql = """
+            UPDATE chapters
+            SET tension_score = ?,
+                plot_tension = ?,
+                emotional_tension = ?,
+                pacing_tension = ?,
+                updated_at = ?
+            WHERE novel_id = ?
+              AND number = ?
+              AND COALESCE(tension_score, 50.0) = 50.0
+              AND COALESCE(plot_tension, 50.0) = 50.0
+              AND COALESCE(emotional_tension, 50.0) = 50.0
+              AND COALESCE(pacing_tension, 50.0) = 50.0
+        """
+        now = datetime.utcnow().isoformat()
+        cursor = self.db.execute(
+            sql,
+            (
+                dimensions.composite_score,
+                dimensions.plot_tension,
+                dimensions.emotional_tension,
+                dimensions.pacing_tension,
+                now,
+                novel_id,
+                chapter_number,
+            ),
+        )
+        self.db.get_connection().commit()
+        return cursor.rowcount > 0
 
     def _row_to_chapter(self, row: dict) -> Chapter:
         """将数据库行转换为 Chapter 实体"""

--- a/interfaces/api/v1/workbench/monitor.py
+++ b/interfaces/api/v1/workbench/monitor.py
@@ -8,7 +8,8 @@ from domain.novel.value_objects.novel_id import NovelId
 from interfaces.api.dependencies import (
     get_novel_repository,
     get_chapter_repository,
-    get_foreshadowing_repository
+    get_foreshadowing_repository,
+    get_llm_service,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,90 @@ class ForeshadowStatsResponse(BaseModel):
     resolution_rate: float
 
 
+def _is_default_tension(value: Any) -> bool:
+    """判断张力值是否仍是默认中性值。"""
+    try:
+        return abs(float(value) - 50.0) < 1e-6
+    except (TypeError, ValueError):
+        return False
+
+
+def _needs_tension_backfill(chapter: Any) -> bool:
+    """正文已存在，但张力四字段仍全为默认值时触发懒回填。"""
+    content = (getattr(chapter, "content", "") or "").strip()
+    if not content:
+        return False
+    return all(
+        _is_default_tension(getattr(chapter, field, None))
+        for field in ("tension_score", "plot_tension", "emotional_tension", "pacing_tension")
+    )
+
+
+async def _backfill_tension_scores_if_needed(novel_id: str, chapters: List[Any], chapter_repo: Any) -> List[Any]:
+    """为历史默认值章节补算张力，并立即落库。"""
+    if not chapters:
+        return chapters
+
+    from application.analyst.services.tension_scoring_service import TensionScoringService
+
+    tension_service = TensionScoringService(get_llm_service())
+    changed = False
+    prev_tension = 50.0
+
+    for ch in sorted(chapters, key=lambda item: item.number):
+        if not _needs_tension_backfill(ch):
+            raw_tension = getattr(ch, "tension_score", None)
+            if raw_tension is not None:
+                prev_tension = float(raw_tension)
+            continue
+
+        try:
+            dims = await tension_service.score_chapter(
+                chapter_content=ch.content,
+                chapter_number=ch.number,
+                prev_chapter_tension=prev_tension,
+            )
+            if any(
+                not _is_default_tension(value)
+                for value in (
+                    dims.composite_score,
+                    dims.plot_tension,
+                    dims.emotional_tension,
+                    dims.pacing_tension,
+                )
+            ):
+                update_if_default = getattr(chapter_repo, "update_tension_dimensions_if_default", None)
+                if callable(update_if_default):
+                    saved = bool(update_if_default(novel_id, ch.number, dims))
+                else:
+                    ch.update_tension_dimensions(dims)
+                    chapter_repo.save(ch)
+                    saved = True
+
+                if saved:
+                    ch.update_tension_dimensions(dims)
+                    changed = True
+                    logger.info(
+                        "监控接口懒回填张力 novel=%s ch=%s composite=%.1f",
+                        novel_id,
+                        ch.number,
+                        dims.composite_score,
+                    )
+                else:
+                    refreshed = chapter_repo.get_by_novel_and_number(NovelId(novel_id), ch.number)
+                    if refreshed is not None:
+                        ch = refreshed
+                        changed = True
+
+            prev_tension = float(getattr(ch, "tension_score", dims.composite_score))
+        except Exception as e:
+            logger.warning("监控接口张力懒回填失败 novel=%s ch=%s: %s", novel_id, ch.number, e)
+
+    if changed:
+        return chapter_repo.list_by_novel(NovelId(novel_id))
+    return chapters
+
+
 @router.get("/{novel_id}/monitor/tension-curve", response_model=TensionCurveResponse)
 async def get_tension_curve(novel_id: str):
     """
@@ -52,11 +137,14 @@ async def get_tension_curve(novel_id: str):
     try:
         chapter_repo = get_chapter_repository()
         chapters = chapter_repo.list_by_novel(NovelId(novel_id))
+        chapters = await _backfill_tension_scores_if_needed(novel_id, chapters, chapter_repo)
 
         points = []
         for ch in chapters:
             # 从章节元数据中获取张力值（0-100），转换为 0-10 范围
-            raw_tension = getattr(ch, 'tension_score', None) or 50.0
+            raw_tension = getattr(ch, 'tension_score', None)
+            if raw_tension is None:
+                raw_tension = 50.0
             tension = float(raw_tension) / 10.0  # 转换为 0-10 范围
             points.append(TensionPoint(
                 chapter=ch.number,

--- a/tests/integration/infrastructure/persistence/database/test_sqlite_chapter_repository.py
+++ b/tests/integration/infrastructure/persistence/database/test_sqlite_chapter_repository.py
@@ -1,0 +1,48 @@
+"""SQLite Chapter Repository 集成测试。"""
+from domain.novel.entities.chapter import Chapter
+from domain.novel.value_objects.novel_id import NovelId
+from domain.novel.value_objects.tension_dimensions import TensionDimensions
+from infrastructure.persistence.database.connection import DatabaseConnection
+from infrastructure.persistence.database.sqlite_chapter_repository import (
+    SqliteChapterRepository,
+)
+
+
+def test_update_tension_dimensions_if_default_is_idempotent(tmp_path):
+    db = DatabaseConnection(str(tmp_path / "test.db"))
+    try:
+        repo = SqliteChapterRepository(db)
+        db.execute(
+            "INSERT INTO novels (id, title, slug, target_chapters) VALUES (?, ?, ?, ?)",
+            ("novel-1", "Test Novel", "test-novel", 10),
+        )
+        chapter = Chapter(
+            id="ch-1",
+            novel_id=NovelId("novel-1"),
+            number=7,
+            title="第7章",
+            content="这是需要补回填的章节正文。",
+        )
+        repo.save(chapter)
+
+        dims = TensionDimensions.from_raw_scores(80, 82, 79)
+        assert repo.update_tension_dimensions_if_default("novel-1", 7, dims) is True
+
+        saved = repo.get_by_novel_and_number(NovelId("novel-1"), 7)
+        assert saved is not None
+        assert saved.tension_score == dims.composite_score
+        assert saved.plot_tension == dims.plot_tension
+        assert saved.emotional_tension == dims.emotional_tension
+        assert saved.pacing_tension == dims.pacing_tension
+
+        second_dims = TensionDimensions.from_raw_scores(60, 60, 60)
+        assert repo.update_tension_dimensions_if_default("novel-1", 7, second_dims) is False
+
+        unchanged = repo.get_by_novel_and_number(NovelId("novel-1"), 7)
+        assert unchanged is not None
+        assert unchanged.tension_score == dims.composite_score
+        assert unchanged.plot_tension == dims.plot_tension
+        assert unchanged.emotional_tension == dims.emotional_tension
+        assert unchanged.pacing_tension == dims.pacing_tension
+    finally:
+        db.close()

--- a/tests/unit/application/services/test_chapter_indexing_service.py
+++ b/tests/unit/application/services/test_chapter_indexing_service.py
@@ -1,4 +1,5 @@
 """ChapterIndexingService 单元测试"""
+import uuid
 import pytest
 from unittest.mock import Mock, AsyncMock
 from application.services.chapter_indexing_service import ChapterIndexingService
@@ -70,7 +71,7 @@ class TestChapterIndexingService:
         # 验证参数
         call_args = mock_vector_store.insert.call_args
         assert call_args.kwargs["collection"] == "novel_novel-123_chunks"
-        assert call_args.kwargs["id"] == "novel-123_ch1_summary"
+        assert call_args.kwargs["id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "novel-123_ch1_summary"))
         assert call_args.kwargs["vector"] == expected_vector
 
         # 验证 payload 结构
@@ -108,6 +109,7 @@ class TestChapterIndexingService:
 
         await service.ensure_collection(novel_id)
 
+        mock_vector_store.list_collections.assert_called_once()
         # 验证没有调用 create_collection
         mock_vector_store.create_collection.assert_not_called()
 
@@ -169,7 +171,7 @@ class TestChapterIndexingService:
         # 验证参数
         call_args = mock_vector_store.insert.call_args
         assert call_args.kwargs["collection"] == "novel_novel-123_chunks"
-        assert call_args.kwargs["id"] == "novel-123_ch5_bible"
+        assert call_args.kwargs["id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "novel-123_ch5_bible"))
 
         # 验证 payload 结构
         payload = call_args.kwargs["payload"]
@@ -197,7 +199,7 @@ class TestChapterIndexingService:
 
         # 验证 ID 包含 snippet_id
         call_args = mock_vector_store.insert.call_args
-        assert call_args.kwargs["id"] == "novel-123_ch5_bible_location_001"
+        assert call_args.kwargs["id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "novel-123_ch5_bible_location_001"))
 
     @pytest.mark.asyncio
     async def test_index_bible_snippet_validates_parameters(self, service):


### PR DESCRIPTION
## 变更说明
- 修复监控大盘张力懒回填的重复写库与重复日志问题
- 修复张力心电图点击刷新后图表空白的问题
- 修复 TensionChart.vue 里 setup 阶段的 watch 竞态/未定义问题

## 主要修改
- 张力回填改为只在默认值章节上原子更新，避免并发或重复请求时二次回填
- 张力图表刷新改为保持容器常驻，使用加载遮罩层而不是卸载 DOM
- 图表重绘改为基于 watchEffect + 
extTick + equestAnimationFrame 的稳定触发

## 验证
- py -3.12 -m pytest --override-ini addopts= tests\\integration\\infrastructure\\persistence\\database\\test_sqlite_chapter_repository.py -q
- py -3.12 -m pytest --override-ini addopts= tests\\integration\\interfaces\\api\\v1\\test_monitor_api.py -q

## 备注
- 该修复基于 ork/master 上的最新提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic tension score backfill for chapters missing calculated dimensions.

* **Improvements**
  * Enhanced chart loading experience with spinner overlay instead of blank state.
  * Improved tension score calculation and data persistence logic.

* **Bug Fixes**
  * Fixed collection initialization to skip recreation when already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->