### PR TITLE
fix: support HuggingFace model ID in LocalEmbeddingService

### DIFF
--- a/infrastructure/ai/local_embedding_service.py
+++ b/infrastructure/ai/local_embedding_service.py
@@ -80,6 +80,10 @@ class LocalEmbeddingService(EmbeddingService):
         else:
             model_path = model_name
 
+        # 判断是否为 HuggingFace 模型 ID（如 "BAAI/bge-small-zh-v1.5"）
+        _original_model_name = model_path
+        _is_hf_model_id = "/" in model_path and not Path(model_path).is_absolute()
+
         # 将路径转为绝对路径（相对路径基于项目根目录）
         _resolved = Path(model_path)
         if not _resolved.is_absolute():
@@ -95,6 +99,10 @@ class LocalEmbeddingService(EmbeddingService):
             if _fallback.exists():
                 model_name = str(_fallback)
                 logger.info(f"Using local model path (auto-resolved): {model_name}")
+            elif _is_hf_model_id:
+                # 看起来像 HuggingFace 模型 ID，保留原始值让 SentenceTransformer 从缓存加载
+                model_name = _original_model_name
+                logger.info(f"Using HuggingFace model ID (cached): {model_name}")
             else:
                 raise FileNotFoundError(
                     f"Local model not found at '{_resolved}' or '{_fallback}'.\n\n"


### PR DESCRIPTION
## Summary
- `LocalEmbeddingService` 在加载本地嵌入模型时，会将 HuggingFace 模型 ID（如 `BAAI/bge-small-zh-v1.5`）误判为相对文件路径，导致在项目根目录下找不到模型文件而报错
- 增加了对 HuggingFace 模型 ID 的识别逻辑：当传入值包含 `/` 且不是绝对路径时，直接将原始模型 ID 传给 `SentenceTransformer`，由其从 HF 缓存中加载

## Test plan
- [x] 启动后端，确认 `BAAI/bge-small-zh-v1.5` 模型能从 HF 缓存正常加载（dimension: 512）
- [x] 本地文件路径（如 `.models/bge-small-zh-v1.5`）仍能正常识别和加载
- [x] 后端启动无报错，所有路由正常注册

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model loading to automatically fetch and use HuggingFace models when local copies are unavailable, preventing loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->