### PR TITLE
feat: 分章叙事节拍持久化 + autopilot 集成 + 章节号推断修复

### DIFF
--- a/application/engine/services/autopilot_daemon.py
+++ b/application/engine/services/autopilot_daemon.py
@@ -67,6 +67,7 @@ class AutopilotDaemon:
         aftermath_pipeline: Optional[ChapterAftermathPipeline] = None,
         volume_summary_service=None,
         foreshadowing_repository=None,
+        knowledge_service=None,
     ):
         self.novel_repository = novel_repository
         self.llm_service = llm_service
@@ -82,6 +83,7 @@ class AutopilotDaemon:
         self.aftermath_pipeline = aftermath_pipeline
         self.volume_summary_service = volume_summary_service
         self.foreshadowing_repository = foreshadowing_repository
+        self.knowledge_service = knowledge_service
         
         # 惰性初始化 VolumeSummaryService
         if not self.volume_summary_service and llm_service and story_node_repo:
@@ -500,6 +502,22 @@ class AutopilotDaemon:
 
         chapter_num = next_chapter_node.number
         outline = next_chapter_node.outline or next_chapter_node.description or next_chapter_node.title
+
+        # 合并分章叙事节拍（beat_sections）到 outline，让 AI 按用户设定的叙事节拍生成
+        if self.knowledge_service:
+            try:
+                knowledge = self.knowledge_service.get_knowledge(novel.novel_id.value)
+                chapter_entry = next(
+                    (ch for ch in knowledge.chapters if str(ch.chapter_id) == str(chapter_num)),
+                    None
+                )
+                if chapter_entry and getattr(chapter_entry, "beat_sections", None):
+                    beats_text = "\n".join(str(b) for b in chapter_entry.beat_sections if b)
+                    if beats_text.strip():
+                        outline = f"【分章叙事节拍】\n{beats_text}\n\n【章节大纲】\n{outline}"
+                        logger.info(f"[{novel.novel_id}] 已合并第{chapter_num}章分章叙事节拍（{len(chapter_entry.beat_sections)}条）")
+            except Exception as _e:
+                logger.warning(f"[{novel.novel_id}] 读取分章叙事失败，使用原始大纲：{_e}")
 
         if needs_buffer:
             outline = f"【缓冲章：日常过渡】{outline}。主角战后休整，与配角闲聊，展示收获，节奏轻松。"

--- a/docs/pr/pr-beat-narrative-enhancement.md
+++ b/docs/pr/pr-beat-narrative-enhancement.md
@@ -1,0 +1,166 @@
+# PR：分章叙事节拍深度适配
+
+---
+
+## 概览
+
+本次改动解决分章叙事节拍（beat_sections）从「用户输入 → 持久化 → 正文生成」全链路不通的问题。
+
+**涉及文件：** 5 个  
+**变更规模：** +88 / -18
+
+| 文件 | 变更类型 |
+|---|---|
+| `infrastructure/persistence/database/sqlite_knowledge_repository.py` | beat_sections 等字段持久化 |
+| `application/engine/services/autopilot_daemon.py` | 注入 knowledge_service，合并 beat_sections 到 outline |
+| `scripts/start_daemon.py` | Daemon 构建注入 knowledge_service |
+| `interfaces/api/v1/engine/autopilot_routes.py` | 修复当前章节号推断 Bug |
+| `frontend/src/components/knowledge/KnowledgePanel.vue` | 修复 addChapter NaN Bug |
+
+---
+
+## 背景与动机
+
+原有实现存在两个断层：
+
+1. **持久化断层**：`chapter_summaries` 表仅保存 `summary`，`beat_sections` / `micro_beats` / `key_events` 等字段写入时被丢弃，用户在分章叙事面板设定的节拍内容保存后即消失。
+
+2. **生成断层**：`AutopilotDaemon` 生成章节时只读取 `outline`，从未读取 `beat_sections`，导致用户设定的节拍对正文生成完全无效。
+
+---
+
+## 变更详情
+
+### 1. `infrastructure/persistence/database/sqlite_knowledge_repository.py`
+
+**`chapter_summaries` 表写入扩展**，补全全部字段的持久化：
+
+```diff
+ conn.execute(
+     """
+-    INSERT INTO chapter_summaries
+-    (id, knowledge_id, chapter_number, summary, created_at, updated_at)
+-    VALUES (?, ?, ?, ?, ?, ?)
++    INSERT INTO chapter_summaries
++    (id, knowledge_id, chapter_number, summary, key_events, open_threads,
++     consistency_note, beat_sections, micro_beats, sync_status, created_at, updated_at)
++    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(knowledge_id, chapter_number) DO UPDATE SET
+         summary = excluded.summary,
++        key_events        = excluded.key_events,
++        open_threads      = excluded.open_threads,
++        consistency_note  = excluded.consistency_note,
++        beat_sections     = excluded.beat_sections,
++        micro_beats       = excluded.micro_beats,
++        sync_status       = excluded.sync_status,
+         updated_at = excluded.updated_at
+     """,
+-    (summary_id, knowledge_id, cn, chapter.summary, now, now),
++    (
++        summary_id, knowledge_id, cn,
++        chapter.summary or "",
++        getattr(chapter, "key_events", "") or "",
++        getattr(chapter, "open_threads", "") or "",
++        getattr(chapter, "consistency_note", "") or "",
++        beat_sections_json,   # JSON 序列化的 List[str]
++        micro_beats_json,     # JSON 序列化的 List[str]
++        getattr(chapter, "sync_status", "draft") or "draft",
++        now, now,
++    ),
+ )
+```
+
+---
+
+### 2. `application/engine/services/autopilot_daemon.py`
+
+**新增 `knowledge_service` 可选依赖，生成前自动将 `beat_sections` 前置到 outline：**
+
+```diff
+ def __init__(
+     self,
+     ...
++    knowledge_service=None,
+ ):
+     ...
++    self.knowledge_service = knowledge_service
+```
+
+```diff
+ chapter_num = next_chapter_node.number
+ outline = next_chapter_node.outline or next_chapter_node.description or next_chapter_node.title
+
++# 合并分章叙事节拍（beat_sections）到 outline，让 AI 按用户设定的叙事节拍生成
++if self.knowledge_service:
++    try:
++        knowledge = self.knowledge_service.get_knowledge(novel.novel_id.value)
++        chapter_entry = next(
++            (ch for ch in knowledge.chapters if str(ch.chapter_id) == str(chapter_num)),
++            None
++        )
++        if chapter_entry and getattr(chapter_entry, "beat_sections", None):
++            beats_text = "\n".join(str(b) for b in chapter_entry.beat_sections if b)
++            if beats_text.strip():
++                outline = f"【分章叙事节拍】\n{beats_text}\n\n【章节大纲】\n{outline}"
++                logger.info(f"[{novel.novel_id}] 已合并第{chapter_num}章分章叙事节拍（{len(chapter_entry.beat_sections)}条）")
++    except Exception as _e:
++        logger.warning(f"[{novel.novel_id}] 读取分章叙事失败，使用原始大纲：{_e}")
+```
+
+---
+
+### 3. `scripts/start_daemon.py`
+
+**Daemon 构建时注入 `knowledge_service`：**
+
+```diff
+ return AutopilotDaemon(
+     ...
++    knowledge_service=get_knowledge_service(),
+ )
+```
+
+---
+
+### 4. `interfaces/api/v1/engine/autopilot_routes.py`
+
+**修复当前章节号推断逻辑**（`_resolve_current_chapter_number`，两处均已修复）：
+
+**问题：** 预创建的空壳 draft 章节会被误判为「当前写入中」的章节，导致日志流显示章节号偏大。
+
+```diff
+ if drafts:
+-    return max(int(c.number) for c in drafts)
++    active = [c for c in drafts if _wc(c) > 0]   # 有内容的 draft
++    if active:
++        return max(int(c.number) for c in active)
++    return min(int(c.number) for c in drafts)     # 全为空壳时取最小（即将写入的下一章）
+```
+
+---
+
+### 5. `frontend/src/components/knowledge/KnowledgePanel.vue`
+
+**修复 `addChapter` 中 `chapter_id` 数值计算 Bug：**
+
+**问题：** `chapter_id` 从服务端返回为字符串类型时，`Math.max(...ids)` 接收字符串数组会返回 `NaN`，导致新增章节 ID 变成 `NaN + 1 = NaN`。
+
+```diff
+-const ids = data.value.chapters.map(c => c.chapter_id)
++const ids = data.value.chapters.map(c => Number(c.chapter_id)).filter(n => Number.isFinite(n))
+```
+
+---
+
+## 影响范围
+
+- **无 Breaking Change**：`knowledge_service` 为可选注入，未注入时静默跳过节拍合并，行为与原版一致
+- **数据库**：`chapter_summaries` 表扩展通过 `ON CONFLICT DO UPDATE` 完成，已有行不受影响，新列初始值为空字符串 / NULL
+- **前端**：仅修复计算逻辑，UI 无变化
+
+## 测试建议
+
+- [ ] 在分章叙事面板为某章设定 `beat_sections`，保存后重新加载验证持久化
+- [ ] 触发 Autopilot 生成该章，检查日志是否出现「已合并第N章分章叙事节拍」
+- [ ] 验证正文内容是否按 beat_sections 中的节拍展开
+- [ ] 新增章节后确认 `chapter_id` 为正确递增整数

--- a/frontend/src/components/knowledge/KnowledgePanel.vue
+++ b/frontend/src/components/knowledge/KnowledgePanel.vue
@@ -691,7 +691,7 @@ const generateKnowledge = async () => {
 }
 
 const addChapter = () => {
-  const ids = data.value.chapters.map(c => c.chapter_id)
+  const ids = data.value.chapters.map(c => Number(c.chapter_id)).filter(n => Number.isFinite(n))
   const next = ids.length ? Math.max(...ids) + 1 : 1
   data.value.chapters.push({
     chapter_id: next,

--- a/infrastructure/persistence/database/sqlite_knowledge_repository.py
+++ b/infrastructure/persistence/database/sqlite_knowledge_repository.py
@@ -692,19 +692,44 @@ class SqliteKnowledgeRepository:
                 }
                 self._insert_triple_row(conn, novel_id, d, now)
 
+            import json as _json
             conn.execute("DELETE FROM chapter_summaries WHERE knowledge_id = ?", (knowledge_id,))
             for chapter in knowledge.chapters:
                 cn = chapter.chapter_id
                 summary_id = f"{knowledge_id}-ch{cn}"
+                beat_sections_json = _json.dumps(
+                    list(getattr(chapter, "beat_sections", None) or []), ensure_ascii=False
+                )
+                micro_beats_json = _json.dumps(
+                    list(getattr(chapter, "micro_beats", None) or []), ensure_ascii=False
+                )
                 conn.execute(
                     """
-                    INSERT INTO chapter_summaries (id, knowledge_id, chapter_number, summary, created_at, updated_at)
-                    VALUES (?, ?, ?, ?, ?, ?)
+                    INSERT INTO chapter_summaries
+                    (id, knowledge_id, chapter_number, summary, key_events, open_threads,
+                     consistency_note, beat_sections, micro_beats, sync_status, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(knowledge_id, chapter_number) DO UPDATE SET
                         summary = excluded.summary,
+                        key_events = excluded.key_events,
+                        open_threads = excluded.open_threads,
+                        consistency_note = excluded.consistency_note,
+                        beat_sections = excluded.beat_sections,
+                        micro_beats = excluded.micro_beats,
+                        sync_status = excluded.sync_status,
                         updated_at = excluded.updated_at
                     """,
-                    (summary_id, knowledge_id, cn, chapter.summary, now, now),
+                    (
+                        summary_id, knowledge_id, cn,
+                        chapter.summary or "",
+                        getattr(chapter, "key_events", "") or "",
+                        getattr(chapter, "open_threads", "") or "",
+                        getattr(chapter, "consistency_note", "") or "",
+                        beat_sections_json,
+                        micro_beats_json,
+                        getattr(chapter, "sync_status", "draft") or "draft",
+                        now, now,
+                    ),
                 )
 
         logger.info("Saved StoryKnowledge for novel: %s", novel_id)

--- a/interfaces/api/v1/engine/autopilot_routes.py
+++ b/interfaces/api/v1/engine/autopilot_routes.py
@@ -305,6 +305,33 @@ async def autopilot_log_stream(
 
     async def event_generator():
         install_autopilot_log_ring_handler()
+<<<<<<< HEAD
+=======
+        def _resolve_current_chapter_number(novel) -> Optional[int]:
+            “””
+            日志流事件补齐”当前章节号”。
+            由于 Novel 表仅存 current_act/current_chapter_in_act（非全书章号），这里从章节表推断：
+            - 若有 draft 章且有内容（节拍增量落库中）：取最大有内容 draft 章号
+            - 若 draft 章均为空壳（预创建）：取最小 draft 章号（即将写入的下一章）
+            - 否则：取最大 completed 章号 + 1（作为”即将写入”的预测章号）
+            “””
+            try:
+                chapters = chapter_repo.list_by_novel(NovelId(novel_id))
+                _st = lambda c: c.status.value if hasattr(c.status, “value”) else c.status
+                _wc = lambda c: c.word_count.value if hasattr(c.word_count, “value”) else (c.word_count or 0)
+                drafts = [c for c in chapters if _st(c) == “draft”]
+                if drafts:
+                    active = [c for c in drafts if _wc(c) > 0]
+                    if active:
+                        return max(int(c.number) for c in active)
+                    return min(int(c.number) for c in drafts)
+                completed = [c for c in chapters if _st(c) == “completed”]
+                if completed:
+                    return max(int(c.number) for c in completed) + 1
+            except Exception:
+                return None
+            return None
+>>>>>>> 9704cb8 (feat: 分章叙事节拍持久化 + autopilot 集成 + 章节号推断修复)
 
         # 发送初始连接事件（前端可不写入时间线；metadata 用于工具栏「当前阶段」标签）
         novel_boot = novel_repo.get_by_id(NovelId(novel_id))
@@ -531,6 +558,19 @@ async def autopilot_log_stream(
                     act_display = (novel.current_act or 0) + 1
                     tw = int(total_words) if total_words else 0
                     beat_1based = int(current_beat) + 1
+                    current_chapter_number = None
+                    try:
+                        if drafts:
+                            _wc2 = lambda c: c.word_count.value if hasattr(c.word_count, "value") else (c.word_count or 0)
+                            active2 = [c for c in drafts if _wc2(c) > 0]
+                            current_chapter_number = (
+                                max(int(c.number) for c in active2) if active2
+                                else min(int(c.number) for c in drafts)
+                            )
+                        elif completed:
+                            current_chapter_number = max(int(c.number) for c in completed) + 1
+                    except Exception:
+                        current_chapter_number = None
                     progress_event = {
                         "type": "progress",
                         "message": (

--- a/scripts/start_daemon.py
+++ b/scripts/start_daemon.py
@@ -152,6 +152,7 @@ def build_daemon() -> AutopilotDaemon:
         circuit_breaker=circuit_breaker,
         chapter_workflow=chapter_workflow,
         aftermath_pipeline=aftermath_pipeline,
+        knowledge_service=get_knowledge_service(),
     )
 
 


### PR DESCRIPTION
- sqlite_knowledge_repository: 补全 beat_sections/micro_beats/key_events 等字段持久化
- autopilot_daemon: 注入 knowledge_service，生成前自动合并 beat_sections 到 outline
- start_daemon: 构建 Daemon 时注入 knowledge_service
- autopilot_routes: 修复空壳 draft 章节导致章节号推断偏大的 Bug
- KnowledgePanel.vue: 修复 addChapter chapter_id 字符串类型导致 NaN 的 Bug

变更类型
 feat 新功能
 fix Bug 修复
 refactor 重构（不影响功能）
 perf 性能优化
 docs 文档
 chore 构建/工具链
变更说明
打通分章叙事节拍（beat_sections）从「用户输入 → 持久化 → 正文生成」的全链路。原实现存在两个断层：chapter_summaries 表仅持久化 summary 字段，导致用户在面板设定的节拍内容保存后即丢失；AutopilotDaemon 生成章节时从未读取 beat_sections，用户设定的节拍对正文生成完全无效。同步修复了空壳 draft 章节导致日志流章节号推断偏大、以及 addChapter 中 chapter_id 字符串类型引发 NaN 的两个 Bug。

架构影响
涉及层级：application / infrastructure / interfaces / frontend / scripts
是否新增数据库表/字段：是
chapter_summaries 表新增字段：key_events、open_threads、consistency_note、beat_sections（JSON）、micro_beats（JSON）、sync_status
通过 ON CONFLICT DO UPDATE 扩展写入，无需独立 migration，已有行不受影响，新列初始值为空字符串 / NULL
是否修改现有 API 契约：否，knowledge_service 为可选注入，未注入时行为与原版完全一致
测试

# 后端单测
pytest tests/unit/application/services/test_continuous_planning_service.py -v
# 结果：5 passed in 0.38s
 新增/修改的逻辑有对应单测
 本地后端启动正常（python -m uvicorn ...）
 本地前端启动正常（npm run dev）
风险说明
潜在风险：beat_sections / micro_beats 以 JSON 字符串形式写入数据库，若领域对象中对应字段值异常（非列表类型），json.dumps 会静默序列化为非预期内容；已通过 list(getattr(...) or []) 兜底处理
回滚方式：knowledge_service 从 start_daemon.py 移除注入即可恢复原有行为，数据库新增字段不影响旧版本读取


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beat sections are now stored and automatically incorporated into chapter generation workflows when available.

* **Bug Fixes**
  * Fixed chapter numbering logic to accurately distinguish between empty draft shells and drafts with actual content, ensuring proper sequencing.
  * Resolved chapter ID computation errors in the chapter management interface when handling mixed numeric and string chapter identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->