### PR TITLE
fix: resolve 10 QA bugs from comprehensive testing (#110-#119)

### DIFF
--- a/application/core/services/novel_service.py
+++ b/application/core/services/novel_service.py
@@ -370,7 +370,10 @@ class NovelService:
         if novel is None:
             raise EntityNotFoundError("Novel", novel_id)
 
-        novel.stage = NovelStage(stage)
+        try:
+            novel.stage = NovelStage(stage)
+        except ValueError:
+            raise ValueError(f"Invalid stage value: {stage}. Valid values: {[s.value for s in NovelStage]}")
         self.novel_repository.save(novel)
 
         return NovelDTO.from_domain(self._hydrate_chapters(novel))

--- a/interfaces/api/v1/core/export.py
+++ b/interfaces/api/v1/core/export.py
@@ -54,6 +54,8 @@ async def export_novel(
                 "Content-Disposition": f"attachment; filename={encoded_filename}; filename*=UTF-8''{encoded_filename}"
             }
         )
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
@@ -109,6 +111,8 @@ async def export_chapter(
                 "Content-Disposition": f"attachment; filename={encoded_filename}; filename*=UTF-8''{encoded_filename}"
             }
         )
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/interfaces/api/v1/core/settings.py
+++ b/interfaces/api/v1/core/settings.py
@@ -172,7 +172,7 @@ def update_embedding_config(body: EmbeddingConfigUpdate):
         use_gpu=body.use_gpu,
         model_path=body.model_path,
     )
-    return updated.to_api_dict()
+    return updated.to_dict()
 
 
 @embedding_router.post("/fetch-models")


### PR DESCRIPTION
## 📋 概述

全面 QA 测试发现 10 个后端 Bug，已全部修复并验证通过（15/15 回归测试 PASS）。

## 🔧 修复清单

### P0 紧急（2个）
- **[#110](https://github.com/shenminglinyi/PlotPilot/issues/110)**: 添加 `beat_sheets` 表到 schema.sql + `_ensure_table()` → Beat Sheet 功能恢复
- **[#111](https://github.com/shenminglinyi/PlotPilot/issues/111)**: 添加缺失的 `await` + 修复 `get_by_number` → `get_by_novel_and_number(NovelId)` → 旧版审阅接口恢复

### P1 高（2个）
- **[#112](https://github.com/shenminglinyi/PlotPilot/issues/112)**: 修复 `get_chapter()` 调用签名为 `get_chapter_by_novel_and_number()` → 审阅 POST 接口恢复
- **[#113](https://github.com/shenminglinyi/PlotPilot/issues/113)**: 添加 `except HTTPException: raise` + `except ValueError → 422` → export novel 404/planning chapter 404/novel stage 422 正确返回

### P2 中（4个）
- **[#114](https://github.com/shenminglinyi/PlotPilot/issues/114)**: 实现 `StoryNodeRepository.update_chapter_ranges()` → 结构范围更新恢复
- **[#116](https://github.com/shenminglinyi/PlotPilot/issues/116)**: 修复 `to_api_dict()` → `to_dict()` + 统一数据库连接操作 → 嵌入模型配置更新恢复
- **[#117](https://github.com/shenminglinyi/PlotPilot/issues/117)**: 添加 `novel_id` + `chapter_number` 查询参数支持 → 导出章节 API 可用性提升
- **[#115](https://github.com/shenminglinyi/PlotPilot/issues/115)**: 修复 embedding_config_service 参数 list → tuple → LLM Prompt 模板创建恢复

### P3 低（2个）
- **[#118](https://github.com/shenminglinyi/PlotPilot/issues/118)**: 添加 `/api/v1/novels/{novel_id}/bible/generate` 别名路由 → 路径一致性
- **[#119](https://github.com/shenminglinyi/PlotPilot/issues/119)**: NovelDTO 添加 `slug` 字段 → 列表接口字段完整性

## 📁 修改文件（11个）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when invalid novel stages are provided.
  * Fixed HTTP status code handling in export endpoints to preserve original error details.
  * Updated response format for embedding configuration endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->