### PR TITLE
fix: sync chapter deletion with structure tree removal

### DIFF
--- a/application/blueprint/services/story_structure_service.py
+++ b/application/blueprint/services/story_structure_service.py
@@ -208,11 +208,17 @@ class StoryStructureService:
                 self._chapter_repository.delete(ChapterId(chapter_id))
                 coordinator = self._chapter_renumber_coordinator
                 if coordinator is not None:
-                    coordinator.on_chapter_deleted(node.novel_id, chapter_number)
+                    coordinator.on_chapter_deleted(node.novel_id, chapter_number, chapter_id)
                 deleted_any = True
 
-        deleted_any = await self.repository.delete(node_id) or deleted_any
-        return deleted_any
+        remaining = await self.repository.get_by_id(node_id)
+        if remaining is None:
+            return node.node_type == NodeType.CHAPTER and deleted_any
+
+        deleted_node = await self.repository.delete(node_id)
+        if deleted_node:
+            return True
+        return False
 
     async def reorder_nodes(self, node_ids: List[str]) -> List[Dict[str, Any]]:
         """重新排序节点"""

--- a/application/blueprint/services/story_structure_service.py
+++ b/application/blueprint/services/story_structure_service.py
@@ -6,13 +6,15 @@
 """
 
 import uuid
-from typing import List, Optional, Dict, Any, TYPE_CHECKING
+from typing import List, Optional, Dict, Any, TYPE_CHECKING, Set
 
+from domain.novel.value_objects.chapter_id import ChapterId
 from domain.novel.value_objects.novel_id import NovelId
 from domain.structure.story_node import StoryNode, StoryTree, NodeType
 from infrastructure.persistence.database.story_node_repository import StoryNodeRepository
 
 if TYPE_CHECKING:
+    from application.novel.chapter_renumber.coordinator import ChapterRenumberCoordinator
     from domain.novel.repositories.chapter_repository import ChapterRepository
     from application.blueprint.services.continuous_planning_service import ContinuousPlanningService
 
@@ -30,10 +32,12 @@ class StoryStructureService:
         self,
         repository: StoryNodeRepository,
         chapter_repository: Optional["ChapterRepository"] = None,
+        chapter_renumber_coordinator: Optional["ChapterRenumberCoordinator"] = None,
         planning_service: Optional["ContinuousPlanningService"] = None,
     ):
         self.repository = repository
         self._chapter_repository = chapter_repository
+        self._chapter_renumber_coordinator = chapter_renumber_coordinator
         self._planning_service = planning_service
 
     def _enrich_chapter_nodes_from_chapters_table(
@@ -159,9 +163,56 @@ class StoryStructureService:
         saved_node = await self.repository.save(node)
         return saved_node.to_dict()
 
+    def _collect_descendant_chapter_numbers(self, novel_id: str, root_id: str) -> List[int]:
+        """找出子树内挂着的正文章节编号，供删结构时同步清理正文库。"""
+        nodes = self.repository.get_by_novel_sync(novel_id)
+        by_id = {node.id: node for node in nodes}
+        root = by_id.get(root_id)
+        if root is None:
+            return []
+
+        children_by_parent: Dict[str, List[StoryNode]] = {}
+        for node in nodes:
+            if node.parent_id:
+                children_by_parent.setdefault(node.parent_id, []).append(node)
+
+        chapter_numbers: Set[int] = set()
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.node_type == NodeType.CHAPTER:
+                try:
+                    chapter_numbers.add(int(node.number))
+                except (TypeError, ValueError):
+                    pass
+            stack.extend(children_by_parent.get(node.id, []))
+
+        return sorted(chapter_numbers, reverse=True)
+
     async def delete_node(self, node_id: str) -> bool:
-        """删除节点"""
-        return await self.repository.delete(node_id)
+        """删除节点，并同步清理关联的正文章节。"""
+        node = await self.repository.get_by_id(node_id)
+        if not node:
+            return False
+
+        deleted_any = False
+        if self._chapter_repository is not None:
+            chapter_numbers = self._collect_descendant_chapter_numbers(node.novel_id, node_id)
+            for chapter_number in chapter_numbers:
+                chapter = self._chapter_repository.get_by_novel_and_number(
+                    NovelId(node.novel_id), chapter_number
+                )
+                if chapter is None:
+                    continue
+                chapter_id = chapter.id.value if hasattr(chapter.id, "value") else chapter.id
+                self._chapter_repository.delete(ChapterId(chapter_id))
+                coordinator = self._chapter_renumber_coordinator
+                if coordinator is not None:
+                    coordinator.on_chapter_deleted(node.novel_id, chapter_number)
+                deleted_any = True
+
+        deleted_any = await self.repository.delete(node_id) or deleted_any
+        return deleted_any
 
     async def reorder_nodes(self, node_ids: List[str]) -> List[Dict[str, Any]]:
         """重新排序节点"""

--- a/infrastructure/persistence/database/story_node_repository.py
+++ b/infrastructure/persistence/database/story_node_repository.py
@@ -20,6 +20,7 @@ class StoryNodeRepository:
         """获取数据库连接"""
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
         return conn
 
     def save_sync(self, node: StoryNode) -> StoryNode:

--- a/interfaces/api/v1/blueprint/story_structure.py
+++ b/interfaces/api/v1/blueprint/story_structure.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from application.blueprint.services.story_structure_service import StoryStructureService
 from application.blueprint.services.continuous_planning_service import ContinuousPlanningService
+from interfaces.api.dependencies import get_chapter_renumber_coordinator
 from infrastructure.persistence.database.story_node_repository import StoryNodeRepository
 from infrastructure.persistence.database.chapter_element_repository import ChapterElementRepository
 from infrastructure.persistence.database.sqlite_chapter_repository import SqliteChapterRepository
@@ -68,6 +69,7 @@ def get_service(
     return StoryStructureService(
         repository,
         chapter_repository=chapter_repo,
+        chapter_renumber_coordinator=get_chapter_renumber_coordinator(),
         planning_service=planning_service
     )
 

--- a/tests/integration/infrastructure/persistence/database/test_story_node_repository.py
+++ b/tests/integration/infrastructure/persistence/database/test_story_node_repository.py
@@ -1,0 +1,72 @@
+"""StoryNodeRepository integration tests."""
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from domain.structure.story_node import NodeType, StoryNode
+from infrastructure.persistence.database.story_node_repository import StoryNodeRepository
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[5]
+    / "infrastructure"
+    / "persistence"
+    / "database"
+    / "schema.sql"
+)
+
+
+@pytest.fixture
+def repo_db(tmp_path):
+    db_path = tmp_path / "story-node-repo.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA_PATH.read_text(encoding="utf-8"))
+    conn.commit()
+    conn.close()
+    return StoryNodeRepository(str(db_path)), db_path
+
+
+def test_delete_cascades_to_descendant_story_nodes(repo_db):
+    repo, db_path = repo_db
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO novels (id, title, slug, target_chapters) VALUES (?, ?, ?, ?)",
+        ("novel-1", "Novel 1", "novel-1", 10),
+    )
+    conn.commit()
+    conn.close()
+
+    repo.save_sync(
+        StoryNode(
+            id="volume-1",
+            novel_id="novel-1",
+            node_type=NodeType.VOLUME,
+            number=1,
+            title="Volume 1",
+            order_index=0,
+        )
+    )
+    repo.save_sync(
+        StoryNode(
+            id="act-1",
+            novel_id="novel-1",
+            parent_id="volume-1",
+            node_type=NodeType.ACT,
+            number=1,
+            title="Act 1",
+            order_index=0,
+        )
+    )
+
+    deleted = asyncio.run(repo.delete("volume-1"))
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT id, parent_id, node_type FROM story_nodes ORDER BY id"
+    ).fetchall()
+    conn.close()
+
+    assert deleted is True
+    assert rows == []

--- a/tests/unit/application/services/test_story_structure_service.py
+++ b/tests/unit/application/services/test_story_structure_service.py
@@ -27,9 +27,10 @@ class _FakeStoryRepo:
 
 
 class _FakeChapterRepo:
-    def __init__(self, chapters):
+    def __init__(self, chapters, on_delete=None):
         self._chapters = {number: chapter for number, chapter in chapters.items()}
         self.deleted_numbers = []
+        self._on_delete = on_delete
 
     def get_by_novel_and_number(self, novel_id, chapter_number):
         return self._chapters.get(chapter_number)
@@ -40,6 +41,8 @@ class _FakeChapterRepo:
             if current_id == chapter_id.value:
                 self.deleted_numbers.append(number)
                 del self._chapters[number]
+                if self._on_delete is not None:
+                    self._on_delete(chapter_id.value)
                 return
 
 
@@ -47,8 +50,13 @@ class _FakeCoordinator:
     def __init__(self):
         self.calls = []
 
-    def on_chapter_deleted(self, novel_id: str, deleted_chapter_number: int) -> None:
-        self.calls.append((novel_id, deleted_chapter_number))
+    def on_chapter_deleted(
+        self,
+        novel_id: str,
+        deleted_chapter_number: int,
+        deleted_chapter_id: Optional[str] = None,
+    ) -> None:
+        self.calls.append((novel_id, deleted_chapter_number, deleted_chapter_id))
 
 
 def _node(node_id: str, node_type: NodeType, number: int, parent_id: Optional[str] = None):
@@ -85,5 +93,50 @@ def test_delete_node_removes_descendant_chapters_before_deleting_structure_node(
 
     assert result is True
     assert chapter_repo.deleted_numbers == [2, 1]
-    assert coordinator.calls == [("novel-1", 2), ("novel-1", 1)]
+    assert coordinator.calls == [
+        ("novel-1", 2, "chapter-2"),
+        ("novel-1", 1, "chapter-1"),
+    ]
     assert repo.deleted_ids == ["act-1"]
+
+
+def test_delete_node_returns_true_when_direct_chapter_delete_removes_story_node():
+    repo = _FakeStoryRepo([_node("chapter-1", NodeType.CHAPTER, 1)])
+    chapter_repo = _FakeChapterRepo(
+        {1: _chapter(1)},
+        on_delete=lambda chapter_id: repo._nodes.pop(chapter_id, None),
+    )
+    coordinator = _FakeCoordinator()
+    service = StoryStructureService(
+        repo,
+        chapter_repository=chapter_repo,
+        chapter_renumber_coordinator=coordinator,
+    )
+
+    result = asyncio.run(service.delete_node("chapter-1"))
+
+    assert result is True
+    assert chapter_repo.deleted_numbers == [1]
+    assert coordinator.calls == [("novel-1", 1, "chapter-1")]
+    assert asyncio.run(repo.get_by_id("chapter-1")) is None
+    assert repo.deleted_ids == []
+
+
+def test_delete_node_returns_false_when_structure_delete_fails_after_chapter_cleanup():
+    class _FailingDeleteStoryRepo(_FakeStoryRepo):
+        async def delete(self, node_id):
+            return False
+
+    repo = _FailingDeleteStoryRepo(
+        [
+            _node("act-1", NodeType.ACT, 1),
+            _node("chapter-1", NodeType.CHAPTER, 1, parent_id="act-1"),
+        ]
+    )
+    chapter_repo = _FakeChapterRepo({1: _chapter(1)})
+    service = StoryStructureService(repo, chapter_repository=chapter_repo)
+
+    result = asyncio.run(service.delete_node("act-1"))
+
+    assert result is False
+    assert chapter_repo.deleted_numbers == [1]

--- a/tests/unit/application/services/test_story_structure_service.py
+++ b/tests/unit/application/services/test_story_structure_service.py
@@ -1,0 +1,89 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Optional
+
+from application.blueprint.services.story_structure_service import StoryStructureService
+from domain.novel.value_objects.chapter_id import ChapterId
+from domain.structure.story_node import NodeType
+
+
+class _FakeStoryRepo:
+    def __init__(self, nodes):
+        self._nodes = {node.id: node for node in nodes}
+        self.deleted_ids = []
+
+    async def get_by_id(self, node_id):
+        return self._nodes.get(node_id)
+
+    def get_by_novel_sync(self, novel_id):
+        return [node for node in self._nodes.values() if node.novel_id == novel_id]
+
+    async def delete(self, node_id):
+        existed = node_id in self._nodes
+        if existed:
+            self.deleted_ids.append(node_id)
+            del self._nodes[node_id]
+        return existed
+
+
+class _FakeChapterRepo:
+    def __init__(self, chapters):
+        self._chapters = {number: chapter for number, chapter in chapters.items()}
+        self.deleted_numbers = []
+
+    def get_by_novel_and_number(self, novel_id, chapter_number):
+        return self._chapters.get(chapter_number)
+
+    def delete(self, chapter_id: ChapterId):
+        for number, chapter in list(self._chapters.items()):
+            current_id = chapter.id.value if hasattr(chapter.id, "value") else chapter.id
+            if current_id == chapter_id.value:
+                self.deleted_numbers.append(number)
+                del self._chapters[number]
+                return
+
+
+class _FakeCoordinator:
+    def __init__(self):
+        self.calls = []
+
+    def on_chapter_deleted(self, novel_id: str, deleted_chapter_number: int) -> None:
+        self.calls.append((novel_id, deleted_chapter_number))
+
+
+def _node(node_id: str, node_type: NodeType, number: int, parent_id: Optional[str] = None):
+    return SimpleNamespace(
+        id=node_id,
+        novel_id="novel-1",
+        parent_id=parent_id,
+        node_type=node_type,
+        number=number,
+    )
+
+
+def _chapter(number: int):
+    return SimpleNamespace(id=f"chapter-{number}", number=number)
+
+
+def test_delete_node_removes_descendant_chapters_before_deleting_structure_node():
+    repo = _FakeStoryRepo(
+        [
+            _node("act-1", NodeType.ACT, 1),
+            _node("chapter-1", NodeType.CHAPTER, 1, parent_id="act-1"),
+            _node("chapter-2", NodeType.CHAPTER, 2, parent_id="act-1"),
+        ]
+    )
+    chapter_repo = _FakeChapterRepo({1: _chapter(1), 2: _chapter(2)})
+    coordinator = _FakeCoordinator()
+    service = StoryStructureService(
+        repo,
+        chapter_repository=chapter_repo,
+        chapter_renumber_coordinator=coordinator,
+    )
+
+    result = asyncio.run(service.delete_node("act-1"))
+
+    assert result is True
+    assert chapter_repo.deleted_numbers == [2, 1]
+    assert coordinator.calls == [("novel-1", 2), ("novel-1", 1)]
+    assert repo.deleted_ids == ["act-1"]


### PR DESCRIPTION
## 变更类型

- [ ] `feat` 新功能
- [x] `fix` Bug 修复
- [ ] `refactor` 重构（不影响功能）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `chore` 构建/工具链

---

## 变更说明

结构树删除原先只处理了章节正文清理，但没有保证 `story_nodes` 子树级联删除真正生效，也会把“删掉了正文但根结构节点没删掉”的场景误报为成功。这次修复补上了 SQLite 外键级联支持，明确了 `StoryStructureService.delete_node()` 的成功条件，并补充 direct chapter 删除与子树删除的回归覆盖。

---

## 架构影响

- 涉及层级：`application` / `infrastructure` / `interfaces`
- 是否新增数据库表/字段：否
- 是否修改现有 API 契约（路径/字段/类型变更）：否

---

## 测试

```bash
# 后端单测（必填，粘贴你实际跑的命令和结果摘要）
pytest tests/unit/application/services/test_story_structure_service.py -q
# 结果：3 passed

pytest tests/integration/infrastructure/persistence/database/test_story_node_repository.py -q
# 结果：1 passed

# 前端构建（如改了前端必填）
# 未改前端
```

- [x] 新增/修改的逻辑有对应单测
- [ ] 本地后端启动正常（`python -m uvicorn ...`）
- [ ] 本地前端启动正常（`npm run dev`）

---

## 风险说明

- 潜在风险：`StoryNodeRepository` 现在会按数据库外键约束真实级联删除子节点；如果有旧逻辑依赖删除父节点后残留孤儿 `story_nodes`，需要额外回归。
- 回滚方式：回滚提交 `3399e65` 与 `69527ae`，恢复删除路径的原行为，并移除对应测试。

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a story-structure node now removes descendant chapters and triggers chapter renumbering so numbering remains consistent.
* **Chores**
  * SQLite persistence now enforces foreign-key cascades to ensure descendant nodes are removed reliably.
* **Tests**
  * Added unit and integration tests covering node/chapter deletion, cascade behavior, and renumbering callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->