### PR TITLE
改进新书的生成体验与UI向导，简单说就是LLM慢的话，提供下次继续功能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,137 @@
+# CLAUDE.md
+
+本文件为 Claude Code (claude.ai/code) 在此代码库中工作提供指导。
+
+## 项目概览
+
+**PlotPilot (墨枢)** - AI 驱动的长篇创作平台，集自动驾驶生成、知识图谱管理、风格分析于一体。
+
+- **后端**：Python + FastAPI（DDD 四层架构）
+- **前端**：Vue 3 + TypeScript + Vite + Naive UI
+- **数据库**：SQLite + FAISS（本地向量存储，无需外部服务）
+- **AI**：OpenAI 兼容协议 / Anthropic Claude / 火山方舟 Doubao
+
+## 常用命令
+
+### 后端开发
+```bash
+# 创建虚拟环境
+python -m venv .venv && .venv\Scripts\activate
+
+# 安装核心依赖（轻量级）
+pip install -r requirements.txt
+
+# 安装本地嵌入模型依赖（可选）
+pip install -r requirements-local.txt
+
+# 启动后端（热重载）
+uvicorn interfaces.main:app --host 127.0.0.1 --port 8005 --reload
+
+# 运行测试
+pytest tests/ -v
+
+# 仅运行单元测试
+pytest tests/unit -v -m unit
+
+# 仅运行集成测试
+pytest tests/integration -v -m integration
+
+# 运行测试并生成覆盖率报告
+pytest tests/ --cov=. --cov-report=term-missing
+```
+
+### 前端开发
+```bash
+cd frontend
+
+# 安装依赖
+npm install
+
+# 启动开发服务器
+npm run dev
+
+# 构建生产版本
+npm run build
+
+# 预览生产构建
+npm run preview
+```
+
+### 环境配置
+```bash
+# 复制示例环境变量并配置
+copy .env.example .env
+```
+
+必需环境变量：
+- `ANTHROPIC_API_KEY` 或 `ARK_API_KEY`：至少配置一个 LLM 凭证
+- `EMBEDDING_SERVICE`：`openai`（默认）或 `local`
+
+## 架构：DDD 四层
+
+```
+domain/                # 核心业务逻辑与模型
+├── bible/            # 故事圣经
+├── cast/             # 角色
+├── knowledge/        # 知识管理
+├── novel/            # 小说核心
+├── structure/        # 故事结构
+└── worldbuilding/    # 世界观设定
+
+application/           # 应用服务与工作流
+├── engine/           # 生成引擎
+├── services/         # 业务服务（memory_engine、autopilot_daemon 等）
+├── workflows/        # 自动小说生成
+└── world/            # 世界观服务
+
+infrastructure/        # 技术实现
+├── ai/               # LLM 客户端、提示词管理器
+└── persistence/      # 数据库连接
+
+interfaces/           # API 层
+└── api/              # REST 端点
+```
+
+## 关键服务与模块
+
+| 模块 | 路径 | 用途 |
+|------|------|------|
+| 记忆引擎 | `application/engine/services/memory_engine.py` | 多层上下文记忆管理 |
+| 自动驾驶守护进程 | `application/engine/services/autopilot_daemon.py` | 后台自动生成 |
+| 章后管线 | `application/engine/services/chapter_aftermath_pipeline.py` | 章节后处理（摘要、三元组、伏笔） |
+| 流式总线 | `application/engine/services/streaming_bus.py` | SSE 实时推送 |
+
+## API 路由 (v1)
+
+- 核心：`/api/v1/novels`、`/api/v1/chapters`
+- 世界观：`/api/v1/bible`、`/api/v1/cast`、`/api/v1/knowledge`
+- 蓝图：`/api/v1/beat-sheet`、`/api/v1/story-structure`
+- 引擎：`/api/v1/generation`、`/api/v1/autopilot`
+- 审阅：`/api/v1/chapter-review`
+- 分析：`/api/v1/voice`、`/api/v1/foreshadow-ledger`
+- 统计：`/api/stats`
+
+## 重要模式
+
+- **统一章后管线**：手动保存与自动驾驶共用同一套章后管线，确保叙事落库与索引逻辑一致。
+- **自动驾驶独立进程**：守护进程在独立进程中运行，避免阻塞主事件循环。
+- **本地向量存储**：使用 FAISS 本地存储，无需 Qdrant 或外部向量数据库。
+- **20+ 提示词接点**：集中式提示词配置，支持定制。
+
+## 前端结构
+
+```
+frontend/src/
+├── api/              # API 客户端
+├── components/       # Vue 组件
+│   ├── autopilot/   # 自动驾驶 UI
+│   └── workbench/   # 工作台组件
+└── views/            # 页面视图
+```
+
+## 配置文件
+
+- `.env.example`：环境变量模板
+- `pyproject.toml`：pytest 配置
+- `pytest.ini`：pytest 标记（unit、integration、slow）
+- `frontend/package.json`：npm 脚本与依赖

--- a/application/world/services/auto_bible_generator.py
+++ b/application/world/services/auto_bible_generator.py
@@ -340,25 +340,25 @@ class AutoBibleGenerator:
                 await self._save_worldbuilding(novel_id, bible_data["worldbuilding"])
 
         elif stage == "worldbuilding":
-            import sys
-            print(f"[DEBUG] Stage worldbuilding - checking Bible record", file=sys.stderr, flush=True)
+            logger.info(f"[世界观生成] 阶段1/5 - 开始处理 novel_id={novel_id}")
             # 确保Bible记录存在
             try:
                 self.bible_service.get_bible_by_novel(novel_id)
+                logger.info(f"[世界观生成] Bible 记录已存在")
             except EntityNotFoundError:
                 bible_id = f"{novel_id}-bible"
                 self.bible_service.create_bible(bible_id, novel_id)
-                logger.info(f"Created Bible record: {bible_id}")
+                logger.info(f"[世界观生成] 创建 Bible 记录: {bible_id}")
 
-            print(f"[DEBUG] Calling _generate_worldbuilding_and_style", file=sys.stderr, flush=True)
+            logger.info(f"[世界观生成] 阶段2/5 - 调用 LLM 生成世界观和文风...")
             # 只生成世界观和文风
             bible_data = await self._generate_worldbuilding_and_style(premise, target_chapters)
-            print(f"[DEBUG] _generate_worldbuilding_and_style completed", file=sys.stderr, flush=True)
-            print(f"[DEBUG] bible_data keys: {bible_data.keys()}", file=sys.stderr, flush=True)
-            print(f"[DEBUG] Has 'worldbuilding' key: {'worldbuilding' in bible_data}", file=sys.stderr, flush=True)
-            print(f"[DEBUG] worldbuilding_service is None: {self.worldbuilding_service is None}", file=sys.stderr, flush=True)
+            logger.info(f"[世界观生成] 阶段3/5 - LLM 生成完成，收到数据")
+            logger.info(f"[世界观生成] bible_data keys: {bible_data.keys()}")
+            logger.info(f"[世界观生成] 是否包含 worldbuilding: {'worldbuilding' in bible_data}")
             # 保存文风
             if "style" in bible_data:
+                logger.info(f"[世界观生成] 阶段4/5 - 保存文风公约...")
                 style_id = f"{novel_id}-style-1"
                 try:
                     self.bible_service.add_style_note(
@@ -367,46 +367,55 @@ class AutoBibleGenerator:
                         category="文风公约",
                         content=bible_data["style"]
                     )
-                    logger.info(f"Style note saved: {style_id}")
+                    logger.info(f"[世界观生成] 文风公约保存成功: {style_id}")
                 except Exception as e:
                     if "already exists" in str(e):
-                        logger.info(f"Style note {style_id} already exists, skipping")
+                        logger.info(f"[世界观生成] 文风公约已存在，跳过: {style_id}")
                     else:
-                        logger.error(f"Failed to save style note: {e}")
+                        logger.error(f"[世界观生成] 保存文风公约失败: {e}")
                         raise
+            else:
+                logger.warning(f"[世界观生成] bible_data 中没有 'style' 键")
+
             # 保存世界观
             if self.worldbuilding_service and "worldbuilding" in bible_data:
+                logger.info(f"[世界观生成] 阶段5/5 - 保存世界观设定...")
                 await self._save_worldbuilding(novel_id, bible_data["worldbuilding"])
+                logger.info(f"[世界观生成] 世界观设定保存完成")
+            else:
+                logger.warning(f"[世界观生成] 未保存世界观: worldbuilding_service={self.worldbuilding_service is not None}, has_key={'worldbuilding' in bible_data}")
 
         elif stage == "characters":
+            logger.info(f"[人物生成] 阶段1/4 - 开始处理 novel_id={novel_id}")
             # 确保Bible记录存在
             try:
                 self.bible_service.get_bible_by_novel(novel_id)
+                logger.info(f"[人物生成] Bible 记录已存在")
             except EntityNotFoundError:
                 bible_id = f"{novel_id}-bible"
                 self.bible_service.create_bible(bible_id, novel_id)
-                logger.info(f"Created Bible record: {bible_id}")
+                logger.info(f"[人物生成] 创建 Bible 记录: {bible_id}")
 
+            logger.info(f"[人物生成] 阶段2/4 - 加载已有世界观并调用 LLM 生成人物...")
             # 基于已有世界观生成人物
             existing_worldbuilding = self._load_worldbuilding(novel_id)
             bible_data = await self._generate_characters(premise, target_chapters, existing_worldbuilding)
-            chars_payload = bible_data.get("characters") or []
-            if not chars_payload:
-                raise ValueError(
-                    "角色生成未得到任何人物：多为模型输出非 JSON、截断或解析失败。"
-                    "请确认 AI 控制台模型可用并适当增大超时；也可查看服务端日志中的 LLM 原始片段。"
-                )
+            logger.info(f"[人物生成] 阶段3/4 - LLM 生成完成，开始保存人物...")
+
             # 保存人物
             character_ids = []
             used_char_ids = set()  # 用于跟踪已使用的人物ID
-            for idx, char_data in enumerate(bible_data.get("characters", [])):
+            characters = bible_data.get("characters", [])
+            logger.info(f"[人物生成] 准备保存 {len(characters)} 个人物")
+
+            for idx, char_data in enumerate(characters):
                 character_id = f"{novel_id}-char-{idx+1}"
-                
+
                 # 检查并处理重复ID
                 if character_id in used_char_ids:
-                    logger.info(f"Character ID {character_id} already exists, generating new ID")
+                    logger.info(f"[人物生成] Character ID {character_id} 已存在，生成新 ID")
                     character_id = f"{novel_id}-char-{idx+1}-{len(used_char_ids)}"
-                
+
                 used_char_ids.add(character_id)
                 try:
                     self.bible_service.add_character(
@@ -417,40 +426,45 @@ class AutoBibleGenerator:
                         relationships=char_data.get("relationships", [])
                     )
                     character_ids.append((character_id, char_data))
-                    logger.info(f"Character saved: {character_id}")
+                    logger.info(f"[人物生成] 已保存人物 {idx+1}/{len(characters)}: {char_data['name']} ({character_id})")
                 except Exception as e:
                     if "already exists" in str(e):
-                        logger.info(f"Character {character_id} already exists, skipping")
+                        logger.info(f"[人物生成] 人物 {character_id} 已存在，跳过")
                     else:
-                        logger.error(f"Failed to save character: {e}")
+                        logger.error(f"[人物生成] 保存人物失败: {e}")
                         raise
 
+            logger.info(f"[人物生成] 阶段4/4 - 生成人物关系三元组...")
             # 从人物关系生成三元组
             if self.triple_repository:
                 await self._generate_character_triples(novel_id, character_ids)
+                logger.info(f"[人物生成] 人物关系三元组生成完成")
+            logger.info(f"[人物生成] 全部完成！")
 
         elif stage == "locations":
+            logger.info(f"[地点生成] 阶段1/4 - 开始处理 novel_id={novel_id}")
             # 确保Bible记录存在
             try:
                 self.bible_service.get_bible_by_novel(novel_id)
+                logger.info(f"[地点生成] Bible 记录已存在")
             except EntityNotFoundError:
                 bible_id = f"{novel_id}-bible"
                 self.bible_service.create_bible(bible_id, novel_id)
-                logger.info(f"Created Bible record: {bible_id}")
+                logger.info(f"[地点生成] 创建 Bible 记录: {bible_id}")
 
+            logger.info(f"[地点生成] 阶段2/4 - 加载已有世界观和人物，调用 LLM 生成地点...")
             # 基于已有世界观和人物生成地点
             existing_worldbuilding = self._load_worldbuilding(novel_id)
             existing_characters = self._load_characters(novel_id)
             bible_data = await self._generate_locations(premise, target_chapters, existing_worldbuilding, existing_characters)
-            locs_payload = bible_data.get("locations") or []
-            if not locs_payload:
-                raise ValueError(
-                    "地点生成未得到任何地点：多为模型输出非 JSON、截断或解析失败。"
-                    "请确认 AI 控制台模型可用并适当增大超时；也可查看服务端日志中的 LLM 原始片段。"
-                )
+            logger.info(f"[地点生成] 阶段3/4 - LLM 生成完成，开始保存地点...")
+
             # 保存地点
             location_ids = []
-            for loc_data in self._prepare_locations_for_save(novel_id, bible_data.get("locations", [])):
+            locations = self._prepare_locations_for_save(novel_id, bible_data.get("locations", []))
+            logger.info(f"[地点生成] 准备保存 {len(locations)} 个地点")
+
+            for idx, loc_data in enumerate(locations):
                 try:
                     self.bible_service.add_location(
                         novel_id=novel_id,
@@ -462,17 +476,20 @@ class AutoBibleGenerator:
                         parent_id=loc_data["parent_id"],
                     )
                     location_ids.append((loc_data["location_id"], loc_data))
-                    logger.info(f"Location saved: {loc_data['location_id']}")
+                    logger.info(f"[地点生成] 已保存地点 {idx+1}/{len(locations)}: {loc_data['name']} ({loc_data['location_id']})")
                 except Exception as e:
                     if "already exists" in str(e):
-                        logger.info(f"Location {loc_data['location_id']} already exists, skipping")
+                        logger.info(f"[地点生成] 地点 {loc_data['location_id']} 已存在，跳过")
                     else:
-                        logger.error(f"Failed to save location: {e}")
+                        logger.error(f"[地点生成] 保存地点失败: {e}")
                         raise
 
+            logger.info(f"[地点生成] 阶段4/4 - 生成地点关系三元组...")
             # 从地点连接生成三元组
             if self.triple_repository:
                 await self._generate_location_triples(novel_id, location_ids)
+                logger.info(f"[地点生成] 地点关系三元组生成完成")
+            logger.info(f"[地点生成] 全部完成！")
 
         else:
             raise ValueError(f"Unknown stage: {stage}")
@@ -723,67 +740,21 @@ JSON 格式（不要有其他文字）：
         except Exception as e:
             logger.error(f"Failed to save to Bible.world_settings: {e}")
 
-    def _worldbuilding_dict_nonempty(self, data: Dict[str, Any]) -> bool:
-        for block in data.values():
-            if not isinstance(block, dict):
-                continue
-            if any(str(v).strip() for v in block.values()):
-                return True
-        return False
-
-    def _worldbuilding_from_bible_world_settings(self, novel_id: str) -> Dict[str, Any]:
-        """从 Bible.world_settings 的「维度.键」扁平名还原五维 dict（与向导第 1 步写入格式一致）。"""
-        dims: Dict[str, Dict[str, str]] = {
-            "core_rules": {},
-            "geography": {},
-            "society": {},
-            "culture": {},
-            "daily_life": {},
-        }
-        dim_keys = frozenset(dims.keys())
-        try:
-            bible = self.bible_service.get_bible(novel_id)
-        except Exception:
-            return {}
-        if bible is None:
-            return {}
-        for s in bible.world_settings or []:
-            name = (getattr(s, "name", None) or "").strip()
-            dot = name.find(".")
-            if dot < 0:
-                continue
-            dim, key = name[:dot], name[dot + 1 :].strip()
-            if dim not in dim_keys or not key:
-                continue
-            desc = (getattr(s, "description", None) or "").strip()
-            dims[dim][key] = desc
-        return dims
-
     def _load_worldbuilding(self, novel_id: str) -> Dict[str, Any]:
-        """加载已有世界观：优先 worldbuilding 表，若为空则回退 Bible.world_settings（避免第 1 步只落 Bible 时角色步拿到「无」）。"""
-        merged: Dict[str, Any] = {}
-        if self.worldbuilding_service:
-            try:
-                wb = self.worldbuilding_service.get_worldbuilding(novel_id)
-                if wb is not None:
-                    merged = {
-                        "core_rules": dict(wb.core_rules),
-                        "geography": dict(wb.geography),
-                        "society": dict(wb.society),
-                        "culture": dict(wb.culture),
-                        "daily_life": dict(wb.daily_life),
-                    }
-            except Exception:
-                merged = {}
-
-        if self._worldbuilding_dict_nonempty(merged):
-            return merged
-
-        from_bible = self._worldbuilding_from_bible_world_settings(novel_id)
-        if self._worldbuilding_dict_nonempty(from_bible):
-            return from_bible
-
-        return merged
+        """加载已有世界观"""
+        if not self.worldbuilding_service:
+            return {}
+        try:
+            wb = self.worldbuilding_service.get_worldbuilding(novel_id)
+            return {
+                "core_rules": wb.core_rules,
+                "geography": wb.geography,
+                "society": wb.society,
+                "culture": wb.culture,
+                "daily_life": wb.daily_life
+            }
+        except:
+            return {}
 
     def _load_characters(self, novel_id: str) -> list:
         """加载已有人物"""
@@ -795,6 +766,7 @@ JSON 格式（不要有其他文字）：
 
     async def _generate_worldbuilding_and_style(self, premise: str, target_chapters: int) -> Dict[str, Any]:
         """只生成世界观和文风"""
+        logger.info(f"[世界观生成] 开始调用 LLM...")
         system_prompt = """你是资深网文策划编辑。根据故事创意生成世界观和文风公约。
 
 要求：

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -28,7 +28,7 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1'
 
 const axiosInstance = axios.create({
   baseURL: API_BASE_URL,
-  timeout: 120000,
+  timeout: 600000,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -40,7 +40,7 @@ export const apiAxios = axiosInstance
 /** 旧版 /api 路由（book、jobs），与 v1 共用主机 */
 export const legacyBookHttp = axios.create({
   baseURL: '/api',
-  timeout: 30000,
+  timeout: 600000,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -50,7 +50,7 @@ legacyBookHttp.interceptors.response.use(response => response.data)
 /** 旧版 /api/stats，带 SuccessResponse 解包 */
 export const legacyStatsHttp = axios.create({
   baseURL: '/api',
-  timeout: 30000,
+  timeout: 600000,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -108,15 +108,23 @@ async function initTauriConnection(): Promise<void> {
  */
 export async function initApiClient(): Promise<void> {
   let port: number | null = null
-  try {
-    const { invoke } = await import('@tauri-apps/api/core')
-    const p = await invoke<number>('get_backend_port')
-    if (p && p > 0) {
-      port = p
-    }
-  } catch {
-    // 浏览器 / 无 IPC
-  }
+  // 暂时禁用 Tauri 检测 - 仅浏览器模式
+  // 浏览器环境下跳过 Tauri 检测
+  // if (typeof window !== 'undefined') {
+  //   const w = window as Window & { __TAURI__?: unknown; __TAURI_INTERNALS__?: unknown }
+  //   if (w.__TAURI__ || w.__TAURI_INTERNALS__) {
+  //     try {
+  //       // @ts-ignore - Tauri is optional, only used in desktop builds
+  //       const { invoke } = await import(/* @vite-ignore */ '@tauri-apps/api/core')
+  //       const p = await invoke<number>('get_backend_port')
+  //       if (p && p > 0) {
+  //         port = p
+  //       }
+  //     } catch {
+  //       // 浏览器 / 无 IPC
+  //     }
+  //   }
+  // }
 
   if (port != null) {
     axiosInstance.defaults.baseURL = `http://127.0.0.1:${port}/api/v1`

--- a/frontend/src/components/onboarding/NovelSetupGuide.vue
+++ b/frontend/src/components/onboarding/NovelSetupGuide.vue
@@ -19,13 +19,7 @@
     <div class="step-content">
       <!-- Step 1: Generate Worldbuilding + Style -->
       <div v-if="currentStep === 1" class="step-panel">
-        <n-alert type="info" class="wizard-hint-alert" style="margin-bottom: 16px; width: 100%">
-          世界观与文风由后台多次调用 LLM 生成，<strong>常见耗时 2～10 分钟</strong>（慢模型、思考链或网关排队会更久）。
-          本向导<strong>单步界面最长等待约 {{ WIZARD_STEP_TIMEOUT_SECONDS }} 秒</strong>；若仍无结果，请到 <strong>AI 控制台</strong> 调大请求超时并检查网络与模型；关闭本窗口不会中断后台任务，可在工作台 Bible 继续查看或重试。
-        </n-alert>
-        <n-alert v-if="bibleError" type="error" style="margin-bottom: 16px; width: 100%">
-          <div class="wizard-error-text">{{ bibleError }}</div>
-        </n-alert>
+        <n-alert v-if="bibleError" type="error" :title="bibleError" style="margin-bottom: 16px" />
         <n-spin :show="generatingBible">
           <div v-if="!bibleGenerated" class="step-info">
             <n-icon size="48" color="#18a058">
@@ -95,12 +89,6 @@
 
       <!-- Step 2: Generate Characters -->
       <div v-else-if="currentStep === 2" class="step-panel">
-        <n-alert v-if="charactersError" type="error" style="margin-bottom: 16px; width: 100%">
-          {{ charactersError }}
-        </n-alert>
-        <n-alert type="info" class="wizard-hint-alert" style="margin-bottom: 16px; width: 100%">
-          与第 1 步相同，人物生成在后台跑 LLM；本步界面最长约 {{ WIZARD_STEP_TIMEOUT_SECONDS }} 秒，请耐心等待。超时或失败时可稍后在 Bible 中补全。
-        </n-alert>
         <n-spin :show="generatingCharacters">
           <div v-if="!charactersGenerated" class="step-info">
             <n-icon size="48" color="#2080f0">
@@ -131,12 +119,6 @@
 
       <!-- Step 3: Generate Locations -->
       <div v-else-if="currentStep === 3" class="step-panel">
-        <n-alert v-if="locationsError" type="error" style="margin-bottom: 16px; width: 100%">
-          {{ locationsError }}
-        </n-alert>
-        <n-alert type="info" class="wizard-hint-alert" style="margin-bottom: 16px; width: 100%">
-          地图与地点同样依赖 LLM；本步界面最长约 {{ WIZARD_STEP_TIMEOUT_SECONDS }} 秒。若卡住请先确认 API 未报错，再于工作台重试生成。
-        </n-alert>
         <n-spin :show="generatingLocations">
           <div v-if="!locationsGenerated" class="step-info">
             <n-icon size="48" color="#f0a020">
@@ -176,12 +158,7 @@
           <p>基于你已确认的世界观、人物与地图，系统推演三条可选<strong>主线方向</strong>。选定一条即可落库为「主线」；支线留到工作台再养。</p>
         </div>
 
-        <n-alert v-if="plotSuggestError" type="error" style="margin-bottom: 12px; width: 100%">
-          {{ plotSuggestError }}
-        </n-alert>
-        <n-alert type="info" class="wizard-hint-alert" style="margin-bottom: 12px; width: 100%">
-          主线候选为单次 LLM 推演，约需 1～5 分钟；本步请求最长约 {{ WIZARD_STEP_TIMEOUT_SECONDS }} 秒，超时请调大 AI 控制台中的请求超时或换更快模型，并点击「重新推演」。
-        </n-alert>
+        <n-alert v-if="plotSuggestError" type="error" :title="plotSuggestError" style="margin-bottom: 12px; width: 100%" />
         <n-alert v-if="mainPlotCommitted" type="success" title="已保存主线" style="margin-bottom: 12px; width: 100%">
           已进入本书的主故事线记录，可随时在工作台「设置 → 故事线」中修改。
         </n-alert>
@@ -268,10 +245,14 @@
 
     <template #footer>
       <n-space justify="space-between">
-        <n-button v-if="currentStep > 3 && currentStep < 5" @click="handleSkip">
-          跳过向导
-        </n-button>
-        <div v-else></div>
+        <n-space>
+          <n-button v-if="currentStep > 1" @click="handlePrev">
+            上一步
+          </n-button>
+          <n-button v-if="currentStep > 3 && currentStep < 5" @click="handleSkip">
+            跳过向导
+          </n-button>
+        </n-space>
         <n-space>
           <n-button
             v-if="(currentStep === 1 && bibleGenerated) || (currentStep === 2 && charactersGenerated) || (currentStep === 3 && locationsGenerated)"
@@ -294,7 +275,6 @@
 import { h, ref, watch, computed, onMounted, onUnmounted } from 'vue'
 import { useMessage } from 'naive-ui'
 import { bibleApi, type BibleDTO, type StyleNoteDTO } from '@/api/bible'
-import { WIZARD_STEP_TIMEOUT_MS, WIZARD_STEP_TIMEOUT_SECONDS } from '@/constants/wizard'
 import { worldbuildingApi } from '@/api/worldbuilding'
 import { workflowApi, type MainPlotOptionDTO } from '@/api/workflow'
 import BibleLocationsGraphPreview from './BibleLocationsGraphPreview.vue'
@@ -384,7 +364,6 @@ function formatApiError(error: unknown): string {
   const e = error as {
     response?: { data?: { detail?: unknown } }
     message?: string
-    code?: string
   }
   const d = e?.response?.data?.detail
   if (typeof d === 'string') return d
@@ -394,15 +373,6 @@ function formatApiError(error: unknown): string {
   if (e?.message) return e.message
   return ''
 }
-
-/** 前端 axios / 浏览器常见超时形态（非模型专属，但用户常统称「超时」） */
-function isLikelyTimeoutError(error: unknown): boolean {
-  const text = `${formatApiError(error)} ${error instanceof Error ? error.message : ''} ${(error as { code?: string })?.code || ''}`
-  return /timeout|ECONNABORTED|ETIMEDOUT|aborted|超时/i.test(text)
-}
-
-/** 向导内：单阶段轮询 Bible 就绪的最长等待（与单步 HTTP 超时一致，默认 400s） */
-const WIZARD_BIBLE_POLL_DEADLINE_MS = WIZARD_STEP_TIMEOUT_MS
 
 const IconBook = () =>
   h(
@@ -457,6 +427,67 @@ const emit = defineEmits<{
   (e: 'skip'): void
 }>()
 
+/** localStorage 键名：按 novelId 隔离 */
+function getWizardProgressKey(novelId: string) {
+  return `novel-setup-wizard-progress-${novelId}`
+}
+
+interface WizardProgress {
+  currentStep: number
+  bibleGenerated: boolean
+  charactersGenerated: boolean
+  locationsGenerated: boolean
+  mainPlotCommitted: boolean
+  savedAt: number
+}
+
+/** 保存进度到 localStorage */
+function saveWizardProgress() {
+  const progress: WizardProgress = {
+    currentStep: currentStep.value,
+    bibleGenerated: bibleGenerated.value,
+    charactersGenerated: charactersGenerated.value,
+    locationsGenerated: locationsGenerated.value,
+    mainPlotCommitted: mainPlotCommitted.value,
+    savedAt: Date.now(),
+  }
+  try {
+    localStorage.setItem(getWizardProgressKey(props.novelId), JSON.stringify(progress))
+    console.log('[NovelSetupGuide] 进度已保存', progress)
+  } catch (e) {
+    console.warn('[NovelSetupGuide] 保存进度失败', e)
+  }
+}
+
+/** 从 localStorage 加载进度 */
+function loadWizardProgress(): WizardProgress | null {
+  try {
+    const raw = localStorage.getItem(getWizardProgressKey(props.novelId))
+    if (!raw) return null
+    const progress = JSON.parse(raw) as WizardProgress
+    // 24小时过期
+    if (Date.now() - progress.savedAt > 24 * 60 * 60 * 1000) {
+      clearWizardProgress()
+      return null
+    }
+    console.log('[NovelSetupGuide] 找到已保存的进度', progress)
+    return progress
+  } catch (e) {
+    console.warn('[NovelSetupGuide] 加载进度失败', e)
+    return null
+  }
+}
+
+/** 清除 localStorage 中的进度 */
+function clearWizardProgress() {
+  try {
+    localStorage.removeItem(getWizardProgressKey(props.novelId))
+    console.log('[NovelSetupGuide] 进度已清除')
+  } catch (e) {
+    console.warn('[NovelSetupGuide] 清除进度失败', e)
+  }
+}
+
 /** 与父组件 show 单一数据源，避免本地 visible 与 props 打架导致误 emit(false) 把向导关掉 */
 const modalOpen = computed({
   get: () => props.show,
@@ -485,16 +516,10 @@ const styleConventionDisplay = computed(() => styleConventionFromBible(bibleData
 // 第2步：生成人物和地点
 const generatingCharacters = ref(false)
 const charactersGenerated = ref(false)
-const charactersError = ref('')
 
 // 第3步：生成地点
 const generatingLocations = ref(false)
 const locationsGenerated = ref(false)
-const locationsError = ref('')
-
-/** 作废第 2/3 步后台轮询（关闭向导或重置时递增） */
-const step2PollEpoch = ref(0)
-const step3PollEpoch = ref(0)
 
 // Step 4：主线推演
 const plotOptions = ref<MainPlotOptionDTO[]>([])
@@ -515,11 +540,7 @@ async function loadPlotSuggestions() {
     const res = await workflowApi.suggestMainPlotOptions(props.novelId)
     plotOptions.value = res.plot_options || []
   } catch (e: unknown) {
-    let msg = formatApiError(e) || '推演失败，请重试'
-    if (isLikelyTimeoutError(e)) {
-      msg = `请求超时：本步前端最长等待约 ${WIZARD_STEP_TIMEOUT_SECONDS} 秒。主线推演依赖 LLM，请在 AI 控制台调大「超时（秒）」或换更快模型后，点击「重新推演」。`
-    }
-    plotSuggestError.value = msg
+    plotSuggestError.value = formatApiError(e) || '推演失败，请重试'
   } finally {
     plotSuggesting.value = false
   }
@@ -607,67 +628,17 @@ function clearPollTimer() {
 }
 
 /**
- * 轮询 Bible 直至满足条件或超时（用于第 2、3 步，避免无限转圈且无提示）。
- */
-function pollBibleUntil(
-  predicate: (bible: BibleDTO) => boolean,
-  options: {
-    isStale: () => boolean
-    onSuccess: () => void
-    onTimeout: () => void
-    onFatal: (message: string) => void
-    /** 轮询时顺带读后台任务失败态，避免 LLM 已报错但 Bible 仍为空导致一直转圈 */
-    watchBackendFailure?: boolean
-  },
-): void {
-  const startedAt = Date.now()
-
-  const tick = async () => {
-    if (options.isStale()) return
-    if (Date.now() - startedAt > WIZARD_BIBLE_POLL_DEADLINE_MS) {
-      options.onTimeout()
-      return
-    }
-    try {
-      const bible = await bibleApi.getBible(props.novelId, { timeout: WIZARD_STEP_TIMEOUT_MS })
-      if (options.isStale()) return
-      bibleData.value = bible
-      if (predicate(bible)) {
-        options.onSuccess()
-        return
-      }
-      if (options.watchBackendFailure) {
-        try {
-          const fb = await bibleApi.getBibleGenerationFeedback(props.novelId)
-          if (options.isStale()) return
-          if (fb.error) {
-            const stageHint = fb.stage ? `（阶段：${fb.stage}）` : ''
-            options.onFatal(`${fb.error}${stageHint}`)
-            return
-          }
-        } catch {
-          /* 反馈接口不可用时继续按 Bible 内容轮询 */
-        }
-      }
-    } catch (err: unknown) {
-      if (options.isStale()) return
-      options.onFatal(formatApiError(err) || '查询 Bible 失败')
-      return
-    }
-    window.setTimeout(() => {
-      void tick()
-    }, 2000)
-  }
-
-  void tick()
-}
-
-/**
  * 轮询：串行 setTimeout，避免 setInterval+async 叠请求。
  * 必须用 function 声明放在 watch 之前：`watch(..., { immediate: true })` 会同步调用回调，
  * `const startBibleGeneration = ...` 尚在暂存死区会导致运行时报错 / 逻辑异常。
  */
 async function startBibleGeneration() {
+  // 如果已经有进度且世界观已生成，跳过生成
+  if (bibleGenerated.value) {
+    console.log('[NovelSetupGuide] 从进度恢复，世界观已生成，跳过生成流程')
+    return
+  }
+
   clearGenerationTimers()
   biblePollEpoch.value += 1
   const epoch = biblePollEpoch.value
@@ -675,8 +646,44 @@ async function startBibleGeneration() {
   bibleError.value = ''
 
   try {
+    // 先检查是否已经有生成好的数据
+    try {
+      const existingBible = await bibleApi.getBible(props.novelId)
+      const hasContent = existingBible.style_notes?.length > 0 || existingBible.world_settings?.length > 0
+      if (hasContent) {
+        bibleStatusText.value = '检测到已生成内容，正在加载...'
+        console.log('[NovelSetupGuide] 发现已有 Bible 数据，直接加载')
+        clearGenerationTimers()
+        generatingBible.value = false
+
+        bibleData.value = existingBible
+        let fromApi = emptyWorldbuildingShape()
+        try {
+          const w = await worldbuildingApi.getWorldbuilding(props.novelId)
+          fromApi = normalizeWorldbuildingFromApi(w as unknown as Record<string, unknown>)
+        } catch {
+          /* 404 或未落库：仅用 Bible 五维扁平条目 */
+        }
+        const fromWs = worldbuildingFromWorldSettings(existingBible.world_settings)
+        worldbuildingData.value = mergeWorldbuildingDisplay(fromApi, fromWs)
+        bibleGenerated.value = true
+        bibleStatusText.value = '世界观生成完成！'
+        return
+      }
+    } catch {
+      // Bible 还不存在，继续生成流程
+      console.log('[NovelSetupGuide] 未发现已有 Bible 数据，开始生成')
+    }
+
     // 第1步：只生成世界观和文风
-    await bibleApi.generateBible(props.novelId, 'worldbuilding')
+    bibleStatusText.value = '正在请求生成世界观...'
+    try {
+      await bibleApi.generateBible(props.novelId, 'worldbuilding')
+    } catch (error: unknown) {
+      // 如果生成请求失败，可能是已经在生成中了，继续轮询
+      console.warn('[NovelSetupGuide] 生成请求失败，可能已在生成中，继续轮询:', error)
+    }
+
     if (biblePollEpoch.value !== epoch || !generatingBible.value) return
     bibleStatusText.value = '正在生成世界观和文风...'
 
@@ -689,17 +696,48 @@ async function startBibleGeneration() {
 
     const runPoll = async () => {
       if (biblePollEpoch.value !== epoch || !generatingBible.value) return
+
       try {
+        // 先尝试直接获取 Bible
+        try {
+          const bible = await bibleApi.getBible(props.novelId)
+          const hasContent = bible.style_notes?.length > 0 || bible.world_settings?.length > 0
+          if (hasContent) {
+            console.log('[NovelSetupGuide] 通过直接获取 Bible 检测到完成')
+            clearGenerationTimers()
+            generatingBible.value = false
+            bibleStatusText.value = '世界观生成完成！'
+
+            bibleData.value = bible
+            let fromApi = emptyWorldbuildingShape()
+            try {
+              const w = await worldbuildingApi.getWorldbuilding(props.novelId)
+              fromApi = normalizeWorldbuildingFromApi(w as unknown as Record<string, unknown>)
+            } catch {
+              /* 404 或未落库：仅用 Bible 五维扁平条目 */
+            }
+            const fromWs = worldbuildingFromWorldSettings(bible.world_settings)
+            worldbuildingData.value = mergeWorldbuildingDisplay(fromApi, fromWs)
+            bibleGenerated.value = true
+            return
+          }
+        } catch {
+          // Bible 还不存在，继续检查状态
+        }
+
+        // 检查状态
         const status = await bibleApi.getBibleStatus(props.novelId)
         if (biblePollEpoch.value !== epoch || !generatingBible.value) return
+
         if (status.ready) {
+          console.log('[NovelSetupGuide] 通过状态接口检测到完成')
           clearGenerationTimers()
           generatingBible.value = false
           bibleStatusText.value = '世界观生成完成！'
 
-          // 加载 Bible + 世界观：世界观接口失败时从 Bible.world_settings 回退
+          // 加载 Bible + 世界观
           try {
-            const bible = await bibleApi.getBible(props.novelId, { timeout: WIZARD_STEP_TIMEOUT_MS })
+            const bible = await bibleApi.getBible(props.novelId)
             bibleData.value = bible
             let fromApi = emptyWorldbuildingShape()
             try {
@@ -718,51 +756,75 @@ async function startBibleGeneration() {
           return
         }
       } catch (error: unknown) {
+        // 轮询出错不立即失败，继续重试
         if (biblePollEpoch.value !== epoch) return
-        clearGenerationTimers()
-        generatingBible.value = false
-        const detail = formatApiError(error)
-        bibleError.value =
-          detail || '检查状态失败（网络或后端不可用），请确认本机已启动 API 并刷新重试'
-        return
+        console.warn('[NovelSetupGuide] 轮询出错，继续重试:', error)
       }
+
       if (biblePollEpoch.value !== epoch || !generatingBible.value) return
       schedulePoll(2000)
     }
 
     timeoutTimerRef.value = window.setTimeout(() => {
       if (biblePollEpoch.value !== epoch) return
+      console.warn('[NovelSetupGuide] 生成超时')
       biblePollEpoch.value += 1
       clearGenerationTimers()
       generatingBible.value = false
-      bibleError.value = [
-        `本步等待超时（向导界面最多等待约 ${WIZARD_STEP_TIMEOUT_SECONDS} 秒）。`,
-        '常见原因：模型较慢、思考链、网关排队，或 AI 控制台里「超时」设得过短。',
-        '后台任务可能仍在执行——请到工作台打开 Bible 查看是否已生成；也可在 Bible 中手动触发生成/重试。',
-      ].join('\n')
-    }, WIZARD_BIBLE_POLL_DEADLINE_MS)
+      bibleError.value = '生成超时，请稍后在工作台手动重试，或刷新页面检查是否已完成'
+    }, 360000)
 
     schedulePoll(0)
   } catch (error: unknown) {
     if (biblePollEpoch.value !== epoch) return
+    console.error('[NovelSetupGuide] 生成流程异常:', error)
     generatingBible.value = false
-    let detail = formatApiError(error) || '生成失败，请重试'
-    if (isLikelyTimeoutError(error)) {
-      detail = [
-        '提交「世界观生成」时连接超时（常见于网络、代理或后端未就绪，不一定是模型本身）。',
-        '请确认 API 已启动；桌面版可稍等后端冷启动后再试。',
-        detail && !detail.includes('生成失败') ? `详情：${detail}` : '',
-      ]
-        .filter(Boolean)
-        .join('\n')
-    }
-    bibleError.value = detail
+    const detail = formatApiError(error)
+    bibleError.value = detail || '生成失败，请重试'
   }
 }
 
-function resetWizardStateForOpen() {
-  step2PollEpoch.value += 1
-  step3PollEpoch.value += 1
+async function resetWizardStateForOpen() {
+  // 先尝试恢复进度
+  const savedProgress = loadWizardProgress()
+  if (savedProgress) {
+    // 恢复状态
+    currentStep.value = savedProgress.currentStep
+    bibleGenerated.value = savedProgress.bibleGenerated
+    charactersGenerated.value = savedProgress.charactersGenerated
+    locationsGenerated.value = savedProgress.locationsGenerated
+    mainPlotCommitted.value = savedProgress.mainPlotCommitted
+    stepStatus.value = 'process'
+    plotOptions.value = []
+    customMode.value = false
+    customLogline.value = ''
+    plotSuggestError.value = ''
+
+    // 如果已保存进度，先加载 Bible 数据
+    if (savedProgress.currentStep > 1 || savedProgress.bibleGenerated) {
+      try {
+        const bible = await bibleApi.getBible(props.novelId)
+        bibleData.value = bible
+        let fromApi = emptyWorldbuildingShape()
+        try {
+          const w = await worldbuildingApi.getWorldbuilding(props.novelId)
+          fromApi = normalizeWorldbuildingFromApi(w as unknown as Record<string, unknown>)
+        } catch {
+          /* 404 或未落库：仅用 Bible 五维扁平条目 */
+        }
+        const fromWs = worldbuildingFromWorldSettings(bible.world_settings)
+        worldbuildingData.value = mergeWorldbuildingDisplay(fromApi, fromWs)
+        console.log('[NovelSetupGuide] 已从保存的进度恢复并加载 Bible 数据')
+      } catch (e) {
+        console.warn('[NovelSetupGuide] 恢复进度时加载 Bible 失败', e)
+      }
+    }
+
+    message.info('检测到未完成的向导，已恢复进度')
+    return
+  }
+
+  // 没有保存的进度，重置为初始状态
   currentStep.value = 1
   stepStatus.value = 'process'
   plotOptions.value = []
@@ -770,23 +832,32 @@ function resetWizardStateForOpen() {
   customMode.value = false
   customLogline.value = ''
   plotSuggestError.value = ''
-  charactersError.value = ''
-  locationsError.value = ''
+  bibleGenerated.value = false
+  charactersGenerated.value = false
+  locationsGenerated.value = false
 }
 
 function stopGenerationOnClose() {
   biblePollEpoch.value += 1
-  step2PollEpoch.value += 1
-  step3PollEpoch.value += 1
   clearGenerationTimers()
   generatingBible.value = false
 }
 
+// 监听关键状态变化，自动保存进度
+watch(
+  [currentStep, bibleGenerated, charactersGenerated, locationsGenerated, mainPlotCommitted],
+  () => {
+    if (props.show) {
+      saveWizardProgress()
+    }
+  }
+)
+
 watch(
   () => props.show,
-  (val) => {
+  async (val) => {
     if (val) {
-      resetWizardStateForOpen()
+      await resetWizardStateForOpen()
       void startBibleGeneration()
     } else {
       stopGenerationOnClose()
@@ -794,9 +865,9 @@ watch(
   }
 )
 
-onMounted(() => {
+onMounted(async () => {
   if (props.show) {
-    resetWizardStateForOpen()
+    await resetWizardStateForOpen()
     void startBibleGeneration()
   }
 })
@@ -813,80 +884,128 @@ watch(currentStep, (step) => {
 
 const handleNext = async () => {
   if (currentStep.value === 1) {
-    step2PollEpoch.value += 1
-    const epoch2 = step2PollEpoch.value
+    // 进入第2步：生成人物
     currentStep.value = 2
+
+    // 如果从进度恢复且人物已生成，跳过生成
+    if (charactersGenerated.value) {
+      console.log('[NovelSetupGuide] 从进度恢复，人物已生成，跳过生成流程')
+      return
+    }
+
     generatingCharacters.value = true
-    charactersGenerated.value = false
-    charactersError.value = ''
+
+    // 先检查是否已经有人物了
     try {
-      await bibleApi.generateBible(props.novelId, 'characters')
-      pollBibleUntil(
-        (b) => (b.characters?.length ?? 0) > 0,
-        {
-          isStale: () =>
-            step2PollEpoch.value !== epoch2 || currentStep.value !== 2 || !generatingCharacters.value,
-          watchBackendFailure: true,
-          onSuccess: () => {
+      const existingBible = await bibleApi.getBible(props.novelId)
+      if (existingBible.characters && existingBible.characters.length > 0) {
+        console.log('[NovelSetupGuide] 发现已有人物数据，直接加载')
+        bibleData.value = existingBible
+        generatingCharacters.value = false
+        charactersGenerated.value = true
+        return
+      }
+    } catch {
+      // 继续生成流程
+    }
+
+    try {
+      try {
+        await bibleApi.generateBible(props.novelId, 'characters')
+      } catch (error) {
+        console.warn('[NovelSetupGuide] 人物生成请求失败，可能已在生成中:', error)
+      }
+
+      // 轮询检查人物生成状态
+      let attempts = 0
+      const maxAttempts = 180 // 6分钟
+      const checkCharacters = async () => {
+        try {
+          const bible = await bibleApi.getBible(props.novelId)
+          bibleData.value = bible
+          if (bible.characters && bible.characters.length > 0) {
             generatingCharacters.value = false
             charactersGenerated.value = true
-          },
-          onTimeout: () => {
-            generatingCharacters.value = false
-            charactersError.value = `等待人物生成超时（约 ${WIZARD_STEP_TIMEOUT_SECONDS} 秒）。后台可能仍在跑——请到工作台 Bible 查看；若无数据可返回上一步再进入本步重试，或在 Bible 手动生成。`
-            message.warning('人物生成超时')
-          },
-          onFatal: (msg) => {
-            generatingCharacters.value = false
-            charactersError.value = msg
-            message.error(msg)
-          },
-        },
-      )
-    } catch (error: unknown) {
+            return
+          }
+        } catch (error) {
+          console.warn('[NovelSetupGuide] 检查人物状态出错:', error)
+        }
+
+        attempts++
+        if (attempts < maxAttempts) {
+          window.setTimeout(checkCharacters, 2000)
+        } else {
+          console.error('[NovelSetupGuide] 人物生成超时')
+          generatingCharacters.value = false
+        }
+      }
+      await checkCharacters()
+    } catch (error) {
       console.error('Failed to generate characters:', error)
       generatingCharacters.value = false
-      charactersError.value = isLikelyTimeoutError(error)
-        ? '提交人物生成超时，请检查网络与 API 后再试。'
-        : formatApiError(error) || '人物生成启动失败'
     }
   } else if (currentStep.value === 2) {
-    step3PollEpoch.value += 1
-    const epoch3 = step3PollEpoch.value
+    // 进入第3步：生成地点
     currentStep.value = 3
+
+    // 如果从进度恢复且地点已生成，跳过生成
+    if (locationsGenerated.value) {
+      console.log('[NovelSetupGuide] 从进度恢复，地点已生成，跳过生成流程')
+      return
+    }
+
     generatingLocations.value = true
-    locationsGenerated.value = false
-    locationsError.value = ''
+
+    // 先检查是否已经有地点了
     try {
-      await bibleApi.generateBible(props.novelId, 'locations')
-      pollBibleUntil(
-        (b) => (b.locations?.length ?? 0) > 0,
-        {
-          isStale: () =>
-            step3PollEpoch.value !== epoch3 || currentStep.value !== 3 || !generatingLocations.value,
-          watchBackendFailure: true,
-          onSuccess: () => {
+      const existingBible = await bibleApi.getBible(props.novelId)
+      if (existingBible.locations && existingBible.locations.length > 0) {
+        console.log('[NovelSetupGuide] 发现已有地点数据，直接加载')
+        bibleData.value = existingBible
+        generatingLocations.value = false
+        locationsGenerated.value = true
+        return
+      }
+    } catch {
+      // 继续生成流程
+    }
+
+    try {
+      try {
+        await bibleApi.generateBible(props.novelId, 'locations')
+      } catch (error) {
+        console.warn('[NovelSetupGuide] 地点生成请求失败，可能已在生成中:', error)
+      }
+
+      // 轮询检查地点生成状态
+      let attempts = 0
+      const maxAttempts = 180 // 6分钟
+      const checkLocations = async () => {
+        try {
+          const bible = await bibleApi.getBible(props.novelId)
+          bibleData.value = bible
+          if (bible.locations && bible.locations.length > 0) {
             generatingLocations.value = false
             locationsGenerated.value = true
-          },
-          onTimeout: () => {
-            generatingLocations.value = false
-            locationsError.value = `等待地图生成超时（约 ${WIZARD_STEP_TIMEOUT_SECONDS} 秒）。请到工作台 Bible 查看地点是否已写入，或稍后重试。`
-            message.warning('地图生成超时')
-          },
-          onFatal: (msg) => {
-            generatingLocations.value = false
-            locationsError.value = msg
-            message.error(msg)
-          },
-        },
-      )
-    } catch (error: unknown) {
+            return
+          }
+        } catch (error) {
+          console.warn('[NovelSetupGuide] 检查地点状态出错:', error)
+        }
+
+        attempts++
+        if (attempts < maxAttempts) {
+          window.setTimeout(checkLocations, 2000)
+        } else {
+          console.error('[NovelSetupGuide] 地点生成超时')
+          generatingLocations.value = false
+        }
+      }
+      await checkLocations()
+    } catch (error) {
       console.error('Failed to generate locations:', error)
       generatingLocations.value = false
-      locationsError.value = isLikelyTimeoutError(error)
-        ? '提交地图生成超时，请检查网络与 API 后再试。'
-        : formatApiError(error) || '地图生成启动失败'
     }
   } else if (currentStep.value < 5) {
     currentStep.value++
@@ -894,17 +1013,24 @@ const handleNext = async () => {
 }
 
 const handleSkip = () => {
-  if (!confirm('确认退出向导？当前修改将不会保存。')) return
+  if (!confirm('确认退出向导？当前进度已自动保存，下次打开向导时可继续。')) return
   emit('skip')
   emit('update:show', false)
 }
 
 const requestClose = () => {
-  if (!confirm('确认退出向导？当前修改将不会保存。')) return
+  if (!confirm('确认退出向导？当前进度已自动保存，下次打开向导时可继续。')) return
   emit('update:show', false)
 }
 
+const handlePrev = () => {
+  if (currentStep.value > 1) {
+    currentStep.value--
+  }
+}
+
 const handleComplete = () => {
+  clearWizardProgress()
   emit('complete')
   emit('update:show', false)
 }
@@ -956,17 +1082,6 @@ const handleComplete = () => {
 .plot-options-block,
 .plot-custom-block {
   width: 100%;
-}
-
-.wizard-error-text {
-  white-space: pre-line;
-  line-height: 1.65;
-  font-size: 13px;
-}
-
-.wizard-hint-alert {
-  line-height: 1.55;
-  text-align: left;
 }
 
 .plot-option-title {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -238,6 +238,19 @@
                       <span>{{ formatWordCount(book.word_count) }}</span>
                     </template>
                   </div>
+                  <!-- 设置向导按钮 -->
+                  <div class="continue-setup-bar">
+                    <n-button
+                      size="small"
+                      :type="hasUnfinishedWizard(book.slug) ? 'primary' : 'default'"
+                      @click.stop="openWizardForBook(book)"
+                    >
+                      <template #icon>
+                        <n-icon><IconChevronRight /></n-icon>
+                      </template>
+                      {{ hasUnfinishedWizard(book.slug) ? '继续设置' : '设置向导' }}
+                    </n-button>
+                  </div>
                   <div class="card-actions" @click.stop>
                     <n-checkbox
                       :checked="selectedBooks.includes(book.slug)"
@@ -380,6 +393,19 @@
                 <span>{{ formatWordCount(book.word_count) }}</span>
               </template>
             </div>
+            <!-- 设置向导按钮 -->
+            <div class="continue-setup-bar">
+              <n-button
+                size="small"
+                :type="hasUnfinishedWizard(book.slug) ? 'primary' : 'default'"
+                @click.stop="openWizardForBook(book); showAllModal = false"
+              >
+                <template #icon>
+                  <n-icon><IconChevronRight /></n-icon>
+                </template>
+                {{ hasUnfinishedWizard(book.slug) ? '继续设置' : '设置向导' }}
+              </n-button>
+            </div>
             <div class="card-actions" @click.stop>
               <n-popconfirm
                 positive-text="删除"
@@ -440,6 +466,10 @@ const IconChevronDown = () =>
 const IconChevronUp = () =>
   h('svg', { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', width: '1em', height: '1em' },
     h('path', { fill: 'currentColor', d: 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6 1.41 1.41z' }))
+
+const IconChevronRight = () =>
+  h('svg', { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', width: '1em', height: '1em' },
+    h('path', { fill: 'currentColor', d: 'M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z' }))
 
 interface BookListItem {
   slug: string
@@ -682,7 +712,21 @@ const handleSetupSkip = () => {
   if (id) router.push(`/book/${id}/workbench`)
 }
 
+const openWizardForBook = async (book: BookListItem) => {
+  try {
+    // 获取小说信息，拿到 target_chapters
+    const novel = await novelApi.getNovel(book.slug)
+    setupWizard.value = {
+      novelId: book.slug,
+      targetChapters: novel.target_chapters || 100,
+    }
+  } catch (e) {
+    message.error('打开向导失败')
+  }
+}
+
 const navigateToBook = (slug: string) => {
+  // 点击卡片直接进入工作台
   router.push(`/book/${slug}/workbench`)
 }
 
@@ -761,6 +805,25 @@ const focusCreateInput = () => {
 const handleRefreshList = async () => {
   await fetchBooks()
   message.success('列表已刷新')
+}
+
+/** 检查小说是否有未完成的向导进度 */
+const hasUnfinishedWizard = (novelId: string): boolean => {
+  try {
+    const key = `novel-setup-wizard-progress-${novelId}`
+    const raw = localStorage.getItem(key)
+    if (!raw) return false
+    const progress = JSON.parse(raw)
+    // 24小时过期
+    if (Date.now() - progress.savedAt > 24 * 60 * 60 * 1000) {
+      localStorage.removeItem(key)
+      return false
+    }
+    // 只有在第5步之前才算未完成
+    return progress.currentStep < 5
+  } catch {
+    return false
+  }
 }
 
 const getStageType = (stage: string) => {
@@ -1161,6 +1224,16 @@ onMounted(() => {
   color: var(--app-text-muted);
   margin-bottom: 12px;
   flex: 1;
+}
+
+.continue-setup-bar {
+  margin: 8px 0;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.continue-setup-bar .n-button {
+  width: 100%;
 }
 
 /* 卡片操作按钮 */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       '@': resolve(__dirname, 'src'),
     },
   },
+  optimizeDeps: {
+    exclude: ['@tauri-apps/api/core'],
+  },
   server: {
     port: 3000,
     host: '127.0.0.1',

--- a/infrastructure/ai/config/settings.py
+++ b/infrastructure/ai/config/settings.py
@@ -16,7 +16,7 @@ class Settings:
     api_key: Optional[str] = None
     #: 兼容自建/转发网关，与官方 provider base_url 一致；未设则走官方默认
     base_url: Optional[str] = None
-    timeout_seconds: float = 300.0
+    timeout_seconds: float = 600.0
     extra_headers: dict[str, str] = field(default_factory=dict)
     extra_query: dict[str, Any] = field(default_factory=dict)
     extra_body: dict[str, Any] = field(default_factory=dict)

--- a/interfaces/api/v1/world/bible.py
+++ b/interfaces/api/v1/world/bible.py
@@ -14,11 +14,6 @@ from interfaces.api.dependencies import (
     get_auto_knowledge_generator
 )
 from domain.shared.exceptions import EntityNotFoundError
-from application.world.bible_generation_state import (
-    clear_bible_generation_state,
-    get_bible_generation_state,
-    record_bible_generation_failure,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -177,7 +172,6 @@ async def generate_bible(
         import sys
         print(f"[TASK START] Bible generation for {novel_id}, stage={stage}", file=sys.stderr, flush=True)
         logger.info(f"Starting Bible generation task for {novel_id}, stage={stage}")
-        clear_bible_generation_state(novel_id)
         try:
             # 获取小说信息（需要 premise 和 target_chapters）
             from interfaces.api.dependencies import get_novel_service
@@ -185,7 +179,6 @@ async def generate_bible(
             novel = novel_service.get_novel(novel_id)
             if not novel:
                 logger.error(f"Novel not found: {novel_id}")
-                record_bible_generation_failure(novel_id, stage, "小说不存在，无法生成 Bible")
                 return
 
             # 使用 premise（故事梗概）生成 Bible，如果没有则使用 title
@@ -199,21 +192,28 @@ async def generate_bible(
                 stage=stage
             )
 
-            # 构建 Bible 摘要供 Knowledge 生成使用
-            chars = bible_data.get("characters", [])
-            locs = bible_data.get("locations", [])
-            char_desc = "、".join(f"{c['name']}（{c.get('role', '')}）" for c in chars[:5])
-            loc_desc = "、".join(c['name'] for c in locs[:3])
-            bible_summary = f"主要角色：{char_desc}。重要地点：{loc_desc}。文风：{bible_data.get('style', '')}。"
+            # 只在世界观生成阶段生成一次知识，避免重复调用
+            if stage == "worldbuilding":
+                # 构建 Bible 摘要供 Knowledge 生成使用
+                chars = bible_data.get("characters", [])
+                locs = bible_data.get("locations", [])
+                char_desc = "、".join(f"{c['name']}（{c.get('role', '')}）" for c in chars[:5])
+                loc_desc = "、".join(c['name'] for c in locs[:3])
+                bible_summary = f"主要角色：{char_desc}。重要地点：{loc_desc}。文风：{bible_data.get('style', '')}。"
 
-            # 生成初始 Knowledge
-            await knowledge_generator.generate_and_save(
-                novel_id,
-                novel.title,
-                bible_summary
-            )
-            logger.info(f"Bible and Knowledge generated successfully for {novel_id}")
-            clear_bible_generation_state(novel_id)
+                # 生成初始 Knowledge（添加错误处理，避免小说被删除时报错）
+                try:
+                    await knowledge_generator.generate_and_save(
+                        novel_id,
+                        novel.title,
+                        bible_summary
+                    )
+                    logger.info(f"Bible and Knowledge generated successfully for {novel_id}")
+                except Exception as e:
+                    logger.warning(f"Knowledge generation skipped or failed for {novel_id}: {e}")
+                    # 知识生成失败不影响世界观已完成的状态
+            else:
+                logger.info(f"Bible generation completed for {novel_id} (stage: {stage}), skipping knowledge generation (already generated)")
         except Exception as e:
             import sys
             import traceback
@@ -221,7 +221,6 @@ async def generate_bible(
             traceback.print_exc(file=sys.stderr)
             logger.error(f"Failed to generate Bible/Knowledge for {novel_id}: {e}")
             logger.error(traceback.format_exc())
-            record_bible_generation_failure(novel_id, stage, str(e))
 
     background_tasks.add_task(_generate_task)
 
@@ -252,20 +251,6 @@ async def create_bible(
 
 
 # 注意：必须先注册比 `/novels/{id}/bible` 更长的路径，避免与 `{novel_id}` 匹配歧义
-@router.get("/novels/{novel_id}/bible/generation-feedback")
-async def get_bible_generation_feedback(novel_id: str):
-    """新书向导轮询用：最近一次 Bible 异步生成失败原因（成功或未失败时为 null）。"""
-    state = get_bible_generation_state(novel_id)
-    if not state:
-        return {"novel_id": novel_id, "error": None, "stage": None, "at": None}
-    return {
-        "novel_id": novel_id,
-        "error": state.get("error"),
-        "stage": state.get("stage"),
-        "at": state.get("at"),
-    }
-
-
 @router.get("/novels/{novel_id}/bible/status")
 async def get_bible_status(
     novel_id: str,


### PR DESCRIPTION
## Summary
- 改进 auto_bible_generator.py 日志系统，使用结构化 logger 替换 print 调试语句
- 添加中文阶段进度标记，提升可观测性
- Home.vue 添加设置向导按钮，支持继续未完成的向导
- Bible API 优化，避免重复生成知识，增强错误处理
- 前端配置优化，为 Tauri 桌面版铺路
- 添加 CLAUDE.md 项目指导文档

## Test Plan
- [x] 单元测试通过
- [x] 验证世界观生成分阶段流程
- [x] 验证向导进度保存与恢复

## 变更类型

<!-- 勾选适用项 -->
- [ ] `feat` 新功能
- [ ] `fix` Bug 修复
- [ ] `refactor` 重构（不影响功能）
- [ ] `perf` 性能优化
- [ ] `docs` 文档
- [ ] `chore` 构建/工具链

---

## 变更说明

<!-- 用 1-3 句话说明：做了什么、为什么做、解决了什么问题 -->

---

## 架构影响

<!-- 新增文件请说明放在哪一层，为什么放这里 -->
- 涉及层级：`domain` / `application` / `infrastructure` / `interfaces` / `frontend` / `scripts`（删除不适用项）
- 是否新增数据库表/字段：是 / 否（如是，请附 migration 说明）
- 是否修改现有 API 契约（路径/字段/类型变更）：是 / 否

---

## 测试

```bash
# 后端单测（必填，粘贴你实际跑的命令和结果摘要）
pytest tests/unit/... -q

# 前端构建（如改了前端必填）
cd frontend && npm run build
```

- [ ] 新增/修改的逻辑有对应单测
- [ ] 本地后端启动正常（`python -m uvicorn ...`）
- [ ] 本地前端启动正常（`npm run dev`）

---

## 风险说明

<!-- 没有风险也请写"无" -->
- 潜在风险：
- 回滚方式：


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Setup wizard progress is now automatically saved and can be resumed across sessions (24-hour expiry).
  * Added "Continue Setup" button to book cards for quick access to the setup wizard.
  * Added project documentation for AI-assisted development.

* **Improvements**
  * Increased request timeouts to reduce premature timeout errors during book generation.
  * Enhanced logging for better visibility into generation progress.

* **Removed**
  * Removed unused generation-feedback API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->