### PR TITLE
fix(autopilot): hoist rec_chapters_per_act out of `if not target_act` branch

### DIFF
--- a/application/engine/services/autopilot_daemon.py
+++ b/application/engine/services/autopilot_daemon.py
@@ -338,6 +338,16 @@ class AutopilotDaemon:
 
         target_act = next((n for n in act_nodes if n.number == target_act_number), None)
 
+        # 结构推荐参数：在动态幕生成与章节规划 fallback 两个分支都会用到，
+        # 必须在 `if not target_act:` 之外提前计算，否则 target_act 已存在时
+        # 后面 `chapter_budget = target_act.suggested_chapter_count or rec_chapters_per_act`
+        # 会触发 UnboundLocalError。
+        from application.blueprint.services.continuous_planning_service import calculate_structure_params
+        target_chapters = novel.target_chapters or 100
+        struct_params = calculate_structure_params(target_chapters)
+        rec_chapters_per_act = struct_params["chapters_per_act"]
+        rec_acts_per_volume = struct_params["acts_per_volume"]
+
         # 动态幕生成：超长篇可能只规划了部/卷框架，幕节点需要动态生成
         if not target_act:
             # 先尝试找到父卷节点
@@ -345,13 +355,6 @@ class AutopilotDaemon:
                 [n for n in all_nodes if n.node_type.value == "volume"],
                 key=lambda n: n.number
             )
-
-            # 使用结构计算引擎获取推荐参数（替代硬编码的 // 3）
-            from application.blueprint.services.continuous_planning_service import calculate_structure_params
-            target_chapters = novel.target_chapters or 100
-            struct_params = calculate_structure_params(target_chapters)
-            rec_chapters_per_act = struct_params["chapters_per_act"]
-            rec_acts_per_volume = struct_params["acts_per_volume"]
 
             # 智能父卷选择：优先让当前卷填满（达到 rec_acts_per_volume 幕），再跳下一卷
             parent_volume = self._find_parent_volume_for_new_act(

--- a/tests/unit/application/engine/test_autopilot_act_planning_unbound.py
+++ b/tests/unit/application/engine/test_autopilot_act_planning_unbound.py
@@ -1,0 +1,67 @@
+"""回归测试：_handle_act_planning 中 rec_chapters_per_act 的 UnboundLocalError。
+
+在 commit b1327cb (feat(continuous-planning): implement structure calculation engine)
+中，rec_chapters_per_act / rec_acts_per_volume 仅在 `if not target_act:` 分支内
+定义；当 target_act 已存在（正常流程）时，后续
+`chapter_budget = target_act.suggested_chapter_count or rec_chapters_per_act`
+会抛 UnboundLocalError，导致守护进程在幕规划阶段连续失败被熔断。
+
+本测试通过静态读取源码验证两个变量的定义出现在 `if not target_act:` 之外。
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+from application.engine.services.autopilot_daemon import AutopilotDaemon
+
+
+def _get_handle_act_planning_source() -> str:
+    """取 _handle_act_planning 方法的源码文本。"""
+    source = inspect.getsource(AutopilotDaemon._handle_act_planning)
+    return source
+
+
+def _parse_method_ast() -> ast.AsyncFunctionDef:
+    """解析 autopilot_daemon.py 整个模块，返回 _handle_act_planning 的 AST。
+
+    相比 inspect.getsource + dedent，直接读文件更稳（不受缩进困扰）。
+    """
+    from application.engine.services import autopilot_daemon
+    source_path = Path(autopilot_daemon.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    for cls in tree.body:
+        if isinstance(cls, ast.ClassDef) and cls.name == "AutopilotDaemon":
+            for item in cls.body:
+                if isinstance(item, ast.AsyncFunctionDef) and item.name == "_handle_act_planning":
+                    return item
+    raise AssertionError("AutopilotDaemon._handle_act_planning not found")
+
+
+def test_rec_chapters_per_act_defined_outside_if_branch() -> None:
+    """rec_chapters_per_act 必须在 `if not target_act:` 分支之外赋值，
+    否则当 target_act 已存在时访问该变量会抛 UnboundLocalError。
+    """
+    func_def = _parse_method_ast()
+
+    # 找出所有顶层（不在 if 语句内）的赋值，收集 target 名称
+    top_level_names: set[str] = set()
+    for node in func_def.body:
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    top_level_names.add(t.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            top_level_names.add(node.target.id)
+
+    # 这两个变量必须在函数体的顶层赋值，不能只在 if 分支里
+    assert "rec_chapters_per_act" in top_level_names, (
+        "rec_chapters_per_act 必须在 `if not target_act:` 之外赋值，"
+        "否则 target_act 已存在时会触发 UnboundLocalError。"
+    )
+    assert "rec_acts_per_volume" in top_level_names, (
+        "rec_acts_per_volume 必须在 `if not target_act:` 之外赋值。"
+    )


### PR DESCRIPTION
## 变更类型

- [x] \`fix\` Bug 修复

---

## 变更说明

回归自 [b1327cb](https://github.com/shenminglinyi/PlotPilot/commit/b1327cb) \`feat(continuous-planning)\`：

\`AutopilotDaemon._handle_act_planning\` 中 \`rec_chapters_per_act\` 和 \`rec_acts_per_volume\` **仅在 \`if not target_act:\` 分支内定义**，但后续在该 if 之外也有引用：

\`\`\`python
chapter_budget = target_act.suggested_chapter_count or rec_chapters_per_act
#                                                      ^^^^^^^^^^^^^^^^^^^^
\`\`\`

当 \`target_act\` 已存在（正常流程，跳过动态幕生成分支）时，此处会抛 \`UnboundLocalError: cannot access local variable 'rec_chapters_per_act' where it is not associated with a value\`，导致守护进程连续失败并触发熔断器打开，阻塞幕级规划阶段。

实际错误日志（可复现）：

\`\`\`
autopilot_daemon - ❌ [novel-XXX] 处理失败: cannot access local variable 'rec_chapters_per_act' where it is not associated with a value
  File "application/engine/services/autopilot_daemon.py", line 420, in _handle_act_planning
    chapter_budget = target_act.suggested_chapter_count or rec_chapters_per_act
UnboundLocalError: cannot access local variable 'rec_chapters_per_act' where it is not associated with a value
circuit_breaker - [CircuitBreaker] 连续失败 11 次 → OPEN，暂停 180s
\`\`\`

### 修复

将结构推荐参数（\`calculate_structure_params\` 结果）上移至 \`target_act\` 判断之前，确保两个分支都能访问。

---

## 架构影响

- 涉及层级：\`application\`
- 是否新增数据库表/字段：否
- 是否修改现有 API 契约：否

---

## 测试

新增回归测试 \`tests/unit/application/engine/test_autopilot_act_planning_unbound.py\`：通过 AST 静态验证 \`rec_chapters_per_act\` / \`rec_acts_per_volume\` 出现在 \`_handle_act_planning\` 函数体顶层而非 if 分支内。

反向验证：还原修复后测试失败，应用修复后测试通过。

\`\`\`bash
pytest tests/unit/application/engine/test_autopilot_act_planning_unbound.py -v
# ========================= 1 passed, 1 warning in 0.14s =========================
\`\`\`

- [x] 新增/修改的逻辑有对应单测
- [x] 本地后端启动正常
- [ ] 本地前端启动正常（本改动不涉及前端）

---

## 补充说明

- 如果觉得 AST 测试太"间接"，可以改成更端到端的 mock 测试（用 mock 构造 target_act 已存在的场景，断言方法不抛 UnboundLocalError）。我写 AST 版是因为 \`_handle_act_planning\` 涉及较多仓储 mock，AST 验证更轻量、更聚焦在"变量作用域"这个核心契约上。如作者倾向行为测试，我可以再补。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential runtime error in the autopilot daemon's act planning when handling structure recommendations.

* **Tests**
  * Added regression test to prevent recurrence of the planning error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->