### PR TITLE
fix(engine): 修复截断检测误判 + 新增章节修复功能

### DIFF
--- a/application/audit/dtos/chapter_repair_dto.py
+++ b/application/audit/dtos/chapter_repair_dto.py
@@ -1,0 +1,25 @@
+"""章节修复扫描结果 DTO"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ShortChapterDTO:
+    """短章节扫描结果项"""
+    chapter_number: int
+    title: str
+    word_count: int
+    status: str
+    content_preview: str  # 前 200 字
+    severity: str  # "critical"(<1000) / "warning"(<2500) / "info"(<threshold)
+
+
+@dataclass
+class ChapterRepairScanResult:
+    """短章节扫描结果"""
+    novel_id: str
+    threshold: int
+    total_chapters: int
+    short_chapters: list[ShortChapterDTO] = field(default_factory=list)
+    summary: dict[str, int] = field(default_factory=dict)  # {"critical": N, "warning": N, "info": N}

--- a/application/audit/services/chapter_repair_service.py
+++ b/application/audit/services/chapter_repair_service.py
@@ -1,0 +1,274 @@
+"""章节修复服务：扫描短章节 + AI 扩写 + 批量修复"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, AsyncIterator, Optional, TYPE_CHECKING
+
+from application.audit.dtos.chapter_repair_dto import ChapterRepairScanResult, ShortChapterDTO
+from application.core.services.chapter_service import ChapterService
+from application.ai.llm_output_sanitize import strip_reasoning_artifacts
+from domain.ai.services.llm_service import GenerationConfig, LLMService
+from domain.ai.value_objects.prompt import Prompt
+from domain.novel.repositories.chapter_repository import ChapterRepository
+from domain.novel.repositories.novel_repository import NovelRepository
+from domain.novel.value_objects.novel_id import NovelId
+
+if TYPE_CHECKING:
+    from application.engine.services.chapter_aftermath_pipeline import ChapterAftermathPipeline
+
+logger = logging.getLogger(__name__)
+
+# 严重程度阈值
+_CRITICAL_THRESHOLD = 1000
+_WARNING_THRESHOLD = 2500
+
+# 前后章节摘录长度
+_PREV_CHAPTER_TAIL_CHARS = 2000
+_NEXT_CHAPTER_HEAD_CHARS = 500
+
+
+class ChapterRepairService:
+    """章节修复服务"""
+
+    def __init__(
+        self,
+        chapter_repository: ChapterRepository,
+        novel_repository: NovelRepository,
+        llm_service: LLMService,
+        chapter_service: ChapterService,
+        aftermath_pipeline: Optional["ChapterAftermathPipeline"] = None,
+    ):
+        self._chapter_repo = chapter_repository
+        self._novel_repo = novel_repository
+        self._llm = llm_service
+        self._chapter_svc = chapter_service
+        self._aftermath = aftermath_pipeline
+
+    def scan_short_chapters(
+        self, novel_id: str, threshold: int = 4000
+    ) -> ChapterRepairScanResult:
+        """扫描字数不足的章节"""
+        chapters = self._chapter_repo.list_by_novel(NovelId(novel_id))
+        short_chapters: list[ShortChapterDTO] = []
+        summary = {"critical": 0, "warning": 0, "info": 0}
+
+        for ch in chapters:
+            wc = ch.word_count.value
+            if wc >= threshold:
+                continue
+
+            if wc < _CRITICAL_THRESHOLD:
+                severity = "critical"
+            elif wc < _WARNING_THRESHOLD:
+                severity = "warning"
+            else:
+                severity = "info"
+
+            summary[severity] += 1
+            content = ch.content or ""
+            short_chapters.append(ShortChapterDTO(
+                chapter_number=ch.number,
+                title=ch.title or f"第{ch.number}章",
+                word_count=wc,
+                status=ch.status.value if hasattr(ch.status, "value") else ch.status,
+                content_preview=content[:200],
+                severity=severity,
+            ))
+
+        return ChapterRepairScanResult(
+            novel_id=novel_id,
+            threshold=threshold,
+            total_chapters=len(chapters),
+            short_chapters=short_chapters,
+            summary=summary,
+        )
+
+    async def expand_chapter(
+        self,
+        novel_id: str,
+        chapter_number: int,
+        target_words: int = 4000,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """扩写单个章节，SSE 事件流"""
+        yield {"type": "phase", "phase": "loading", "chapter_number": chapter_number}
+
+        # 加载当前章
+        current = self._chapter_svc.get_chapter_by_novel_and_number(novel_id, chapter_number)
+        if not current:
+            yield {"type": "error", "message": f"章节 {chapter_number} 不存在"}
+            return
+
+        existing_content = current.content or ""
+        title = current.title or f"第{chapter_number}章"
+        outline = self._get_chapter_outline(novel_id, chapter_number, title, existing_content)
+
+        # 加载前后章
+        prev_tail = self._get_prev_chapter_tail(novel_id, chapter_number)
+        next_head = self._get_next_chapter_head(novel_id, chapter_number)
+
+        yield {"type": "phase", "phase": "context", "chapter_number": chapter_number}
+
+        # 构建 prompt
+        prompt = self._build_expand_prompt(
+            chapter_number=chapter_number,
+            title=title,
+            outline=outline,
+            existing_content=existing_content,
+            prev_tail=prev_tail,
+            next_head=next_head,
+            target_words=target_words,
+        )
+
+        yield {"type": "phase", "phase": "llm", "chapter_number": chapter_number}
+
+        # 流式 LLM 生成
+        config = GenerationConfig(max_tokens=min(target_words * 3, 16384), temperature=0.7)
+        chunks: list[str] = []
+        try:
+            async for piece in self._llm.stream_generate(prompt, config):
+                chunks.append(piece)
+                yield {"type": "chunk", "text": piece, "chapter_number": chapter_number}
+        except Exception as e:
+            logger.error(f"章节 {chapter_number} 扩写 LLM 失败: {e}")
+            yield {"type": "error", "message": f"LLM 生成失败: {e}"}
+            return
+
+        # 拼接并清理
+        expanded = strip_reasoning_artifacts("".join(chunks)).strip()
+        if not expanded:
+            yield {"type": "error", "message": "LLM 返回空内容"}
+            return
+
+        yield {"type": "phase", "phase": "saving", "chapter_number": chapter_number}
+
+        # 保存
+        try:
+            chapter_entity = self._chapter_repo.get_by_novel_and_number(
+                NovelId(novel_id), chapter_number
+            )
+            if chapter_entity:
+                chapter_entity.update_content(expanded)
+                self._chapter_repo.save(chapter_entity)
+        except Exception as e:
+            logger.error(f"章节 {chapter_number} 保存失败: {e}")
+            yield {"type": "error", "message": f"保存失败: {e}"}
+            return
+
+        # 后处理（异步，不阻塞 SSE）
+        self._schedule_aftermath(novel_id, chapter_number, expanded)
+
+        yield {
+            "type": "done",
+            "chapter_number": chapter_number,
+            "content": expanded,
+            "word_count": len(expanded),
+        }
+
+    async def batch_expand_chapters(
+        self,
+        novel_id: str,
+        chapter_numbers: list[int],
+        target_words: int = 4000,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """批量扩写章节（顺序执行，保证前后衔接）"""
+        total = len(chapter_numbers)
+        yield {
+            "type": "session",
+            "novel_id": novel_id,
+            "chapters": chapter_numbers,
+            "total": total,
+        }
+
+        for i, ch_num in enumerate(chapter_numbers, 1):
+            yield {"type": "chapter_start", "chapter_number": ch_num, "index": i, "total": total}
+            async for event in self.expand_chapter(novel_id, ch_num, target_words):
+                yield event
+            yield {"type": "chapter_done", "chapter_number": ch_num, "index": i, "total": total}
+
+        yield {"type": "session_done"}
+
+    # ── 内部方法 ──
+
+    def _get_chapter_outline(self, novel_id: str, chapter_number: int, title: str, content: str) -> str:
+        """获取章节大纲，优先从 DB 读取，否则从内容合成"""
+        chapter = self._chapter_repo.get_by_novel_and_number(NovelId(novel_id), chapter_number)
+        if chapter and chapter.outline and chapter.outline.strip():
+            return chapter.outline.strip()
+        # 合成大纲
+        preview = content[:200] if content else ""
+        return f"【{title}】\n{preview}" if preview else f"【{title}】\n（大纲缺失，请根据已有内容和上下文扩写）"
+
+    def _get_prev_chapter_tail(self, novel_id: str, chapter_number: int) -> str:
+        """获取上一章尾部内容"""
+        if chapter_number <= 1:
+            return ""
+        prev = self._chapter_svc.get_chapter_by_novel_and_number(novel_id, chapter_number - 1)
+        if not prev or not prev.content:
+            return ""
+        content = prev.content.strip()
+        if len(content) <= _PREV_CHAPTER_TAIL_CHARS:
+            return f"【第{chapter_number - 1}章末尾】\n{content}"
+        return f"【第{chapter_number - 1}章末尾】\n{content[-_PREV_CHAPTER_TAIL_CHARS:]}"
+
+    def _get_next_chapter_head(self, novel_id: str, chapter_number: int) -> str:
+        """获取下一章开头内容"""
+        nxt = self._chapter_svc.get_chapter_by_novel_and_number(novel_id, chapter_number + 1)
+        if not nxt or not nxt.content:
+            return ""
+        content = nxt.content.strip()
+        if len(content) <= _NEXT_CHAPTER_HEAD_CHARS:
+            return f"【第{chapter_number + 1}章开头】\n{content}"
+        return f"【第{chapter_number + 1}章开头】\n{content[:_NEXT_CHAPTER_HEAD_CHARS]}"
+
+    def _build_expand_prompt(
+        self,
+        chapter_number: int,
+        title: str,
+        outline: str,
+        existing_content: str,
+        prev_tail: str,
+        next_head: str,
+        target_words: int,
+    ) -> Prompt:
+        """构建扩写 prompt"""
+        system = (
+            "你是一位资深小说编辑，擅长扩写和修复因技术问题被截断的章节。\n\n"
+            "必须遵守：\n"
+            "1. 保留所有已有剧情事件、因果顺序、角色关系、伏笔信息。\n"
+            "2. 基于章节大纲扩写，补充缺失的场景描写、对话、心理活动、环境细节。\n"
+            "3. 确保与上一章末尾自然衔接，为下一章开头做好铺垫。\n"
+            "4. 输出只能是扩写后的完整章节正文，不要解释，不要加章节标题。\n"
+            f"5. 目标字数：{target_words} 字左右。\n"
+        )
+
+        user_parts = [f"第 {chapter_number} 章，标题：{title}\n"]
+        user_parts.append(f"章节大纲：\n{outline}\n")
+
+        if prev_tail:
+            user_parts.append(f"\n上一章末尾（请确保你的开头自然衔接这段内容）：\n{prev_tail}\n")
+
+        user_parts.append(f"\n当前章节正文（需要扩写）：\n{existing_content}\n")
+
+        if next_head:
+            user_parts.append(f"\n下一章开头（请确保你的结尾能自然过渡到这段内容）：\n{next_head}\n")
+
+        user_parts.append(f"\n请将上述章节正文扩写至约 {target_words} 字，保持剧情连贯，直接输出正文：")
+
+        return Prompt(system=system, user="\n".join(user_parts))
+
+    def _schedule_aftermath(self, novel_id: str, chapter_number: int, content: str) -> None:
+        """异步触发章后管线"""
+        if not self._aftermath or not content.strip():
+            return
+
+        async def _run() -> None:
+            try:
+                await self._aftermath.run_after_chapter_saved(novel_id, chapter_number, content)
+            except Exception as e:
+                logger.warning(f"章节修复后管线失败 novel={novel_id} ch={chapter_number}: {e}")
+
+        try:
+            asyncio.create_task(_run())
+        except Exception as e:
+            logger.warning(f"章节修复后管线未调度: {e}")

--- a/application/engine/services/autopilot_daemon.py
+++ b/application/engine/services/autopilot_daemon.py
@@ -659,9 +659,9 @@ class AutopilotDaemon:
                     # - 最终输出应接近 prompt 目标，略低于原始目标
                     max_tokens = int(beat.target_words * 1.1)
                     cfg = GenerationConfig(max_tokens=max_tokens, temperature=0.85)
-                    beat_content = await self._stream_llm_with_stop_watch(prompt, cfg, novel=novel)
+                    beat_content, beat_stop_reason = await self._stream_llm_with_stop_watch(prompt, cfg, novel=novel)
                 else:
-                    beat_content = await self._stream_one_beat(
+                    beat_content, beat_stop_reason = await self._stream_one_beat(
                         outline,
                         context,
                         beat_prompt,
@@ -672,9 +672,10 @@ class AutopilotDaemon:
                     )
 
                 if beat_content.strip():
-                    # V8: 截断检测与自动续写（软着陆）
+                    # V9: 截断检测与自动续写（基于 stop_reason）
                     beat_content = await self._ensure_complete_ending(
-                        beat_content, beat, outline, chapter_content, novel
+                        beat_content, beat, outline, chapter_content, novel,
+                        stop_reason=beat_stop_reason,
                     )
                     chapter_content += ("\n\n" if chapter_content else "") + beat_content
                     await self._upsert_chapter_content(novel, next_chapter_node, chapter_content, status="draft")
@@ -711,9 +712,9 @@ class AutopilotDaemon:
                     voice_anchors=voice_anchors,
                 )
                 cfg = GenerationConfig(max_tokens=3000, temperature=0.85)
-                beat_content = await self._stream_llm_with_stop_watch(prompt, cfg, novel=novel)
+                beat_content, _ = await self._stream_llm_with_stop_watch(prompt, cfg, novel=novel)
             else:
-                beat_content = await self._stream_one_beat(
+                beat_content, _ = await self._stream_one_beat(
                     outline, context, None, None, novel=novel, voice_anchors=voice_anchors
                 )
             if not self._is_still_running(novel):
@@ -1273,10 +1274,13 @@ class AutopilotDaemon:
 
     async def _stream_llm_with_stop_watch(
         self, prompt: Prompt, config: GenerationConfig, novel=None
-    ) -> str:
+    ) -> tuple[str, str]:
         """与 workflow 共用同一套 Prompt + LLM；novel 传入时并行轮询 DB 是否已停止。
-        
+
         流式生成时会实时推送增量文字到 streaming_callback（如果设置）。
+
+        Returns:
+            (content, stop_reason) 元组，stop_reason 为 LLM API 返回的停止原因。
         """
         content = ""
         stop_detected = asyncio.Event()
@@ -1301,11 +1305,11 @@ class AutopilotDaemon:
                 if novel is not None and stop_detected.is_set():
                     break
                 content += chunk
-                
+
                 # 实时推送增量文字到全局流式队列
                 if novel is not None and chunk:
                     await self._push_streaming_chunk(novel.novel_id.value, chunk)
-                
+
                 if novel is not None and stop_detected.is_set():
                     break
         finally:
@@ -1320,7 +1324,12 @@ class AutopilotDaemon:
         if novel is not None:
             self._merge_autopilot_status_from_db(novel)
 
-        return strip_reasoning_artifacts(content)
+        # 从 provider 读取 stream 的 stop_reason
+        stop_reason = ""
+        if hasattr(self.llm_service, "last_stream_stop_reason"):
+            stop_reason = self.llm_service.last_stream_stop_reason or ""
+
+        return strip_reasoning_artifacts(content), stop_reason
 
     async def _push_streaming_chunk(self, novel_id: str, chunk: str):
         """推送增量文字到全局流式队列，供 SSE 接口消费"""
@@ -1334,11 +1343,14 @@ class AutopilotDaemon:
         outline: str,
         chapter_draft_so_far: str,
         novel=None,
+        stop_reason: str = "",
     ) -> str:
-        """V8: 截断检测与自动续写（软着陆）
+        """V9: 截断检测与自动续写（基于 stop_reason + 文本兜底）
 
-        检测内容是否被截断（没有以句号等结束符结尾），
-        如果被截断，自动发起续写请求完成收尾。
+        优先使用 LLM API 返回的 stop_reason 判断是否截断：
+        - stop_reason 为 "length"/"max_tokens"/"MAX_TOKENS" → 确认截断，发起续写
+        - stop_reason 为其他值（"stop"/"end_turn"/"STOP" 等）→ LLM 正常结束，不续写
+        - stop_reason 为空（无法获取时）→ 降级到文本匹配兜底
 
         Args:
             content: 已生成的内容
@@ -1346,6 +1358,7 @@ class AutopilotDaemon:
             outline: 章节大纲
             chapter_draft_so_far: 本章已生成的正文
             novel: 小说对象
+            stop_reason: LLM API 返回的停止原因
 
         Returns:
             完整的内容（可能包含续写部分）
@@ -1355,17 +1368,23 @@ class AutopilotDaemon:
         if not content or not content.strip():
             return content
 
-        # 检测是否以句子结束符结尾
-        # 中文句号、英文句号、叹号、问号、引号、省略号
-        ending_pattern = r'[。！？…）】》"\'』」]$'
         stripped = content.rstrip()
 
-        if re.search(ending_pattern, stripped):
-            # 结尾完整，无需续写
-            return content
+        # 判断是否需要续写
+        truncated_by_token = stop_reason in ("length", "max_tokens", "MAX_TOKENS")
 
-        # 检测是否被截断
-        logger.warning(f"[截断检测] 内容未以结束符结尾，可能被截断，发起自动续写")
+        if not truncated_by_token:
+            if stop_reason:
+                # LLM 明确报告正常结束，不续写
+                return content
+            # stop_reason 为空（无法获取），降级到文本匹配
+            ending_pattern = r'[。！？…）】》"\'』」]$'
+            if re.search(ending_pattern, stripped):
+                return content
+            # 文本也不匹配结束符，可能是截断
+            logger.warning(f"[截断检测] stop_reason 未知且内容未以结束符结尾，尝试续写")
+        else:
+            logger.warning(f"[截断检测] stop_reason={stop_reason}，确认 token 耗尽截断，发起续写")
 
         # 构建续写 Prompt
         continuation_prompt = Prompt(
@@ -1387,7 +1406,7 @@ class AutopilotDaemon:
 
         try:
             config = GenerationConfig(max_tokens=300, temperature=0.7)
-            continuation = await self._stream_llm_with_stop_watch(
+            continuation, _ = await self._stream_llm_with_stop_watch(
                 continuation_prompt, config, novel=novel
             )
 
@@ -1412,7 +1431,7 @@ class AutopilotDaemon:
         novel=None,
         voice_anchors: str = "",
         chapter_draft_so_far: str = "",
-    ) -> str:
+    ) -> tuple[str, str]:
         """无 AutoNovelGenerationWorkflow 时的降级：爽文短 Prompt + 流式。"""
         va = (voice_anchors or "").strip()
         voice_block = ""

--- a/application/engine/services/autopilot_daemon.py
+++ b/application/engine/services/autopilot_daemon.py
@@ -655,9 +655,9 @@ class AutopilotDaemon:
                     )
                     # 字数控制策略：
                     # - prompt 中要求目标的 75%（在 context_builder 中处理）
-                    # - max_tokens = prompt 目标 × 1.1（硬性上限，超出会被截断）
+                    # - max_tokens = prompt 目标 × 2.0（中文 1 字 ≈ 1-2 token，留足余量）
                     # - 最终输出应接近 prompt 目标，略低于原始目标
-                    max_tokens = int(beat.target_words * 1.1)
+                    max_tokens = int(beat.target_words * 2.0)
                     cfg = GenerationConfig(max_tokens=max_tokens, temperature=0.85)
                     beat_content, beat_stop_reason = await self._stream_llm_with_stop_watch(prompt, cfg, novel=novel)
                 else:

--- a/application/engine/services/autopilot_daemon.py
+++ b/application/engine/services/autopilot_daemon.py
@@ -655,9 +655,9 @@ class AutopilotDaemon:
                     )
                     # 字数控制策略：
                     # - prompt 中要求目标的 75%（在 context_builder 中处理）
-                    # - max_tokens = prompt 目标 × 2.0（中文 1 字 ≈ 1-2 token，留足余量）
-                    # - 最终输出应接近 prompt 目标，略低于原始目标
-                    max_tokens = int(beat.target_words * 2.0)
+                    # - max_tokens 设为足够大的固定值，让模型自然结束
+                    # - 依赖 stop_reason 判断是否真正截断，而非用 max_tokens 硬卡字数
+                    max_tokens = 8192
                     cfg = GenerationConfig(max_tokens=max_tokens, temperature=0.85)
                     beat_content, beat_stop_reason = await self._stream_llm_with_stop_watch(prompt, cfg, novel=novel)
                 else:
@@ -1462,8 +1462,8 @@ class AutopilotDaemon:
             user_parts.append(f"\n{beat_prompt}")
         user_parts.append("\n\n开始撰写：")
 
-        # 字数控制策略（与主流程一致）
-        max_tokens = int(beat.target_words * 1.1) if beat else 3000
+        # 字数控制策略（与主流程一致）：固定上限，依赖 stop_reason 判断截断
+        max_tokens = 8192
 
         prompt = Prompt(system=system, user="\n".join(user_parts))
         config = GenerationConfig(max_tokens=max_tokens, temperature=0.85)

--- a/application/world/services/bible_service.py
+++ b/application/world/services/bible_service.py
@@ -13,7 +13,7 @@ from domain.novel.value_objects.novel_id import NovelId
 from domain.bible.repositories.bible_repository import BibleRepository
 from domain.novel.repositories.novel_repository import NovelRepository
 from domain.novel.repositories.chapter_repository import ChapterRepository
-from domain.shared.exceptions import EntityNotFoundError
+from domain.shared.exceptions import EntityNotFoundError, InvalidOperationError
 from application.world.dtos.bible_dto import BibleDTO, CharacterDTO
 
 if TYPE_CHECKING:
@@ -105,7 +105,7 @@ class BibleService:
         description: str,
         relationships: list = None
     ) -> BibleDTO:
-        """添加人物
+        """添加人物（增量写入，不触碰已有角色和关系）
 
         Args:
             novel_id: 小说 ID
@@ -124,15 +124,41 @@ class BibleService:
         if bible is None:
             raise EntityNotFoundError("Bible", f"for novel {novel_id}")
 
-        character = Character(
-            id=CharacterId(character_id),
-            name=name,
-            description=description,
-            relationships=relationships or [],
-        )
-        bible.add_character(character)
-        self.bible_repository.save(bible)
+        # 检查角色是否已存在
+        if bible.get_character(CharacterId(character_id)) is not None:
+            raise InvalidOperationError(
+                f"Character with id '{character_id}' already exists"
+            )
 
+        # 增量写入：只 INSERT 新角色及其关系，不 DELETE 其他数据
+        repo = self.bible_repository
+        if hasattr(repo, "add_character_incremental"):
+            rel_dicts = []
+            for rel in (relationships or []):
+                if isinstance(rel, dict):
+                    rel_dicts.append(rel)
+                elif hasattr(rel, "model_dump"):
+                    rel_dicts.append(rel.model_dump())
+                elif hasattr(rel, "dict"):
+                    rel_dicts.append(rel.dict())
+                else:
+                    rel_dicts.append({"target": str(rel), "relation": "", "description": ""})
+            repo.add_character_incremental(
+                novel_id, character_id, name, description, rel_dicts,
+            )
+        else:
+            # fallback：非 SQLite 仓储走原路径
+            character = Character(
+                id=CharacterId(character_id),
+                name=name,
+                description=description,
+                relationships=relationships or [],
+            )
+            bible.add_character(character)
+            repo.save(bible)
+
+        # 重新加载最新状态返回
+        bible = self.bible_repository.get_by_novel_id(NovelId(novel_id))
         return BibleDTO.from_domain(bible)
 
     def update_character_voice_anchors(

--- a/domain/ai/services/llm_service.py
+++ b/domain/ai/services/llm_service.py
@@ -30,9 +30,10 @@ class GenerationConfig:
 
 class GenerationResult:
     """生成结果"""
-    def __init__(self, content: str, token_usage: TokenUsage):
+    def __init__(self, content: str, token_usage: TokenUsage, stop_reason: str = ""):
         self.content = content
         self.token_usage = token_usage
+        self.stop_reason = stop_reason  # "stop"/"length"(OpenAI), "end_turn"/"max_tokens"(Anthropic), "STOP"/"MAX_TOKENS"(Gemini)
         self.__post_init__()
 
     def __post_init__(self):

--- a/frontend/src/api/chapterRepair.ts
+++ b/frontend/src/api/chapterRepair.ts
@@ -1,0 +1,214 @@
+/** 章节修复 API */
+import { apiClient, resolveHttpUrl } from './config'
+
+// ── 类型 ──
+
+export interface ShortChapterDTO {
+  chapter_number: number
+  title: string
+  word_count: number
+  status: string
+  content_preview: string
+  severity: 'critical' | 'warning' | 'info'
+}
+
+export interface ChapterRepairScanResult {
+  novel_id: string
+  threshold: number
+  total_chapters: number
+  short_chapters: ShortChapterDTO[]
+  summary: { critical: number; warning: number; info: number }
+}
+
+export type ChapterRepairStreamEvent =
+  | { type: 'phase'; phase: string; chapter_number?: number }
+  | { type: 'chunk'; text: string; chapter_number?: number }
+  | { type: 'done'; content: string; word_count: number; chapter_number: number }
+  | { type: 'error'; message: string }
+  | { type: 'session'; novel_id: string; chapters: number[]; total: number }
+  | { type: 'chapter_start'; chapter_number: number; index: number; total: number }
+  | { type: 'chapter_done'; chapter_number: number; index: number; total: number }
+  | { type: 'session_done' }
+
+// ── REST API ──
+
+export const chapterRepairApi = {
+  scanShortChapters: (novelId: string, threshold: number = 4000) =>
+    apiClient.get<ChapterRepairScanResult>(
+      `/novels/${novelId}/chapter-repair/scan?threshold=${threshold}`
+    ),
+}
+
+// ── SSE 工具 ──
+
+function parseSseDataLine(line: string): unknown | null {
+  if (!line.startsWith('data: ')) return null
+  try {
+    return JSON.parse(line.slice(6)) as unknown
+  } catch {
+    return null
+  }
+}
+
+// ── SSE 消费者：单章扩写 ──
+
+export async function consumeExpandChapterStream(
+  novelId: string,
+  chapterNumber: number,
+  targetWords: number,
+  handlers: {
+    onEvent?: (ev: ChapterRepairStreamEvent) => void
+    onPhase?: (phase: string) => void
+    onChunk?: (text: string) => void
+    onDone?: (result: { content: string; word_count: number }) => void
+    onError?: (message: string) => void
+    signal?: AbortSignal
+  }
+): Promise<void> {
+  const res = await fetch(resolveHttpUrl(`/api/v1/novels/${novelId}/chapter-repair/expand/${chapterNumber}`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target_words: targetWords }),
+    signal: handlers.signal,
+  })
+  if (!res.ok || !res.body) {
+    const t = await res.text().catch(() => '')
+    handlers.onError?.(t || `HTTP ${res.status}`)
+    return
+  }
+  await _consumeSse(res.body, handlers)
+}
+
+// ── SSE 消费者：批量扩写 ──
+
+export async function consumeBatchExpandStream(
+  novelId: string,
+  chapterNumbers: number[],
+  targetWords: number,
+  handlers: {
+    onEvent?: (ev: ChapterRepairStreamEvent) => void
+    onPhase?: (phase: string) => void
+    onChunk?: (text: string, chapterNumber?: number) => void
+    onChapterStart?: (chapterNumber: number, index: number, total: number) => void
+    onChapterDone?: (chapterNumber: number, index: number, total: number) => void
+    onDone?: () => void
+    onError?: (message: string) => void
+    signal?: AbortSignal
+  }
+): Promise<void> {
+  const res = await fetch(resolveHttpUrl(`/api/v1/novels/${novelId}/chapter-repair/batch-expand`), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chapter_numbers: chapterNumbers, target_words: targetWords }),
+    signal: handlers.signal,
+  })
+  if (!res.ok || !res.body) {
+    const t = await res.text().catch(() => '')
+    handlers.onError?.(t || `HTTP ${res.status}`)
+    return
+  }
+
+  const reader = res.body.getReader()
+  const dec = new TextDecoder()
+  let buf = ''
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += dec.decode(value, { stream: true })
+      let sep: number
+      while ((sep = buf.indexOf('\n\n')) >= 0) {
+        const block = buf.slice(0, sep)
+        buf = buf.slice(sep + 2)
+        for (const line of block.split('\n')) {
+          const raw = parseSseDataLine(line)
+          if (!raw || typeof raw !== 'object' || raw === null) continue
+          const o = raw as Record<string, unknown>
+          const typ = o.type as string
+          const ev = o as unknown as ChapterRepairStreamEvent
+          handlers.onEvent?.(ev)
+
+          if (typ === 'phase') {
+            handlers.onPhase?.(String(o.phase ?? ''))
+          } else if (typ === 'chunk') {
+            handlers.onChunk?.(String(o.text ?? ''), o.chapter_number as number | undefined)
+          } else if (typ === 'chapter_start') {
+            handlers.onChapterStart?.(
+              Number(o.chapter_number), Number(o.index), Number(o.total)
+            )
+          } else if (typ === 'chapter_done') {
+            handlers.onChapterDone?.(
+              Number(o.chapter_number), Number(o.index), Number(o.total)
+            )
+          } else if (typ === 'session_done') {
+            handlers.onDone?.()
+            return
+          } else if (typ === 'error') {
+            handlers.onError?.(String(o.message ?? '扩写失败'))
+            return
+          }
+        }
+      }
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === 'AbortError') return
+    const msg = e instanceof Error ? e.message : '流式连接失败'
+    handlers.onError?.(msg)
+  }
+}
+
+// ── 内部：通用 SSE 消费 ──
+
+async function _consumeSse(
+  body: ReadableStream<Uint8Array>,
+  handlers: {
+    onEvent?: (ev: ChapterRepairStreamEvent) => void
+    onPhase?: (phase: string) => void
+    onChunk?: (text: string) => void
+    onDone?: (result: { content: string; word_count: number }) => void
+    onError?: (message: string) => void
+  }
+): Promise<void> {
+  const reader = body.getReader()
+  const dec = new TextDecoder()
+  let buf = ''
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += dec.decode(value, { stream: true })
+      let sep: number
+      while ((sep = buf.indexOf('\n\n')) >= 0) {
+        const block = buf.slice(0, sep)
+        buf = buf.slice(sep + 2)
+        for (const line of block.split('\n')) {
+          const raw = parseSseDataLine(line)
+          if (!raw || typeof raw !== 'object' || raw === null) continue
+          const o = raw as Record<string, unknown>
+          const typ = o.type as string
+          const ev = o as unknown as ChapterRepairStreamEvent
+          handlers.onEvent?.(ev)
+
+          if (typ === 'phase') {
+            handlers.onPhase?.(String(o.phase ?? ''))
+          } else if (typ === 'chunk') {
+            handlers.onChunk?.(String(o.text ?? ''))
+          } else if (typ === 'done') {
+            handlers.onDone?.({
+              content: String(o.content ?? ''),
+              word_count: Number(o.word_count ?? 0),
+            })
+            return
+          } else if (typ === 'error') {
+            handlers.onError?.(String(o.message ?? '扩写失败'))
+            return
+          }
+        }
+      }
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === 'AbortError') return
+    const msg = e instanceof Error ? e.message : '流式连接失败'
+    handlers.onError?.(msg)
+  }
+}

--- a/frontend/src/components/stats/StatsTopBar.vue
+++ b/frontend/src/components/stats/StatsTopBar.vue
@@ -85,6 +85,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { NTooltip, NSpin, NDropdown, NButton, useMessage } from 'naive-ui'
 import { useStatsStore } from '@/stores/statsStore'
+import { useRouter, useRoute } from 'vue-router'
 import { novelApi } from '@/api/novel'
 import GlobalLLMEntryButton from '@/components/global/GlobalLLMEntryButton.vue'
 import PromptPlazaEntryButton from '@/components/global/PromptPlazaEntryButton.vue'
@@ -98,6 +99,8 @@ defineEmits<{
 }>()
 
 const message = useMessage()
+const router = useRouter()
+const route = useRoute()
 
 // AI 工具组件引用（用于以编程方式触发各组件内部按钮）
 const llmRef = ref<{ $el: HTMLElement } | null>(null)
@@ -106,6 +109,8 @@ const plazaRef = ref<{ $el: HTMLElement } | null>(null)
 const aiToolsOptions = [
   { label: '⚙️ AI 控制台', key: 'llm' },
   { label: '✦ 提示词广场', key: 'plaza' },
+  { type: 'divider', key: 'd1' },
+  { label: '🔧 章节修复', key: 'repair' },
 ]
 
 function handleAiToolSelect(key: string) {
@@ -113,6 +118,9 @@ function handleAiToolSelect(key: string) {
     llmRef.value?.$el?.querySelector('button')?.click()
   } else if (key === 'plaza') {
     plazaRef.value?.$el?.querySelector('button')?.click()
+  } else if (key === 'repair') {
+    const slug = route.params.slug as string
+    router.push(`/book/${slug}/chapter-repair`)
   }
 }
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import Workbench from '../views/Workbench.vue'
 import Chapter from '../views/Chapter.vue'
+import ChapterRepair from '../views/ChapterRepair.vue'
 import Cast from '../views/Cast.vue'
 import CharacterGraph from '../views/CharacterGraph.vue'
 import LocationGraph from '../views/LocationGraph.vue'
@@ -14,6 +15,7 @@ const router = createRouter({
     { path: '/book/:slug/workbench', name: 'Workbench', component: Workbench },
     { path: '/book/:slug/cast', name: 'Cast', component: Cast },
     { path: '/book/:slug/chapter/:id', name: 'Chapter', component: Chapter },
+    { path: '/book/:slug/chapter-repair', name: 'ChapterRepair', component: ChapterRepair },
     { path: '/book/:slug/characters', name: 'CharacterGraph', component: CharacterGraph },
     { path: '/book/:slug/location-graph', name: 'LocationGraph', component: LocationGraph },
     { path: '/debug/scheduler', name: 'CharacterSchedulerSimulator', component: CharacterSchedulerSimulator },

--- a/frontend/src/views/ChapterRepair.vue
+++ b/frontend/src/views/ChapterRepair.vue
@@ -1,0 +1,617 @@
+<template>
+  <n-spin :show="pageLoading" class="repair-spin" description="加载中…">
+  <div class="chapter-repair">
+    <!-- 顶栏 -->
+    <header class="repair-header">
+      <n-space align="center" :wrap="false">
+        <n-button quaternary round @click="goBack">
+          <template #icon><span class="ico-back">←</span></template>
+          工作台
+        </n-button>
+        <n-divider vertical />
+        <h2 class="repair-heading">章节修复</h2>
+      </n-space>
+
+      <n-space :size="8" :wrap="false">
+        <n-input-number
+          v-model:value="threshold"
+          :min="500"
+          :max="20000"
+          :step="500"
+          size="small"
+          placeholder="字数阈值"
+          style="width: 120px"
+        />
+        <n-button type="primary" size="small" :loading="scanning" @click="scan">
+          扫描短章节
+        </n-button>
+        <n-button
+          type="warning"
+          size="small"
+          :loading="batchExpanding"
+          :disabled="!scanResult || scanResult.short_chapters.length === 0"
+          @click="oneClickRepair"
+        >
+          一键审查续写
+        </n-button>
+      </n-space>
+    </header>
+
+    <!-- 统计栏 -->
+    <div v-if="scanResult" class="repair-stats">
+      <n-space>
+        <n-statistic label="总章节" :value="scanResult.total_chapters" />
+        <n-statistic label="严重 (<1000字)" :value="scanResult.summary.critical">
+          <template #prefix>
+            <n-tag type="error" size="small">严重</n-tag>
+          </template>
+        </n-statistic>
+        <n-statistic label="警告 (<2500字)" :value="scanResult.summary.warning">
+          <template #prefix>
+            <n-tag type="warning" size="small">警告</n-tag>
+          </template>
+        </n-statistic>
+        <n-statistic label="提示 (<阈值)" :value="scanResult.summary.info">
+          <template #prefix>
+            <n-tag type="info" size="small">提示</n-tag>
+          </template>
+        </n-statistic>
+      </n-space>
+    </div>
+
+    <!-- 无数据 -->
+    <n-empty v-if="scanResult && scanResult.short_chapters.length === 0" description="所有章节字数均达标" style="margin-top: 40px" />
+
+    <!-- 主体：表格 + 详情 -->
+    <div v-if="scanResult && scanResult.short_chapters.length > 0" class="repair-body">
+      <n-split direction="horizontal" :default-size="0.45" :min="0.3" :max="0.7">
+        <template #1>
+          <!-- 左侧：章节表格 -->
+          <div class="repair-table-area">
+            <n-data-table
+              :columns="columns"
+              :data="scanResult.short_chapters"
+              :row-class-name="rowClassName"
+              :row-props="rowProps"
+              :checked-row-keys="selectedRows"
+              @update:checked-row-keys="onCheckedRowKeysChange"
+              :row-key="(row: ShortChapterDTO) => row.chapter_number"
+              :scrollbar-props="{ style: { maxHeight: 'calc(100vh - 280px)' } }"
+              max-height="calc(100vh - 280px)"
+              size="small"
+            />
+          </div>
+        </template>
+        <template #2>
+          <!-- 右侧：详情 + 扩写 -->
+          <div class="repair-detail-area" v-if="selectedChapter">
+            <n-tabs type="segment" v-model:value="detailTab">
+              <n-tab-pane name="preview" tab="当前内容">
+                <n-scrollbar style="max-height: calc(100vh - 380px)">
+                  <div class="content-preview">{{ fullContent || selectedChapter.content_preview }}</div>
+                </n-scrollbar>
+              </n-tab-pane>
+              <n-tab-pane name="expanded" tab="扩写结果">
+                <n-scrollbar style="max-height: calc(100vh - 380px)">
+                  <div class="content-expanded" v-if="expandedContent">{{ expandedContent }}</div>
+                  <n-empty v-else description="点击「扩写此章」开始" style="margin-top: 40px" />
+                </n-scrollbar>
+              </n-tab-pane>
+              <n-tab-pane name="diff" tab="对比">
+                <n-scrollbar style="max-height: calc(100vh - 380px)">
+                  <div class="diff-area" v-if="expandedContent">
+                    <div class="diff-before">
+                      <h4>修复前 ({{ selectedChapter.word_count }} 字)</h4>
+                      <pre>{{ fullContent || selectedChapter.content_preview }}</pre>
+                    </div>
+                    <div class="diff-after">
+                      <h4>修复后 ({{ expandedWordCount }} 字)</h4>
+                      <pre>{{ expandedContent }}</pre>
+                    </div>
+                  </div>
+                  <n-empty v-else description="扩写后可在此对比" style="margin-top: 40px" />
+                </n-scrollbar>
+              </n-tab-pane>
+            </n-tabs>
+
+            <!-- 操作栏 -->
+            <div class="repair-actions">
+              <n-space align="center">
+                <n-text>目标字数：</n-text>
+                <n-input-number
+                  v-model:value="targetWords"
+                  :min="2000"
+                  :max="20000"
+                  :step="500"
+                  size="small"
+                  style="width: 120px"
+                />
+                <n-button
+                  type="primary"
+                  size="small"
+                  :loading="expanding"
+                  @click="expandSelected"
+                >
+                  扩写此章
+                </n-button>
+                <n-button
+                  size="small"
+                  @click="selectAll"
+                >
+                  全选 ({{ scanResult?.short_chapters.length || 0 }})
+                </n-button>
+                <n-button
+                  size="small"
+                  :loading="batchExpanding"
+                  :disabled="selectedRows.length === 0"
+                  @click="batchExpand"
+                >
+                  批量扩写选中 ({{ selectedRows.length }})
+                </n-button>
+                <n-button
+                  v-if="expandedContent"
+                  type="success"
+                  size="small"
+                  @click="goToChapter"
+                >
+                  查看章节
+                </n-button>
+              </n-space>
+            </div>
+          </div>
+          <div v-else class="repair-detail-empty">
+            <n-empty description="选择左侧章节查看详情" />
+          </div>
+        </template>
+      </n-split>
+    </div>
+
+    <!-- 批量进度弹窗 -->
+    <n-modal v-model:show="showBatchProgress" :closable="false" :mask-closable="false">
+      <n-card title="批量扩写进度" style="width: 500px">
+        <n-space vertical>
+          <n-progress
+            type="line"
+            :percentage="batchProgressPercent"
+            :indicator-placement="'inside'"
+          />
+          <n-text>{{ batchProgressText }}</n-text>
+          <n-text depth="3" v-if="currentBatchChapter">
+            正在扩写第 {{ currentBatchChapter }} 章...
+          </n-text>
+        </n-space>
+        <template #action>
+          <n-button size="small" @click="cancelBatch">取消</n-button>
+        </template>
+      </n-card>
+    </n-modal>
+  </div>
+  </n-spin>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, h } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useMessage, NButton, NTag } from 'naive-ui'
+import type { DataTableColumns } from 'naive-ui'
+import { novelApi } from '../api/novel'
+import {
+  chapterRepairApi,
+  consumeExpandChapterStream,
+  consumeBatchExpandStream,
+} from '../api/chapterRepair'
+import type { ShortChapterDTO, ChapterRepairScanResult } from '../api/chapterRepair'
+import { chapterApi } from '../api/chapter'
+
+const route = useRoute()
+const router = useRouter()
+const message = useMessage()
+const slug = route.params.slug as string
+
+// ── 状态 ──
+
+const pageLoading = ref(true)
+const scanning = ref(false)
+const threshold = ref(4000)
+const scanResult = ref<ChapterRepairScanResult | null>(null)
+const selectedChapter = ref<ShortChapterDTO | null>(null)
+const selectedRows = ref<number[]>([])
+const detailTab = ref('preview')
+
+const fullContent = ref('')
+const targetWords = ref(4000)
+const expanding = ref(false)
+const expandedContent = ref('')
+const expandedWordCount = ref(0)
+
+const showBatchProgress = ref(false)
+const batchExpanding = ref(false)
+const batchProgressPercent = ref(0)
+const batchProgressText = ref('')
+const currentBatchChapter = ref<number | null>(null)
+let batchAbortController: AbortController | null = null
+
+let novelId = ''
+
+// ── 表格列 ──
+
+const columns: DataTableColumns<ShortChapterDTO> = [
+  {
+    type: 'selection',
+  },
+  {
+    title: '章节',
+    key: 'chapter_number',
+    width: 70,
+    sorter: (a, b) => a.chapter_number - b.chapter_number,
+    render: (row) => h('span', { style: 'font-weight: 600' }, `第${row.chapter_number}章`),
+  },
+  {
+    title: '标题',
+    key: 'title',
+    ellipsis: { tooltip: true },
+  },
+  {
+    title: '字数',
+    key: 'word_count',
+    width: 80,
+    sorter: (a, b) => a.word_count - b.word_count,
+    render: (row) => {
+      const type = row.severity === 'critical' ? 'error' : row.severity === 'warning' ? 'warning' : 'info'
+      return h(NTag, { type, size: 'small', round: true }, () => row.word_count)
+    },
+  },
+  {
+    title: '严重程度',
+    key: 'severity',
+    width: 90,
+    render: (row) => {
+      const map = {
+        critical: { type: 'error' as const, label: '严重' },
+        warning: { type: 'warning' as const, label: '警告' },
+        info: { type: 'info' as const, label: '提示' },
+      }
+      const { type, label } = map[row.severity] || map.info
+      return h(NTag, { type, size: 'small' }, () => label)
+    },
+  },
+  {
+    title: '状态',
+    key: 'status',
+    width: 70,
+    render: (row) => {
+      const map: Record<string, string> = { draft: '草稿', reviewing: '审阅中', completed: '已完成' }
+      return map[row.status] || row.status
+    },
+  },
+  {
+    title: '操作',
+    key: 'actions',
+    width: 80,
+    render: (row) =>
+      h(
+        NButton,
+        {
+          size: 'tiny',
+          type: 'primary',
+          secondary: true,
+          onClick: (e: Event) => {
+            e.stopPropagation()
+            selectChapter(row)
+          },
+        },
+        () => '查看'
+      ),
+  },
+]
+
+const rowClassName = (row: ShortChapterDTO) => {
+  if (selectedChapter.value?.chapter_number === row.chapter_number) return 'row-selected'
+  return ''
+}
+
+const rowProps = (row: ShortChapterDTO) => ({
+  style: 'cursor: pointer',
+  onClick: () => selectChapter(row),
+})
+
+function onCheckedRowKeysChange(keys: Array<string | number>) {
+  selectedRows.value = keys as number[]
+}
+
+// ── 操作 ──
+
+async function loadNovelId() {
+  try {
+    const novel = await novelApi.getNovel(slug)
+    novelId = novel.id
+  } catch {
+    message.error('加载小说信息失败')
+  }
+}
+
+async function scan() {
+  if (!novelId) return
+  scanning.value = true
+  try {
+    scanResult.value = await chapterRepairApi.scanShortChapters(novelId, threshold.value)
+    selectedChapter.value = null
+    expandedContent.value = ''
+    fullContent.value = ''
+    message.success(`扫描完成，发现 ${scanResult.value.short_chapters.length} 个短章节`)
+  } catch (e: unknown) {
+    message.error(`扫描失败: ${e instanceof Error ? e.message : String(e)}`)
+  } finally {
+    scanning.value = false
+  }
+}
+
+async function selectChapter(ch: ShortChapterDTO) {
+  selectedChapter.value = ch
+  expandedContent.value = ''
+  expandedWordCount.value = 0
+  detailTab.value = 'preview'
+
+  // 加载完整内容
+  try {
+    const full = await chapterApi.getChapter(novelId, ch.chapter_number)
+    fullContent.value = full.content || ''
+  } catch {
+    fullContent.value = ch.content_preview
+  }
+}
+
+async function expandSelected() {
+  if (!selectedChapter.value || !novelId) return
+  expanding.value = true
+  expandedContent.value = ''
+  expandedWordCount.value = 0
+  detailTab.value = 'expanded'
+
+  try {
+    await consumeExpandChapterStream(
+      novelId,
+      selectedChapter.value.chapter_number,
+      targetWords.value,
+      {
+        onChunk: (text) => {
+          expandedContent.value += text
+        },
+        onDone: (result) => {
+          expandedContent.value = result.content
+          expandedWordCount.value = result.word_count
+          message.success(`扩写完成: ${result.word_count} 字`)
+          // 刷新表格字数
+          refreshChapterInTable(selectedChapter.value!.chapter_number, result.word_count)
+        },
+        onError: (msg) => {
+          message.error(`扩写失败: ${msg}`)
+        },
+      }
+    )
+  } catch (e: unknown) {
+    message.error(`扩写异常: ${e instanceof Error ? e.message : String(e)}`)
+  } finally {
+    expanding.value = false
+  }
+}
+
+async function batchExpand() {
+  if (selectedRows.value.length === 0 || !novelId) return
+  batchExpanding.value = true
+  showBatchProgress.value = true
+  batchProgressPercent.value = 0
+  batchProgressText.value = `准备扩写 ${selectedRows.value.length} 个章节...`
+  currentBatchChapter.value = null
+  batchAbortController = new AbortController()
+
+  const total = selectedRows.value.length
+  let done = 0
+
+  try {
+    await consumeBatchExpandStream(
+      novelId,
+      [...selectedRows.value].sort((a, b) => a - b),
+      targetWords.value,
+      {
+        signal: batchAbortController.signal,
+        onChapterStart: (chNum, idx) => {
+          currentBatchChapter.value = chNum
+          batchProgressText.value = `正在扩写第 ${chNum} 章 (${idx}/${total})`
+        },
+        onChunk: (text, chNum) => {
+          if (chNum === selectedChapter.value?.chapter_number) {
+            expandedContent.value += text
+          }
+        },
+        onChapterDone: (chNum, idx) => {
+          done++
+          batchProgressPercent.value = Math.round((done / total) * 100)
+          refreshChapterInTable(chNum, 0) // 刷新字数需要重新扫描
+        },
+        onDone: () => {
+          batchProgressPercent.value = 100
+          batchProgressText.value = '全部扩写完成'
+          message.success(`批量扩写完成: ${done} 个章节`)
+          // 重新扫描以刷新字数
+          scan()
+        },
+        onError: (msg) => {
+          message.error(`批量扩写出错: ${msg}`)
+        },
+      }
+    )
+  } catch (e: unknown) {
+    if (!(e instanceof Error && e.name === 'AbortError')) {
+      message.error(`批量扩写异常: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  } finally {
+    batchExpanding.value = false
+    showBatchProgress.value = false
+    currentBatchChapter.value = null
+    batchAbortController = null
+  }
+}
+
+function cancelBatch() {
+  batchAbortController?.abort()
+  showBatchProgress.value = false
+}
+
+function selectAll() {
+  if (!scanResult.value) return
+  if (selectedRows.value.length === scanResult.value.short_chapters.length) {
+    selectedRows.value = []
+  } else {
+    selectedRows.value = scanResult.value.short_chapters.map((c) => c.chapter_number)
+  }
+}
+
+async function oneClickRepair() {
+  if (!novelId) return
+  // 先扫描
+  if (!scanResult.value) {
+    await scan()
+  }
+  if (!scanResult.value || scanResult.value.short_chapters.length === 0) {
+    message.info('没有需要修复的章节')
+    return
+  }
+  // 全选并开始批量扩写
+  selectedRows.value = scanResult.value.short_chapters.map((c) => c.chapter_number)
+  await batchExpand()
+}
+
+function refreshChapterInTable(chapterNumber: number, newWordCount: number) {
+  if (!scanResult.value) return
+  const ch = scanResult.value.short_chapters.find((c) => c.chapter_number === chapterNumber)
+  if (ch && newWordCount > 0) {
+    ch.word_count = newWordCount
+    ch.severity = newWordCount < 1000 ? 'critical' : newWordCount < 2500 ? 'warning' : 'info'
+  }
+}
+
+function goToChapter() {
+  if (selectedChapter.value) {
+    router.push(`/book/${slug}/chapter/${selectedChapter.value.chapter_number}`)
+  }
+}
+
+function goBack() {
+  router.push(`/book/${slug}/workbench`)
+}
+
+// ── 初始化 ──
+
+onMounted(async () => {
+  await loadNovelId()
+  pageLoading.value = false
+  if (novelId) {
+    await scan()
+  }
+})
+</script>
+
+<style scoped>
+.chapter-repair {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: 12px 16px;
+  gap: 12px;
+}
+
+.repair-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.repair-heading {
+  margin: 0;
+  font-size: 18px;
+}
+
+.repair-stats {
+  flex-shrink: 0;
+  padding: 8px 0;
+}
+
+.repair-body {
+  flex: 1;
+  min-height: 0;
+}
+
+.repair-table-area {
+  padding-right: 8px;
+}
+
+.repair-detail-area {
+  padding-left: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.repair-detail-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.content-preview,
+.content-expanded {
+  font-size: 14px;
+  line-height: 1.8;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 12px;
+}
+
+.repair-actions {
+  flex-shrink: 0;
+  padding: 8px 0;
+  border-top: 1px solid var(--n-border-color);
+}
+
+.diff-area {
+  display: flex;
+  gap: 16px;
+  padding: 12px;
+}
+
+.diff-area > div {
+  flex: 1;
+}
+
+.diff-area h4 {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+
+.diff-area pre {
+  font-size: 13px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 500px;
+  overflow-y: auto;
+  background: var(--n-color);
+  padding: 8px;
+  border-radius: 4px;
+}
+
+.ico-back {
+  font-size: 16px;
+}
+
+:deep(.row-selected) {
+  background-color: var(--n-color-target) !important;
+}
+
+.repair-spin {
+  height: 100%;
+}
+</style>

--- a/infrastructure/ai/provider_factory.py
+++ b/infrastructure/ai/provider_factory.py
@@ -70,9 +70,16 @@ class DynamicLLMService(LLMService):
 
     def __init__(self, factory: Optional[LLMProviderFactory] = None):
         self.factory = factory or LLMProviderFactory()
+        self._last_provider: Optional[LLMService] = None
 
     def _resolve_provider(self) -> LLMService:
         return self.factory.create_active_provider()
+
+    @property
+    def last_stream_stop_reason(self) -> str:
+        if self._last_provider and hasattr(self._last_provider, "last_stream_stop_reason"):
+            return self._last_provider.last_stream_stop_reason  # type: ignore[union-attr]
+        return ""
 
     @staticmethod
     def _merge_config(config: GenerationConfig, provider: LLMService) -> GenerationConfig:
@@ -100,11 +107,13 @@ class DynamicLLMService(LLMService):
 
     async def generate(self, prompt: Prompt, config: GenerationConfig) -> GenerationResult:
         provider = self._resolve_provider()
+        self._last_provider = provider
         effective_config = self._merge_config(config, provider)
         return await provider.generate(prompt, effective_config)
 
     async def stream_generate(self, prompt: Prompt, config: GenerationConfig) -> AsyncIterator[str]:
         provider = self._resolve_provider()
+        self._last_provider = provider
         effective_config = self._merge_config(config, provider)
         async for chunk in provider.stream_generate(prompt, effective_config):
             yield chunk

--- a/infrastructure/ai/providers/anthropic_provider.py
+++ b/infrastructure/ai/providers/anthropic_provider.py
@@ -160,7 +160,7 @@ class AnthropicProvider(BaseProvider):
                 output_tokens=response.usage.output_tokens
             )
 
-            return GenerationResult(content=content, token_usage=token_usage)
+            return GenerationResult(content=content, token_usage=token_usage, stop_reason=response.stop_reason or "")
 
         except RuntimeError:
             raise
@@ -208,6 +208,7 @@ class AnthropicProvider(BaseProvider):
 
         logger.debug(f"[Stream] Calling {url}")
 
+        self.last_stream_stop_reason = ""
         try:
             async with httpx.AsyncClient(
                 timeout=self.settings.timeout_seconds,
@@ -234,6 +235,10 @@ class AnthropicProvider(BaseProvider):
                             text_content = self._parse_sse_event(event_text)
                             if text_content:
                                 yield text_content
+                            # 从 message_delta 事件提取 stop_reason
+                            stop = self._extract_stop_reason_from_sse(event_text)
+                            if stop:
+                                self.last_stream_stop_reason = stop
 
         except Exception as e:
             logger.error(f"[Stream] Failed: {e}")
@@ -265,4 +270,23 @@ class AnthropicProvider(BaseProvider):
             if delta.get("type") == "text_delta":
                 return delta.get("text", "")
 
+        return ""
+
+    def _extract_stop_reason_from_sse(self, event_text: str) -> str:
+        """从 message_delta 事件中提取 stop_reason。"""
+        lines = event_text.strip().split("\n")
+        data = None
+        for line in lines:
+            if line.startswith("data:"):
+                data = line[5:].strip()
+                break
+        if not data:
+            return ""
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            return ""
+        if parsed.get("type") == "message_delta":
+            delta = parsed.get("delta", {})
+            return delta.get("stop_reason", "") or ""
         return ""

--- a/infrastructure/ai/providers/base.py
+++ b/infrastructure/ai/providers/base.py
@@ -17,3 +17,4 @@ class BaseProvider(LLMService, ABC):
             settings: AI 配置设置
         """
         self.settings = settings
+        self.last_stream_stop_reason: str = ""

--- a/infrastructure/ai/providers/gemini_provider.py
+++ b/infrastructure/ai/providers/gemini_provider.py
@@ -56,7 +56,16 @@ class GeminiProvider(BaseProvider):
             input_tokens=int(usage.get('promptTokenCount') or 0),
             output_tokens=int(usage.get('candidatesTokenCount') or 0),
         )
-        return GenerationResult(content=content, token_usage=token_usage)
+
+        # 提取 finishReason
+        stop_reason = ""
+        for candidate in data.get('candidates') or []:
+            fr = candidate.get('finishReason')
+            if fr:
+                stop_reason = fr
+                break
+
+        return GenerationResult(content=content, token_usage=token_usage, stop_reason=stop_reason)
 
     async def stream_generate(self, prompt: Prompt, config: GenerationConfig) -> AsyncIterator[str]:
         model_id = require_resolved_model_id(
@@ -69,6 +78,7 @@ class GeminiProvider(BaseProvider):
         url = self._build_url(model_id, 'streamGenerateContent')
         timeout = httpx.Timeout(self.settings.timeout_seconds)
 
+        self.last_stream_stop_reason = ""
         async with httpx.AsyncClient(timeout=timeout, trust_env=False) as client:
             async with client.stream(
                 'POST',
@@ -86,6 +96,10 @@ class GeminiProvider(BaseProvider):
                         text = self._parse_sse_event(event_text)
                         if text:
                             yield text
+                        # 提取 finishReason
+                        fr = self._extract_finish_reason_from_sse(event_text)
+                        if fr:
+                            self.last_stream_stop_reason = fr
 
     def _build_url(self, model: str, action: str) -> str:
         model_name = model.strip()
@@ -167,4 +181,28 @@ class GeminiProvider(BaseProvider):
             return ''.join(self._extract_text(item) for item in payload if isinstance(item, dict))
         if isinstance(payload, dict):
             return self._extract_text(payload)
+        return ''
+
+    def _extract_finish_reason_from_sse(self, event_text: str) -> str:
+        """从 SSE 事件中提取 finishReason。"""
+        data_lines: list[str] = []
+        for line in event_text.splitlines():
+            if line.startswith('data:'):
+                data_lines.append(line[5:].strip())
+        if not data_lines:
+            return ''
+        raw_payload = ''.join(data_lines).strip()
+        if not raw_payload or raw_payload == '[DONE]':
+            return ''
+        try:
+            payload = json.loads(raw_payload)
+        except json.JSONDecodeError:
+            return ''
+        items = payload if isinstance(payload, list) else [payload]
+        for item in items:
+            if isinstance(item, dict):
+                for candidate in item.get('candidates') or []:
+                    fr = candidate.get('finishReason')
+                    if fr:
+                        return fr
         return ''

--- a/infrastructure/ai/providers/mock_provider.py
+++ b/infrastructure/ai/providers/mock_provider.py
@@ -17,7 +17,7 @@ class MockProvider(LLMService):
 
         No settings or API key needed.
         """
-        pass
+        self.last_stream_stop_reason: str = ""
 
     async def generate(
         self,
@@ -529,7 +529,7 @@ class MockProvider(LLMService):
             output_tokens=len(content)
         )
 
-        return GenerationResult(content=content, token_usage=token_usage)
+        return GenerationResult(content=content, token_usage=token_usage, stop_reason="stop")
 
     async def stream_generate(
         self,
@@ -546,6 +546,7 @@ class MockProvider(LLMService):
             Mock response chunks
         """
         result = await self.generate(prompt, config)
+        self.last_stream_stop_reason = result.stop_reason
         # Simulate streaming by yielding the content in chunks
         chunk_size = 50
         for i in range(0, len(result.content), chunk_size):

--- a/infrastructure/ai/providers/openai_provider.py
+++ b/infrastructure/ai/providers/openai_provider.py
@@ -99,9 +99,13 @@ class OpenAIProvider(BaseProvider):
 
         input_tokens = response.usage.prompt_tokens if response.usage else 0
         output_tokens = response.usage.completion_tokens if response.usage else 0
+        finish_reason = ""
+        if getattr(response, "choices", None):
+            finish_reason = getattr(response.choices[0], "finish_reason", "") or ""
         return GenerationResult(
             content=content,
             token_usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+            stop_reason=finish_reason,
         )
 
     async def stream_generate(
@@ -116,12 +120,19 @@ class OpenAIProvider(BaseProvider):
             if use_responses:
                 try:
                     # 尝试走 Responses 流式 API
+                    self.last_stream_stop_reason = ""
                     request_kwargs = self._build_responses_request_kwargs(prompt, config, stream=True)
                     stream = await self.async_client.responses.create(**request_kwargs)
                     async for chunk in stream:
                         content = self._extract_text_from_responses_chunk(chunk)
                         if content:
                             yield content
+                        # Responses API: response.completed 事件携带 status
+                        event_type = getattr(chunk, "type", "")
+                        if event_type == "response.completed":
+                            resp = getattr(chunk, "response", None)
+                            if resp:
+                                self.last_stream_stop_reason = getattr(resp, "status", "") or ""
                     return  # 正常完成则结束 generator
                 except (openai.NotFoundError, openai.BadRequestError):
                     self.__class__._fallback_to_chat_cache.add(base_url)
@@ -135,6 +146,7 @@ class OpenAIProvider(BaseProvider):
                         raise
 
             # 降级：走原来的 Chat Completions 流式 API
+            self.last_stream_stop_reason = ""
             messages = self._build_messages(prompt)
             request_kwargs = self._build_chat_request_kwargs(messages, config, stream=True)
             stream = await self.async_client.chat.completions.create(**request_kwargs)
@@ -142,6 +154,11 @@ class OpenAIProvider(BaseProvider):
                 content = self._extract_text_from_stream_chunk(chunk)
                 if content:
                     yield content
+                # 记录 finish_reason（最后一个非空 chunk 的 choices[0].finish_reason）
+                if getattr(chunk, "choices", None):
+                    fr = getattr(chunk.choices[0], "finish_reason", None)
+                    if fr:
+                        self.last_stream_stop_reason = fr
         except Exception as e:
             logger.error(f"[Stream] Failed: {e}")
             raise RuntimeError(f"Failed to stream text: {str(e)}") from e
@@ -227,9 +244,20 @@ class OpenAIProvider(BaseProvider):
         input_tokens = response.usage.prompt_tokens if response.usage else 0
         output_tokens = response.usage.completion_tokens if response.usage else 0
 
+        # Responses API: stop_reason 在 output message 上
+        stop_reason = ""
+        if output:
+            for item in output:
+                if getattr(item, "type", "") == "message":
+                    stop_reason = getattr(item, "stop_reason", "") or ""
+                    break
+        if not stop_reason:
+            stop_reason = getattr(response, "status", "") or ""
+
         return GenerationResult(
             content=content,
-            token_usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+            token_usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+            stop_reason=stop_reason,
         )
 
     @staticmethod

--- a/infrastructure/persistence/database/sqlite_bible_repository.py
+++ b/infrastructure/persistence/database/sqlite_bible_repository.py
@@ -315,6 +315,51 @@ class SqliteBibleRepository(BibleRepository):
         r = self.db.fetch_one("SELECT 1 AS o FROM bibles WHERE id = ?", (bible_id,))
         return r is not None
 
+    def add_character_incremental(
+        self,
+        novel_id: str,
+        character_id: str,
+        name: str,
+        description: str,
+        relationships: List[Dict[str, str]],
+        *,
+        mental_state: str = "NORMAL",
+        verbal_tic: str = "",
+        idle_behavior: str = "",
+    ) -> None:
+        """增量添加单个角色及其关系（不触碰其他角色）。"""
+        now = self._now()
+        conn = self._conn()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO bible_characters (
+                    id, novel_id, name, description,
+                    mental_state, mental_state_reason, verbal_tic, idle_behavior,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, '', ?, ?, ?, ?)
+                """,
+                (character_id, novel_id, name, description,
+                 mental_state, verbal_tic, idle_behavior, now, now),
+            )
+            for i, rel in enumerate(relationships):
+                rid = f"{character_id}-rel-{i}-{uuid.uuid4().hex[:6]}"
+                target_name = rel.get("target", "") or ""
+                relation = rel.get("relation", "") or ""
+                desc = rel.get("description", "") or ""
+                conn.execute(
+                    """
+                    INSERT INTO bible_character_relationships
+                    (id, character_id, target_name, relation, description)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (rid, character_id, target_name, relation, desc),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
     def update_character_anchors(
         self,
         novel_id: str,

--- a/interfaces/api/dependencies.py
+++ b/interfaces/api/dependencies.py
@@ -337,6 +337,18 @@ def get_chapter_aftermath_pipeline():
     )
 
 
+def get_chapter_repair_service():
+    """章节修复：扫描短章节 + AI 扩写 + 批量修复。"""
+    from application.audit.services.chapter_repair_service import ChapterRepairService
+    return ChapterRepairService(
+        chapter_repository=get_chapter_repository(),
+        novel_repository=get_novel_repository(),
+        llm_service=get_llm_service(),
+        chapter_service=get_chapter_service(),
+        aftermath_pipeline=get_chapter_aftermath_pipeline(),
+    )
+
+
 def get_hosted_write_service() -> HostedWriteService:
     """托管连写：自动大纲 + 多章流式生成 + 可选落库。"""
     return HostedWriteService(

--- a/interfaces/api/v1/audit/chapter_repair_routes.py
+++ b/interfaces/api/v1/audit/chapter_repair_routes.py
@@ -1,0 +1,122 @@
+"""章节修复 API 端点"""
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from application.audit.services.chapter_repair_service import ChapterRepairService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["chapter-repair"])
+
+
+# ── 请求模型 ──
+
+
+class ExpandChapterRequest(BaseModel):
+    target_words: int = Field(default=4000, ge=500, le=20000, description="目标字数")
+
+
+class BatchExpandRequest(BaseModel):
+    chapter_numbers: list[int] = Field(..., min_length=1, description="章节号列表")
+    target_words: int = Field(default=4000, ge=500, le=20000, description="目标字数")
+
+
+# ── 依赖注入 ──
+
+
+def _get_service() -> ChapterRepairService:
+    from interfaces.api.dependencies import get_chapter_repair_service
+    return get_chapter_repair_service()
+
+
+# ── 端点 ──
+
+
+@router.get("/novels/{novel_id}/chapter-repair/scan")
+async def scan_short_chapters(
+    novel_id: str,
+    threshold: int = Query(default=4000, ge=100, le=20000, description="字数阈值"),
+    service: ChapterRepairService = Depends(_get_service),
+):
+    """扫描字数不足的章节"""
+    result = service.scan_short_chapters(novel_id, threshold)
+    return {
+        "novel_id": result.novel_id,
+        "threshold": result.threshold,
+        "total_chapters": result.total_chapters,
+        "short_chapters": [
+            {
+                "chapter_number": ch.chapter_number,
+                "title": ch.title,
+                "word_count": ch.word_count,
+                "status": ch.status,
+                "content_preview": ch.content_preview,
+                "severity": ch.severity,
+            }
+            for ch in result.short_chapters
+        ],
+        "summary": result.summary,
+    }
+
+
+@router.post("/novels/{novel_id}/chapter-repair/expand/{chapter_number}")
+async def expand_chapter(
+    novel_id: str,
+    chapter_number: int,
+    request: ExpandChapterRequest,
+    service: ChapterRepairService = Depends(_get_service),
+):
+    """SSE 流式扩写单个章节"""
+
+    async def event_gen():
+        try:
+            async for event in service.expand_chapter(novel_id, chapter_number, request.target_words):
+                yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+        except Exception as e:
+            logger.error(f"扩写 SSE 异常: {e}")
+            yield f"data: {json.dumps({'type': 'error', 'message': str(e)}, ensure_ascii=False)}\n\n"
+
+    return StreamingResponse(
+        event_gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/novels/{novel_id}/chapter-repair/batch-expand")
+async def batch_expand_chapters(
+    novel_id: str,
+    request: BatchExpandRequest,
+    service: ChapterRepairService = Depends(_get_service),
+):
+    """SSE 流式批量扩写章节"""
+
+    async def event_gen():
+        try:
+            async for event in service.batch_expand_chapters(
+                novel_id, request.chapter_numbers, request.target_words
+            ):
+                yield f"data: {json.dumps(event, ensure_ascii=False)}\n\n"
+        except Exception as e:
+            logger.error(f"批量扩写 SSE 异常: {e}")
+            yield f"data: {json.dumps({'type': 'error', 'message': str(e)}, ensure_ascii=False)}\n\n"
+
+    return StreamingResponse(
+        event_gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/interfaces/main.py
+++ b/interfaces/main.py
@@ -68,7 +68,7 @@ from interfaces.api.v1.engine import (
 )
 
 # Audit module
-from interfaces.api.v1.audit import chapter_review_routes, macro_refactor, chapter_element_routes
+from interfaces.api.v1.audit import chapter_review_routes, macro_refactor, chapter_element_routes, chapter_repair_routes
 
 # Analyst module
 from interfaces.api.v1.analyst import voice, narrative_state, foreshadow_ledger
@@ -543,6 +543,7 @@ app.include_router(character_scheduler_routes.router, prefix="/api/v1")  # è§’è‰
 app.include_router(chapter_review_routes.router)
 app.include_router(macro_refactor.router, prefix="/api/v1")
 app.include_router(chapter_element_routes.router)
+app.include_router(chapter_repair_routes.router, prefix="/api/v1")
 
 # Analyst module routes
 app.include_router(voice.router, prefix="/api/v1")

--- a/tests/unit/application/services/test_bible_service.py
+++ b/tests/unit/application/services/test_bible_service.py
@@ -40,9 +40,13 @@ class TestBibleService:
 
     def test_add_character(self, service, mock_repository):
         """测试添加人物"""
-        # 准备 mock 数据
-        bible = Bible(id="bible-1", novel_id=NovelId("novel-1"))
-        mock_repository.get_by_novel_id.return_value = bible
+        # 准备 mock 数据：第一次返回空 Bible，第二次返回含角色的 Bible（模拟增量写入后）
+        bible_empty = Bible(id="bible-1", novel_id=NovelId("novel-1"))
+        bible_with_char = Bible(id="bible-1", novel_id=NovelId("novel-1"))
+        bible_with_char.add_character(
+            Character(id=CharacterId("char-1"), name="主角", description="主角描述")
+        )
+        mock_repository.get_by_novel_id.side_effect = [bible_empty, bible_with_char]
 
         bible_dto = service.add_character(
             novel_id="novel-1",
@@ -56,8 +60,8 @@ class TestBibleService:
         assert bible_dto.characters[0].id == "char-1"
         assert bible_dto.characters[0].name == "主角"
 
-        # 验证调用了 save
-        mock_repository.save.assert_called_once()
+        # 验证调用了增量写入
+        mock_repository.add_character_incremental.assert_called_once()
 
     def test_add_character_bible_not_found(self, service, mock_repository):
         """测试向不存在的 Bible 添加人物"""


### PR DESCRIPTION
标题: fix(engine): 修复截断检测误判 + 新增章节修复功能

  变更说明

  1. 修复截断检测误判（stop_reason 方案）

  - GenerationResult 新增 stop_reason 字段，各 Provider（OpenAI / Anthropic / Gemini / Mock）从 API 响应中提取真实截断信号
  - _ensure_complete_ending() 优先使用 stop_reason 判断截断，仅当 stop_reason 为 "length" / "max_tokens" 时才触发续写
  - DynamicLLMService 新增 last_stream_stop_reason 属性，正确代理到实际 provider 实例
  - beat 生成的 max_tokens 从字数估算改为固定 8192，避免中文 tokenizer 差异导致截断

  2. 新增章节修复功能

  - ChapterRepairService：扫描短章节 + 单章 AI 扩写 + 批量顺序扩写
  - 扩写时自动读取前后章节内容（尾部 2000 字 + 头部 500 字），确保故事连贯
  - SSE 流式输出扩写进度
  - 前端 ChapterRepair.vue 页面：扫描表格 + 严重程度标签 + 前后对比 + 全选 + 一键审查续写
  - 工作台 AI 工具菜单增加"章节修复"入口

  架构影响
<img width="873" height="256" alt="图片" src="https://github.com/user-attachments/assets/57715d18-cd3e-4b60-86d2-7790a55a83b0" />


  测试

  pytest tests/unit -q --tb=short
  # 706 passed, 48 failed（均为预先存在的失败，与本次改动无关）

  风险说明

  - stop_reason 默认值为空字符串，完全向后兼容
  - 章节扩写的 max_tokens 上限为 min(target_words*3, 16384)，防止 token 浪费
  - 批量扩写为顺序执行，每章依赖前一章扩写结果，确保衔接


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chapter Repair Tool: scan novels for chapters below word threshold, AI-expand individual chapters with streaming progress, batch-expand multiple chapters simultaneously with cancellation support, and compare expanded vs. original content side-by-side.
  * New dedicated Chapter Repair interface accessible via AI Tools menu.

* **Improvements**
  * Enhanced AI stop reason tracking across all language model providers for better generation completion detection.
  * Improved Autopilot daemon beat-level stop detection and continuation logic for more reliable writing generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->