### PR TITLE
fix(engine): prompt plaza edits not taking effect in generation (#146)

### DIFF
--- a/application/workflows/auto_novel_generation_workflow.py
+++ b/application/workflows/auto_novel_generation_workflow.py
@@ -1741,7 +1741,12 @@ class AutoNovelGenerationWorkflow:
                 "PromptRegistry 不可用 (node_key=%s): %s", _WORKFLOW_CHAPTER_GEN_NODE_KEY, exc
             )
 
-        logger.debug("CPMS: 使用硬编码回退 system 模板")
+        # ★ 修复 #146：将降级日志提升至 WARNING，便于排查提示词广场编辑不生效的问题
+        logger.warning(
+            "CPMS: 使用硬编码回退 system 模板 (node_key=%s)。"
+            "可能原因：PromptRegistry 不可用，或数据库中该节点未正确播种。",
+            _WORKFLOW_CHAPTER_GEN_NODE_KEY,
+        )
         return _FALLBACK_SYSTEM_TEMPLATE
 
     def _get_workflow_user_template(self) -> str:
@@ -1768,7 +1773,11 @@ class AutoNovelGenerationWorkflow:
                 "PromptRegistry 不可用 (node_key=%s): %s", _WORKFLOW_CHAPTER_GEN_NODE_KEY, exc
             )
 
-        logger.debug("CPMS: 使用硬编码回退 user_template")
+        logger.warning(
+            "CPMS: 使用硬编码回退 user_template (node_key=%s)。"
+            "可能原因：PromptRegistry 不可用，或数据库中该节点未正确播种。",
+            _WORKFLOW_CHAPTER_GEN_NODE_KEY,
+        )
         return _FALLBACK_USER_TEMPLATE
 
     async def _extract_chapter_state(self, content: str, chapter_number: int) -> ChapterState:

--- a/infrastructure/ai/prompt_manager.py
+++ b/infrastructure/ai/prompt_manager.py
@@ -905,6 +905,10 @@ class PromptManager:
         db.execute(sql, params)
         db.commit()
 
+        # ★ 修复 #146：节点更新后使 PromptRegistry 缓存失效，
+        # 确保生成管线能立即读取到最新模板。
+        self._invalidate_registry_cache(node_id)
+
         return self.get_node(node_id, by_key=False)
 
     def rollback_node(self, node_id: str,
@@ -1082,6 +1086,20 @@ class PromptManager:
         for node in nodes:
             if node.active_version_id and node.active_version_id in ver_map:
                 node.set_active_version(ver_map[node.active_version_id])
+
+    @staticmethod
+    def _invalidate_registry_cache(node_key_or_id: str) -> None:
+        """使 PromptRegistry 缓存失效（node_key 或 node_id 均可）。"""
+        try:
+            from infrastructure.ai.prompt_registry import get_prompt_registry
+            registry = get_prompt_registry()
+            # 尝试按 node_key 失效；如果是 node_id 则清除全部缓存（更安全）
+            if '-' in node_key_or_id and len(node_key_or_id) < 50:
+                registry.invalidate_cache(node_key_or_id)
+            else:
+                registry.invalidate_cache()
+        except Exception:
+            pass  # Registry 不可用时静默跳过
 
     @staticmethod
     def _get_current_version(db, node_id: str) -> Optional[VersionInfo]:

--- a/interfaces/api/v1/workbench/llm_control.py
+++ b/interfaces/api/v1/workbench/llm_control.py
@@ -266,6 +266,15 @@ def _invalidate_plaza_cache() -> None:
     _plaza_cache = {}
     _plaza_cache_ts = 0.0
 
+    # ★ 修复 #146：同时清除 PromptRegistry 缓存（TTL=300s），否则
+    # 生成管线在 5 分钟内仍会读取旧版 DB 快照，导致提示词广场编辑不生效。
+    try:
+        from infrastructure.ai.prompt_registry import get_prompt_registry
+        registry = get_prompt_registry()
+        registry.invalidate_cache()
+    except Exception:
+        pass  # Registry 不可用时静默跳过，不影响 API 层功能
+
 
 @router.get('/prompts/plaza-init')
 async def plaza_init() -> Dict[str, Any]:


### PR DESCRIPTION
## 变更类型

- [x] `fix` Bug 修复

---

## 变更说明

修复提示词广场编辑后不生效的问题。用户在提示词广场修改提示词并保存后，章节生成仍使用旧版本提示词。

### 根因分析

`PromptRegistry` 对提示词节点有 300 秒（5 分钟）的内存缓存。用户编辑提示词后，API 层的 `_plaza_cache` 会被清除，但 `PromptRegistry` 的缓存未同步失效，导致生成管线在 5 分钟内仍读取旧版 DB 快照。

### 修复内容

1. **`_invalidate_plaza_cache()` 扩展** — 所有提示词写操作（编辑、回滚、新建、删除、导入）现在同时清除 `PromptRegistry` 缓存，确保生成管线立即读取到最新版本。

2. **`PromptManager.update_node()` 补充失效** — 数据库层更新节点后主动调用 `_invalidate_registry_cache()`，作为 API 层失效的兜底。

3. **降级日志级别提升** — `_get_workflow_system_template()` 和 `_get_workflow_user_template()` 的硬编码回退日志从 `DEBUG` 提升至 `WARNING`，便于排查管道是否意外降级到硬编码模板。

---

## 架构影响

- 涉及层级：`interfaces` / `infrastructure` / `application`
- 是否修改现有 API 契约：否
- 是否新增数据库表/字段：否

---

## 测试

- 修改不涉及数据库 schema 变更
- 所有改动为缓存失效逻辑，不影响正常读取路径
- `_invalidate_registry_cache()` 包含异常捕获，`PromptRegistry` 不可用时静默跳过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened cache invalidation to ensure prompt updates and edits are immediately visible throughout the system.
  * Enhanced logging visibility for fallback template scenarios by elevating alerts to warning level.

* **Chores**
  * Refined internal cache management to improve system consistency and data freshness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shenminglinyi/PlotPilot/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->