### PR TITLE
fix(planning): handle empty LLM response in macro plan parsing (#162)

### DIFF
--- a/application/blueprint/services/continuous_planning_service.py
+++ b/application/blueprint/services/continuous_planning_service.py
@@ -1868,6 +1868,11 @@ class ContinuousPlanningService:
 
         cleaned = _sanitize_llm_json_output(content)
         cleaned = _extract_outer_json_value(cleaned)
+
+        # ★ 修复 #162：LLM 返回空响应时提前返回友好错误，而非抛 JSONDecodeError
+        if not cleaned:
+            raise ValueError("LLM 返回内容为空，无法解析规划数据")
+
         try:
             return json.loads(cleaned)
         except json.JSONDecodeError:

--- a/application/core/services/export_service.py
+++ b/application/core/services/export_service.py
@@ -92,6 +92,11 @@ class ExportService:
             chapters = self.chapter_repository.list_by_novel(NovelId(novel_id))
             chapters.sort(key=lambda x: x.number)
             logger.info("导出: %s, 章节数 %s", novel.title, len(chapters))
+            # ★ 修复 #143：记录每章内容长度，便于排查导出内容为空的问题
+            for ch_debug in chapters:
+                ch_len = len(ch_debug.content or "")
+                if ch_len == 0:
+                    logger.warning("导出警告: 章节 %d (%s) 内容为空", ch_debug.number, ch_debug.title or "无标题")
             if format == "epub":
                 result = self._export_to_epub(novel, chapters)
             elif format == "pdf":
@@ -192,7 +197,9 @@ class ExportService:
 
         book.toc = tuple([intro] + spine_items[1:])
         book.add_item(epub.EpubNcx())
-        # 不使用空 EpubNav（ebooklib 生成 nav 时会解析正文，空文档会触发 lxml Document is empty）
+        # ★ 修复 #143：添加 EpubNav 导航文档（EPUB 3 标准要求）
+        # 缺失 nav 文档会导致部分阅读器只显示目录而无法加载正文内容
+        book.add_item(epub.EpubNav())
         book.spine = spine_items
 
         tmp_path: Optional[str] = None


### PR DESCRIPTION
## 变更类型

- [x] `fix` Bug 修复

---

## 变更说明

修复使用 glm-4.5-air 等模型时，LLM 偶尔返回空响应导致的 `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` 错误。

### 根因

`_parse_llm_response()` 方法在清理 LLM 返回内容后，直接调用 `json.loads()`。当模型返回空字符串时（可能由于 API 限流、网络问题或模型自身问题），`json.loads("")` 会抛出难以理解的 JSONDecodeError。

### 修复

在 `json.loads()` 之前增加空内容检查，返回描述性 `ValueError`，便于 `autopilot_daemon` 的现有错误处理逻辑识别并优雅降级。

---

## 架构影响

- 涉及层级：`application`
- 是否修改现有 API 契约：否
- 是否新增数据库表/字段：否

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling with clearer messages when content processing fails
  * Improved EPUB export generation with proper navigation document inclusion for better file compatibility
  * Added diagnostic logging for content-related export issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shenminglinyi/PlotPilot/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->