### PR TITLE
fix: 处理问题 #173

### DIFF
--- a/tools/plotpilot.bat
+++ b/tools/plotpilot.bat
@@ -187,7 +187,7 @@ for /f "tokens=5" %%a in ('netstat -ano 2^>nul ^| findstr ":8006 .*LISTENING"') 
 ::  ② 用 start "" 把 GUI 进程彻底分离，bat 不等待
 ::  ③ bat 立即 exit，黑框消失，GUI 独立存活
 
-:: 安全提取目录（%~dpI 处理带空格/特殊字符的路径极其稳健）
+:: 安全提取 Python 所在目录（兼容带空格/特殊字符的路径）
 for %%I in ("%PYTHON_EXE%") do set "PYTHON_DIR=%%~dpI"
 set "PYTHONW_EXE=%PYTHON_DIR%pythonw.exe"
 


### PR DESCRIPTION
## Summary

- Remove the raw `%~dpI` token from the Windows launcher comment
- Keep the functional `for %%I ... %%~dpI` path extraction logic unchanged
- Avoid `cmd.exe` parsing the comment as an invalid batch parameter substitution on Windows

## Verification

- `cmd.exe //d //c 'C:\Users\liaoy\AppData\Local\Temp\plotpilot_issue_173_old.bat'` → reproduced the old `%~dpI` comment parsing failure
- `cmd.exe //d //c 'C:\Users\liaoy\AppData\Local\Temp\plotpilot_issue_173_new.bat'` → new comment variant printed `NEW_PASS`
- `cmd.exe //d //c 'C:\Users\liaoy\AppData\Local\Temp\plotpilot_issue_173_extract_new.bat'` → verified `PYTHON_DIR=C:\Program Files\Python314\` and `PYTHONW_EXE=C:\Program Files\Python314\pythonw.exe`
- `git diff --check`

Closes #173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python installer launcher reliability by enhancing path handling for installations located in directories with spaces and special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->