### PR TITLE
fix: 处理问题 #189

### DIFF
--- a/application/engine/services/chapter_bridge_service.py
+++ b/application/engine/services/chapter_bridge_service.py
@@ -19,7 +19,7 @@
 
   3. 衔接度自检（check_continuity）：
      章节生成后，用轻量 LLM 检查首段与前章桥段的衔接度，
-     低于阈值则自动修整首段（最多 2 轮）。
+     默认只告警；调用方显式配置自动修整阈值后才改写首段。
 
 性能设计：
   - 桥段提取：复用 narrative_sync 的 LLM 调用，零额外开销
@@ -57,14 +57,15 @@ class ChapterContinuityPolicy:
     """
 
     warn_threshold: float = 0.6
-    auto_fix_threshold: float = 0.4
+    # 默认仅告警，避免无人工确认时静默改写正文；调用方可用正阈值显式开启。
+    auto_fix_threshold: float = 0.0
     max_fix_rounds: int = 2
 
     def needs_attention(self, score: float) -> bool:
         return score < self.warn_threshold
 
     def should_auto_fix(self, score: float) -> bool:
-        return score < self.auto_fix_threshold
+        return self.auto_fix_threshold > 0 and score < self.auto_fix_threshold
 
 
 @dataclass

--- a/engine/runtime/daemon_host.py
+++ b/engine/runtime/daemon_host.py
@@ -875,10 +875,10 @@ class DaemonHostMixin:
         chapter_number: int,
         content: str,
     ) -> str:
-        """🔗 衔接自检：检查章节首段与前章桥段的衔接度，低于阈值则自动修整。
+        """🔗 衔接自检：检查章节首段与前章桥段的衔接度。
 
         仅在非第 1 章时触发。约 ~200 token 的轻量 LLM 调用。
-        如果衔接度 < 0.6，自动修整首段（最多 2 轮）。
+        默认只告警；只有策略显式开启自动修整阈值时才改写首段。
         """
         try:
             from application.engine.services.chapter_bridge_service import ChapterBridgeService

--- a/engine/runtime/legacy_writing_delegate.py
+++ b/engine/runtime/legacy_writing_delegate.py
@@ -1215,7 +1215,7 @@ async def run_legacy_writing(host: Any, novel: Novel) -> None:
     host._beat_exhausted_rewrite_count.pop((novel.novel_id.value, chapter_num), None)
 
     # 🔗 衔接引擎：章节完成后自检衔接度（非第 1 章）
-    # 如果衔接度 < 0.6，自动修整首段（最多 2 轮）
+    # 默认只告警；显式启用自动修整策略时才改写首段。
     if chapter_num > 1:
         # ★ 子步骤状态：衔接自检
         host._update_shared_state(

--- a/tests/unit/application/engine/test_chapter_continuity.py
+++ b/tests/unit/application/engine/test_chapter_continuity.py
@@ -7,6 +7,15 @@ from application.engine.services.chapter_bridge_service import (
 )
 
 
+def test_default_continuity_policy_is_warning_only():
+    policy = ChapterContinuityPolicy()
+
+    assert policy.needs_attention(0.39) is True
+    assert policy.should_auto_fix(0.39) is False
+    assert policy.should_auto_fix(0.0) is False
+    assert policy.should_auto_fix(-0.01) is False
+
+
 def test_continuity_policy_separates_warning_from_auto_fix():
     policy = ChapterContinuityPolicy(warn_threshold=0.6, auto_fix_threshold=0.4)
 
@@ -24,6 +33,28 @@ def test_bridge_service_uses_policy_for_opening_fix():
 
     assert service.should_auto_fix_opening(ContinuityCheckResult(score=0.46)) is False
     assert service.should_auto_fix_opening(ContinuityCheckResult(score=0.44)) is True
+
+
+@pytest.mark.asyncio
+async def test_default_bridge_service_does_not_auto_rewrite_opening(monkeypatch):
+    from application.engine.services.chapter_bridge_service import ChapterBridge, ChapterBridgeService
+
+    service = ChapterBridgeService(llm_service=object())
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("default continuity policy should not rewrite openings")
+
+    monkeypatch.setattr(service, "_invoke_helper_text", fail_if_called)
+    content = "原始首段。" + "后续正文。" * 80
+    fixed = await service.auto_fix_opening(
+        "novel-1",
+        2,
+        content,
+        ChapterBridge(chapter_number=1, suspense_hook="前章悬念"),
+        ContinuityCheckResult(score=0.0, issues=["首段衔接不足"]),
+    )
+
+    assert fixed == content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Make chapter continuity opening auto-fix opt-in by defaulting `ChapterContinuityPolicy.auto_fix_threshold` to `0.0`
- Keep continuity warnings active while preventing default silent manuscript rewrites
- Preserve explicit opt-in auto-fix behavior for callers that configure a positive threshold
- Update nearby comments to describe warning-only default behavior

## Verification

- `PYTHONPATH='/e/Claude Projects/PlotPilot Pr/PlotPilot' python -m pytest '/e/Claude Projects/PlotPilot Pr/PlotPilot/tests/unit/application/engine/test_chapter_continuity.py' -v` → 5 passed
- `python -m py_compile '/e/Claude Projects/PlotPilot Pr/PlotPilot/application/engine/services/chapter_bridge_service.py' '/e/Claude Projects/PlotPilot Pr/PlotPilot/engine/runtime/daemon_host.py' '/e/Claude Projects/PlotPilot Pr/PlotPilot/engine/runtime/legacy_writing_delegate.py' '/e/Claude Projects/PlotPilot Pr/PlotPilot/tests/unit/application/engine/test_chapter_continuity.py'`
- `git diff --check`

Closes #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Chapter continuity validation now defaults to warning-only mode; automatic opening adjustments require explicit policy configuration.

* **Tests**
  * Added tests to verify default continuity behavior and confirm auto-fix remains disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->