### PR TITLE
feat: 接入 Sidecar M4 runtime adapter

### DIFF
--- a/application/blueprint/services/beat_sheet_service.py
+++ b/application/blueprint/services/beat_sheet_service.py
@@ -6,6 +6,7 @@
 import uuid
 import json
 import logging
+from hashlib import sha256
 from typing import Dict, List, Optional, TYPE_CHECKING
 from datetime import datetime
 
@@ -17,6 +18,7 @@ from domain.novel.repositories.storyline_repository import StorylineRepository
 from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
 from application.ai.trace_context import ensure_trace
+from application.workflows.plotpilot_sidecar_m4_adapter import enhance_prompt_for_plotpilot_m4
 
 if TYPE_CHECKING:
     from infrastructure.ai.chromadb_vector_store import ChromaDBVectorStore
@@ -47,6 +49,32 @@ class BeatSheetService:
         self.llm_service = llm_service
         self.vector_store = vector_store
         self.bible_service = bible_service
+        self._sidecar_traces: List[Dict] = []
+        self._last_sidecar_trace: Optional[Dict] = None
+
+    def _apply_sidecar_m4_enhancement(self, prompt: Prompt) -> Prompt:
+        enhanced_prompt, sidecar_trace = enhance_prompt_for_plotpilot_m4(
+            prompt,
+            node_type="beat_sheet",
+            native_call_boundary={
+                "source_file": "systems/PlotPilot/application/blueprint/services/beat_sheet_service.py",
+                "source_function": "BeatSheetService.generate_beat_sheet",
+            },
+        )
+        self._last_sidecar_trace = sidecar_trace
+        self._sidecar_traces.append(sidecar_trace)
+        return enhanced_prompt
+
+    def _record_sidecar_output_evidence(self, content: str) -> None:
+        trace = self._last_sidecar_trace
+        if not trace or not trace.get("enhancement_applied"):
+            return
+        output = (content or "").strip()
+        trace["enhanced_before_native_call"] = True
+        trace["output_evidence"] = {
+            "output_char_count": len(output),
+            "output_excerpt_hash": sha256(output[:1200].encode("utf-8")).hexdigest(),
+        }
 
     async def generate_beat_sheet(
         self,
@@ -69,11 +97,15 @@ class BeatSheetService:
 
         # 2. 构建提示词
         prompt = self._build_beat_sheet_prompt(outline, context)
+        prompt = self._apply_sidecar_m4_enhancement(prompt)
 
         # 3. 调用 LLM 生成节拍表
         ensure_trace(novel_id="", stage="blueprint.beat.generate", stage_label="节拍生成")
         config = GenerationConfig(max_tokens=2048, temperature=0.7)
         response = await self.llm_service.generate(prompt, config)
+        self._record_sidecar_output_evidence(
+            response.content if hasattr(response, "content") else str(response)
+        )
 
         # 4. 解析响应
         scenes = self._parse_llm_response(response)

--- a/application/blueprint/services/setup_main_plot_suggestion_service.py
+++ b/application/blueprint/services/setup_main_plot_suggestion_service.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 import json
 import logging
 import re
+from hashlib import sha256
 from typing import Any, AsyncIterator, Dict, List, Mapping, Optional, Tuple
 
 from domain.ai.services.llm_service import GenerationConfig, LLMService
 from domain.ai.value_objects.prompt import Prompt
+from application.workflows.plotpilot_sidecar_m4_adapter import enhance_prompt_for_plotpilot_m4
 from application.world.services.bible_service import BibleService
 from application.core.services.novel_service import NovelService
 from application.blueprint.services.setup_context_builder import SetupContextBuilder
@@ -112,6 +114,34 @@ class SetupMainPlotSuggestionService:
             bible_service=bible_service,
             novel_service=novel_service,
         )
+        self._sidecar_traces: List[Dict[str, Any]] = []
+        self._last_sidecar_trace: Optional[Dict[str, Any]] = None
+
+    def _apply_sidecar_m4_enhancement(self, prompt: Prompt, *, source_function: str) -> Prompt:
+        enhanced_prompt, sidecar_trace = enhance_prompt_for_plotpilot_m4(
+            prompt,
+            node_type="main_plot",
+            native_call_boundary={
+                "source_file": "systems/PlotPilot/application/blueprint/services/setup_main_plot_suggestion_service.py",
+                "source_function": source_function,
+            },
+        )
+        if not hasattr(self, "_sidecar_traces"):
+            self._sidecar_traces = []
+        self._last_sidecar_trace = sidecar_trace
+        self._sidecar_traces.append(sidecar_trace)
+        return enhanced_prompt
+
+    def _record_sidecar_output_evidence(self, content: str) -> None:
+        trace = getattr(self, "_last_sidecar_trace", None)
+        if not trace or not trace.get("enhancement_applied"):
+            return
+        output = (content or "").strip()
+        trace["enhanced_before_native_call"] = True
+        trace["output_evidence"] = {
+            "output_char_count": len(output),
+            "output_excerpt_hash": sha256(output[:1200].encode("utf-8")).hexdigest(),
+        }
 
     def build_context(self, novel_id: str) -> Dict[str, Any]:
         """公开的向导上下文构建入口，供 AI Invocation 路由复用。"""
@@ -344,8 +374,13 @@ class SetupMainPlotSuggestionService:
 
     async def suggest_options(self, novel_id: str) -> List[Dict[str, Any]]:
         ctx, prompt, config = self._build_prompt_and_config(novel_id)
+        prompt = self._apply_sidecar_m4_enhancement(
+            prompt,
+            source_function="SetupMainPlotSuggestionService.suggest_options",
+        )
         try:
             result = await self._llm.generate(prompt, config)
+            self._record_sidecar_output_evidence(result.content)
             return self.parse_suggested_options(result.content, ctx=ctx)
         except Exception as e:
             logger.warning("Main plot suggestion LLM parse failed: %s", e)
@@ -354,6 +389,10 @@ class SetupMainPlotSuggestionService:
     async def stream_suggest_options(self, novel_id: str) -> AsyncIterator[Dict[str, Any]]:
         """流式推演主线候选：chunk 透传 + option 增量解析；不合同时返回错误事件。"""
         ctx, prompt, config = self._build_prompt_and_config(novel_id)
+        prompt = self._apply_sidecar_m4_enhancement(
+            prompt,
+            source_function="SetupMainPlotSuggestionService.stream_suggest_options",
+        )
         buf = ""
         full_buf = ""
         parsed_options: List[Dict[str, Any]] = []
@@ -396,6 +435,7 @@ class SetupMainPlotSuggestionService:
             if len(parsed_options) < 3:
                 raise MainPlotSuggestionContractError("主线候选数量不足：需要至少 3 条有效方案")
 
+            self._record_sidecar_output_evidence(full_buf)
             yield {"type": "done", "plot_options": parsed_options[:3]}
         except Exception as e:
             logger.warning("Main plot suggestion stream failed: %s", e)

--- a/application/engine/dag/plan/__init__.py
+++ b/application/engine/dag/plan/__init__.py
@@ -4,6 +4,7 @@
 扩展新规划能力时请增加 atoms / extensions，避免改 core 字段语义。
 """
 
+from application.engine.dag.plan import outline_beat_planner
 from application.engine.dag.plan.outline_beat_planner import render_cpms_outline_partition_prompts
 from application.engine.dag.plan.schema import (
     ChapterExecutionPlan,
@@ -17,5 +18,6 @@ __all__ = [
     "ChapterExecutionPlan",
     "PlanningEnvelope",
     "PlanAtomSpec",
+    "outline_beat_planner",
     "render_cpms_outline_partition_prompts",
 ]

--- a/application/engine/dag/plan/outline_beat_planner.py
+++ b/application/engine/dag/plan/outline_beat_planner.py
@@ -23,6 +23,7 @@ from application.engine.dag.plan.schema import (
     PlanDecompositionMode,
     PlanningEnvelope,
 )
+from application.workflows.plotpilot_sidecar_m4_adapter import enhance_prompt_for_plotpilot_m4
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +289,7 @@ def _extract_json_payload(text: str) -> Dict[str, Any]:
 
 
 OutlinePartitionEmitDelta = Optional[Callable[[str], Awaitable[None]]]
+OutlinePartitionTraceSink = Optional[Callable[[Dict[str, Any]], None]]
 
 
 async def llm_decompose_outline(
@@ -297,6 +299,7 @@ async def llm_decompose_outline(
     system: str = "",
     user: str = "",
     emit_delta: OutlinePartitionEmitDelta = None,
+    sidecar_trace_sink: OutlinePartitionTraceSink = None,
     llm_service: Any = None,
 ) -> Optional[List[PlanAtomSpec]]:
     """调用 LLM 拆 atoms。未显式传入 ``user`` 时从 CPMS ``outline-beat-partition`` 渲染。
@@ -320,6 +323,16 @@ async def llm_decompose_outline(
 
         llm = _resolve_llm_service(llm_service)
         prompt = Prompt(system=system.strip() if system else "", user=user)
+        prompt, sidecar_trace = enhance_prompt_for_plotpilot_m4(
+            prompt,
+            node_type="outline_partition",
+            native_call_boundary={
+                "source_file": "systems/PlotPilot/application/engine/dag/plan/outline_beat_planner.py",
+                "source_function": "outline_beat_planner.llm_decompose_outline",
+            },
+        )
+        if sidecar_trace_sink:
+            sidecar_trace_sink(sidecar_trace)
         config = GenerationConfig(max_tokens=2000, temperature=0.45)
         pieces: List[str] = []
         async for piece in llm.stream_generate(prompt, config):
@@ -328,6 +341,12 @@ async def llm_decompose_outline(
                 if emit_delta:
                     await emit_delta(piece)
         raw_text = "".join(pieces).strip()
+        if sidecar_trace.get("enhancement_applied"):
+            sidecar_trace["enhanced_before_native_call"] = True
+            sidecar_trace["output_evidence"] = {
+                "output_char_count": len(raw_text),
+                "output_excerpt_hash": hashlib.sha256(raw_text[:1200].encode("utf-8")).hexdigest(),
+            }
         from application.ai.structured_json_pipeline import sanitize_llm_output
 
         cleaned = sanitize_llm_output(raw_text)
@@ -390,17 +409,21 @@ async def build_chapter_execution_plan_async(
             mode = PlanDecompositionMode.STRUCTURED_OUTLINE.value
 
     if atoms is None and use_llm:
+        sidecar_traces: List[Dict[str, Any]] = []
         llm_atoms = await llm_decompose_outline(
             raw,
             target_chapter_words,
             system=llm_system,
             user=llm_user,
             emit_delta=emit_llm_delta,
+            sidecar_trace_sink=sidecar_traces.append,
             llm_service=llm_service,
         )
         if llm_atoms:
             atoms = llm_atoms
             mode = PlanDecompositionMode.LLM_OUTLINE_DECOMPOSE.value
+        if sidecar_traces:
+            prov["sidecar_traces"] = sidecar_traces
 
     if atoms is None:
         atoms = [

--- a/application/engine/dag/registry.py
+++ b/application/engine/dag/registry.py
@@ -8,6 +8,9 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Set, Type
 
+from domain.ai.value_objects.prompt import Prompt
+from application.workflows.plotpilot_sidecar_m4_adapter import enhance_prompt_for_plotpilot_m4
+
 from application.engine.dag.models import (
     CPMSInjectionPoint,
     NodeCategory,
@@ -22,6 +25,13 @@ from application.engine.dag.models import (
 
 logger = logging.getLogger(__name__)
 
+_DAG_SIDECAR_M4_NODE_TYPES = {
+    "planning_beat_sheet": "planning_beat_sheet",
+    "planning_quick_macro": "planning_quick_macro",
+    "planning_act": "planning_act",
+    "exec_writer": "dag_exec_writer",
+}
+
 
 # ─── 节点基类 ───
 
@@ -35,6 +45,8 @@ class BaseNode(ABC):
     def __init__(self, config: Optional[NodeConfig] = None):
         self._config = config or NodeConfig()
         self._cpms_cache: Dict[str, str] = {}  # node_key -> rendered text cache
+        self._sidecar_traces: List[Dict[str, Any]] = []
+        self._last_sidecar_trace: Optional[Dict[str, Any]] = None
 
     @abstractmethod
     async def execute(self, inputs: Dict[str, Any], context: Dict[str, Any]) -> NodeResult:
@@ -154,10 +166,48 @@ class BaseNode(ABC):
             for key, value in var_map.items():
                 user = user.replace(f"{{{{{key}}}}}", str(value))
 
-        return {
+        resolved = {
             "system": system,
             "user": user,
             "source": prompt_dict["source"],
+        }
+        return self._apply_sidecar_m4_to_resolved_prompt(resolved)
+
+    def _apply_sidecar_m4_to_resolved_prompt(self, resolved: Dict[str, str]) -> Dict[str, str]:
+        if not self.meta:
+            return resolved
+        node_type = _DAG_SIDECAR_M4_NODE_TYPES.get(self.meta.node_type)
+        if not node_type:
+            return resolved
+        system = (resolved.get("system") or "").strip()
+        user = (resolved.get("user") or "").strip()
+        if not system or not user:
+            return resolved
+        try:
+            enhanced_prompt, sidecar_trace = enhance_prompt_for_plotpilot_m4(
+                Prompt(system=system, user=user),
+                node_type=node_type,
+                native_call_boundary={
+                    "source_file": "systems/PlotPilot/application/engine/dag/registry.py",
+                    "source_function": "BaseNode.resolve_prompt",
+                    "dag_node_type": self.meta.node_type,
+                },
+            )
+        except Exception as exc:
+            logger.warning("DAG Sidecar M4 prompt enhancement failed: %s", exc)
+            return resolved
+
+        self._last_sidecar_trace = sidecar_trace
+        self._sidecar_traces.append(sidecar_trace)
+        if not sidecar_trace.get("enhancement_applied"):
+            resolved["sidecar_trace"] = sidecar_trace
+            return resolved
+
+        return {
+            **resolved,
+            "system": enhanced_prompt.system,
+            "user": enhanced_prompt.user,
+            "sidecar_trace": sidecar_trace,
         }
 
     def _fetch_cpms_injection(self, injection: CPMSInjectionPoint) -> str:

--- a/application/engine/dtos/generation_result.py
+++ b/application/engine/dtos/generation_result.py
@@ -1,6 +1,6 @@
 """生成结果 DTO"""
 from dataclasses import dataclass
-from typing import Optional, List, TYPE_CHECKING
+from typing import Optional, List, TYPE_CHECKING, Dict, Any
 from domain.novel.value_objects.consistency_report import ConsistencyReport
 from application.audit.dtos.ghost_annotation import GhostAnnotation
 
@@ -20,6 +20,7 @@ class GenerationResult:
     token_count: int
     ghost_annotations: List[GhostAnnotation] = None  # 幽灵批注（冲突检测结果）
     style_warnings: List['ClicheHit'] = None  # 风格警告（俗套句式检测结果）
+    sidecar_traces: List[Dict[str, Any]] = None  # Sidecar M4 生成前增强 trace
 
     def __post_init__(self):
         if not self.content or not self.content.strip():
@@ -34,3 +35,6 @@ class GenerationResult:
         # 确保 style_warnings 不为 None
         if self.style_warnings is None:
             object.__setattr__(self, 'style_warnings', [])
+        # 确保 sidecar_traces 不为 None
+        if self.sidecar_traces is None:
+            object.__setattr__(self, 'sidecar_traces', [])

--- a/application/workflows/__init__.py
+++ b/application/workflows/__init__.py
@@ -1,4 +1,11 @@
 """工作流层"""
-from application.workflows.auto_novel_generation_workflow import AutoNovelGenerationWorkflow
 
 __all__ = ["AutoNovelGenerationWorkflow"]
+
+
+def __getattr__(name):
+    if name == "AutoNovelGenerationWorkflow":
+        from application.workflows.auto_novel_generation_workflow import AutoNovelGenerationWorkflow
+
+        return AutoNovelGenerationWorkflow
+    raise AttributeError(name)

--- a/application/workflows/auto_novel_generation_workflow.py
+++ b/application/workflows/auto_novel_generation_workflow.py
@@ -5,6 +5,7 @@
 import asyncio
 import logging
 import re
+from hashlib import sha256
 from typing import Tuple, Dict, Any, AsyncIterator, Optional, List, Callable, Awaitable
 from application.engine.services.context_builder import ContextBuilder
 from application.analyst.services.state_extractor import StateExtractor
@@ -27,6 +28,7 @@ from domain.ai.services.llm_service import LLMService, GenerationConfig
 from domain.ai.value_objects.prompt import Prompt
 from application.ai.llm_output_sanitize import strip_reasoning_artifacts
 from application.ai.prose_fragment_aggregator import aggregate_inline_prose_fragments
+from application.workflows.plotpilot_sidecar_m4_adapter import enhance_prompt_for_plotpilot_m4
 from application.workflows.beat_continuation import format_prior_draft_for_prompt
 from application.workflows.prose_discipline import build_prose_discipline_block
 
@@ -277,6 +279,8 @@ class AutoNovelGenerationWorkflow:
         # V6 运行时上下文缓存（供 _build_prompt 使用）
         self._current_novel_id: str = ""
         self._current_chapter_number: int = 0
+        self._sidecar_traces: List[Dict[str, Any]] = []
+        self._last_sidecar_trace: Optional[Dict[str, Any]] = None
         
         # 强制初始化 StateExtractor（如果未提供）
         if state_extractor is None:
@@ -587,6 +591,8 @@ class AutoNovelGenerationWorkflow:
         # ★ V6: 缓存当前 novel_id/chapter_number 供 _build_prompt 中 MemoryEngine 使用
         self._current_novel_id = novel_id
         self._current_chapter_number = chapter_number
+        self._sidecar_traces = []
+        self._last_sidecar_trace = None
 
         logger.info("阶段 1-2: 规划 + 结构化上下文（prepare_chapter_generation）")
         bundle = self.prepare_chapter_generation(
@@ -647,7 +653,8 @@ class AutoNovelGenerationWorkflow:
             context_used=context,
             token_count=token_count,
             ghost_annotations=ghost_annotations,
-            style_warnings=style_warnings
+            style_warnings=style_warnings,
+            sidecar_traces=list(self._sidecar_traces),
         )
 
 
@@ -690,6 +697,8 @@ class AutoNovelGenerationWorkflow:
             logger.info(f"========================================")
             logger.info(f"开始流式生成章节: 小说={novel_id}, 章节={chapter_number}")
             logger.info(f"========================================")
+            self._sidecar_traces = []
+            self._last_sidecar_trace = None
 
             yield {"type": "phase", "phase": "planning"}
             yield {"type": "phase", "phase": "context"}
@@ -800,6 +809,7 @@ class AutoNovelGenerationWorkflow:
                 "total_tokens": total_tokens,
                 "chars": len(content),
                 "beats": [],
+                "sidecar_traces": list(self._sidecar_traces),
                 "ghost_annotations": [ann.to_dict() for ann in ghost_annotations],
                 "style_warnings": [
                     {
@@ -840,10 +850,16 @@ class AutoNovelGenerationWorkflow:
                     f"请写第{chapter_number}章的要点大纲。"
                 ),
             )
+            outline_prompt = self._apply_sidecar_m4_enhancement(
+                outline_prompt,
+                node_type="chapter_outline",
+                source_function="AutoNovelGenerationWorkflow.suggest_outline",
+            )
             cfg = GenerationConfig(max_tokens=1024, temperature=0.7)
             out = await self.llm_service.generate(outline_prompt, cfg)
             text = strip_reasoning_artifacts((out.content or "").strip())
             if text:
+                self._record_sidecar_output_evidence(text)
                 return text
         except Exception as e:
             logger.warning("suggest_outline failed: %s", e)
@@ -1014,6 +1030,40 @@ class AutoNovelGenerationWorkflow:
 
         return "\n".join(parts)
 
+    def _apply_sidecar_m4_enhancement(
+        self,
+        prompt: Prompt,
+        *,
+        source_function: str,
+        node_type: Optional[str] = None,
+        beat_prompt: Optional[str] = None,
+        beat_mode: bool = False,
+    ) -> Prompt:
+        enhanced_prompt, sidecar_trace = enhance_prompt_for_plotpilot_m4(
+            prompt,
+            beat_prompt=beat_prompt,
+            beat_mode=beat_mode,
+            node_type=node_type,
+            native_call_boundary={
+                "source_file": "systems/PlotPilot/application/workflows/auto_novel_generation_workflow.py",
+                "source_function": source_function,
+            },
+        )
+        self._last_sidecar_trace = sidecar_trace
+        self._sidecar_traces.append(sidecar_trace)
+        return enhanced_prompt
+
+    def _record_sidecar_output_evidence(self, content: str) -> None:
+        trace = self._last_sidecar_trace
+        if not trace or not trace.get("enhancement_applied"):
+            return
+        output = (content or "").strip()
+        trace["enhanced_before_native_call"] = True
+        trace["output_evidence"] = {
+            "output_char_count": len(output),
+            "output_excerpt_hash": sha256(output[:1200].encode("utf-8")).hexdigest(),
+        }
+
     def build_chapter_prompt(
         self,
         context: str,
@@ -1060,6 +1110,9 @@ class AutoNovelGenerationWorkflow:
         chapter_draft_so_far: str = "",
         regeneration_guidance: Optional[str] = None,
         chapter_target_words: Optional[int] = None,
+        genre_opening_profile: Optional[Dict[str, Any]] = None,
+        genre_reader_contract: Optional[Dict[str, Any]] = None,
+        genre_rhythm_constraints: Optional[Dict[str, Any]] = None,
     ) -> Prompt:
         """构建 LLM 提示词
 
@@ -1109,6 +1162,14 @@ class AutoNovelGenerationWorkflow:
                 "\n【角色声线与肢体语言（Bible 锚点，必须遵守）】\n"
                 f"{va}\n\n"
             )
+        genre_parts = []
+        if genre_opening_profile:
+            genre_parts.append(f"【类型开篇画像】\n{genre_opening_profile}")
+        if genre_reader_contract:
+            genre_parts.append(f"【类型读者契约】\n{genre_reader_contract}")
+        if genre_rhythm_constraints:
+            genre_parts.append(f"【类型节奏约束】\n{genre_rhythm_constraints}")
+        genre_profile_block = ("\n" + "\n\n".join(genre_parts) + "\n\n") if genre_parts else ""
 
         prior_in_chapter = format_prior_draft_for_prompt(chapter_draft_so_far)
         # 字数控制：像小说家一样自然收束，而非粗暴截断
@@ -1212,6 +1273,9 @@ class AutoNovelGenerationWorkflow:
             "theme_rules": theme_rules,
             "planning_section": planning_section,
             "voice_block": voice_block,
+            "genre_profile_block": genre_profile_block,
+            "behavior_protocol": "",
+            "character_state_lock": "",
             "context": context,
             "fact_lock": fact_lock,
             "shuangwen_directive": shuangwen_directive,
@@ -1219,6 +1283,8 @@ class AutoNovelGenerationWorkflow:
             "length_rule": length_rule,
             "beat_extra": beat_extra,
             "format_rules": format_rules,
+            "nervous_habits": "",
+            "allowlist_block": "",
         }
         system_message = _safe_format(system_template, system_vars)
 
@@ -1307,7 +1373,13 @@ class AutoNovelGenerationWorkflow:
 
         user_message += "\n\n开始撰写："
 
-        return Prompt(system=system_message, user=user_message)
+        prompt = Prompt(system=system_message, user=user_message)
+        return self._apply_sidecar_m4_enhancement(
+            prompt,
+            beat_prompt=beat_prompt,
+            beat_mode=beat_mode,
+            source_function="AutoNovelGenerationWorkflow._build_prompt",
+        )
 
     # ─── CPMS 模板获取辅助方法 ───
 
@@ -1387,10 +1459,16 @@ class AutoNovelGenerationWorkflow:
                 "target_words": str(target_words),
             },
         ).prompt
+        prompt = self._apply_sidecar_m4_enhancement(
+            prompt,
+            node_type="chapter_prose",
+            source_function="AutoNovelGenerationWorkflow._generate_prose_from_script",
+        )
         config = GenerationConfig()
         logger.info("  → 根据剧本生成正文 (node_key=%s)", _PROSE_FROM_SCRIPT_NODE_KEY)
         result = await self.llm_service.generate(prompt, config)
         prose = (result.content or "").strip()
+        self._record_sidecar_output_evidence(prose)
         logger.info("  ✓ 正文生成完成: %d 字符", len(prose))
         return prose
 
@@ -1474,9 +1552,18 @@ class AutoNovelGenerationWorkflow:
                 },
             ).prompt
             logger.info("  → 流式生成正文 (node_key=%s)", _PROSE_FROM_SCRIPT_NODE_KEY)
+        prompt = self._apply_sidecar_m4_enhancement(
+            prompt,
+            node_type="chapter_prose",
+            source_function="AutoNovelGenerationWorkflow._generate_prose_from_script_stream",
+        )
         config = GenerationConfig()
+        prose_parts: List[str] = []
         async for piece in service.stream_generate(prompt, config):
+            if piece:
+                prose_parts.append(piece)
             yield piece
+        self._record_sidecar_output_evidence("".join(prose_parts))
 
     async def _extract_chapter_state(self, content: str, chapter_number: int) -> ChapterState:
         """从生成的内容中提取章节状态

--- a/application/workflows/plotpilot_sidecar_m4_adapter.py
+++ b/application/workflows/plotpilot_sidecar_m4_adapter.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import sys
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+from domain.ai.value_objects.prompt import Prompt
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[4]
+SCRIPTS_ROOT = WORKSPACE_ROOT / "scripts"
+if SCRIPTS_ROOT.is_dir():
+    scripts_root = str(SCRIPTS_ROOT)
+    if scripts_root not in sys.path:
+        sys.path.insert(0, scripts_root)
+
+try:
+    from creative_sidecar.source_registry import load_writing_research_registry
+except Exception:  # pragma: no cover - optional sidecar registry may be absent
+    load_writing_research_registry = None  # type: ignore[assignment]
+
+
+DEFAULT_SELECTABLE_STATUSES = {"active"}
+DEFAULT_CAPABILITY_LIMIT = 2
+DEFAULT_METHOD_LIMIT = 1
+DEFAULT_FAILURE_LIMIT = 1
+
+
+def classify_node_type(
+    *,
+    beat_prompt: str | None = None,
+    beat_mode: bool = False,
+    node_type: str | None = None,
+) -> str:
+    explicit_node_type = (node_type or "").strip()
+    if explicit_node_type:
+        return explicit_node_type
+    if beat_mode or (beat_prompt or "").strip():
+        return "beat_prose"
+    return "chapter_prose"
+
+
+def _as_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _normalize_research_asset(asset: dict[str, Any]) -> dict[str, Any] | None:
+    asset_type = str(asset.get("asset_type") or "").strip()
+    asset_id = (
+        asset.get("asset_id")
+        or asset.get("capability_id")
+        or asset.get("method_id")
+        or asset.get("failure_id")
+        or ""
+    )
+    asset_id = str(asset_id).strip()
+    if not asset_id:
+        return None
+
+    if asset_type == "capability":
+        asset_type = "capability_card"
+    elif asset_type == "method_card":
+        asset_type = "method_card"
+    elif asset_type == "failure_case":
+        asset_type = "failure_case"
+    else:
+        asset_type = asset_type or "research_asset"
+
+    return {
+        "asset_type": asset_type,
+        "asset_id": asset_id,
+        "version": str(asset.get("version") or "0.1").strip() or "0.1",
+        "status": str(asset.get("status") or "active").strip() or "active",
+        "source": str(asset.get("source") or asset.get("source_file") or "").strip(),
+        "source_anchor": str(asset.get("source_anchor") or "").strip(),
+        "source_line": int(asset.get("source_line") or 0),
+        "node_scope": _as_list(asset.get("node_scope") or asset.get("applicable_nodes")),
+        "usage": str(asset.get("usage") or "").strip(),
+    }
+
+
+def _node_scope_score(node_type: str, node_scope: list[str]) -> int:
+    scope = set(node_scope)
+    if node_type == "beat_prose":
+        priorities = ["beat_prose", "beat_scene", "chapter_prose", "next_chapter", "chapter_structure"]
+    elif node_type == "chapter_prose":
+        priorities = ["chapter_prose", "beat_prose", "beat_scene", "next_chapter", "chapter_structure"]
+    elif node_type == "chapter_outline":
+        priorities = ["chapter_outline", "chapter_structure", "next_chapter", "beat_scene", "beat_prose"]
+    elif node_type == "outline_partition":
+        priorities = ["outline_partition", "beat_scene", "chapter_structure", "chapter_outline", "next_chapter"]
+    elif node_type in {"beat_sheet", "planning_beat_sheet"}:
+        priorities = ["beat_sheet", "beat_scene", "chapter_structure", "chapter_outline", "next_chapter"]
+    elif node_type == "main_plot":
+        priorities = ["main_plot", "next_chapter", "chapter_structure", "beat_scene", "chapter_prose"]
+    elif node_type == "dag_exec_writer":
+        priorities = ["dag_exec_writer", "chapter_prose", "beat_prose", "next_chapter", "beat_scene"]
+    elif node_type in {"planning_quick_macro", "planning_act"}:
+        priorities = [node_type, "main_plot", "chapter_structure", "next_chapter", "beat_scene"]
+    else:
+        priorities = ["chapter_prose", "beat_prose", "beat_scene", "next_chapter", "chapter_structure"]
+
+    for score, candidate in enumerate(priorities, start=1):
+        if candidate in scope:
+            return len(priorities) - score + 1
+    return 0
+
+
+def _sort_assets(node_type: str, assets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def sort_key(asset: dict[str, Any]) -> tuple[int, str]:
+        return (
+            _node_scope_score(node_type, list(asset.get("node_scope") or [])),
+            str(asset.get("asset_id") or ""),
+        )
+
+    return sorted(assets, key=sort_key, reverse=True)
+
+
+def _default_registry() -> dict[str, Any]:
+    if load_writing_research_registry is None:
+        return {"research_assets": []}
+    return load_writing_research_registry()
+
+
+def select_research_assets(
+    registry: dict[str, Any] | None = None,
+    *,
+    node_type: str,
+    max_capability_cards: int = DEFAULT_CAPABILITY_LIMIT,
+    max_method_cards: int = DEFAULT_METHOD_LIMIT,
+    max_failure_cases: int = DEFAULT_FAILURE_LIMIT,
+) -> list[dict[str, Any]]:
+    source_registry = registry or _default_registry()
+    raw_assets = source_registry.get("research_assets") or []
+    normalized: list[dict[str, Any]] = []
+    for item in raw_assets:
+        if not isinstance(item, dict):
+            continue
+        asset = _normalize_research_asset(item)
+        if asset is None:
+            continue
+        if asset["asset_type"] not in {"capability_card", "method_card", "failure_case"}:
+            continue
+        if asset["status"] not in DEFAULT_SELECTABLE_STATUSES:
+            continue
+        if not asset["node_scope"]:
+            continue
+        normalized.append(asset)
+
+    capability_cards = [asset for asset in normalized if asset["asset_type"] == "capability_card"]
+    method_cards = [asset for asset in normalized if asset["asset_type"] == "method_card"]
+    failure_cases = [asset for asset in normalized if asset["asset_type"] == "failure_case"]
+
+    selected = _sort_assets(node_type, capability_cards)[:max_capability_cards]
+    selected.extend(_sort_assets(node_type, method_cards)[:max_method_cards])
+    selected.extend(_sort_assets(node_type, failure_cases)[:max_failure_cases])
+    return selected
+
+
+def _render_sidecar_block(
+    *,
+    node_type: str,
+    native_call_boundary: dict[str, Any],
+    selected_assets: list[dict[str, Any]],
+) -> str:
+    asset_lines = []
+    for asset in selected_assets:
+        scope = ", ".join(asset.get("node_scope") or [])
+        asset_lines.append(
+            "- asset_type: {asset_type} | asset_id: {asset_id} | version: {version} | status: {status} | source: {source} | node_scope: {scope}".format(
+                asset_type=asset["asset_type"],
+                asset_id=asset["asset_id"],
+                version=asset["version"],
+                status=asset["status"],
+                source=asset["source"],
+                scope=scope,
+            )
+        )
+
+    boundary = native_call_boundary.get("source_function") or "AutoNovelGenerationWorkflow._build_prompt"
+    return "\n".join(
+        [
+            "【Sidecar M4 pre-generation】",
+            "enhancement_mode: pre_generation",
+            f"node_type: {node_type}",
+            f"native_call_boundary: {boundary}",
+            "selected research assets:",
+            *asset_lines,
+            "rules:",
+            "- Keep the original PlotPilot prompt intact.",
+            "- Use only the selected research assets for this native call.",
+            "- Do not add a post-generation rewrite.",
+        ]
+    )
+
+
+def enhance_prompt_for_plotpilot_m4(
+    prompt: Prompt,
+    *,
+    beat_prompt: str | None = None,
+    beat_mode: bool = False,
+    node_type: str | None = None,
+    native_call_boundary: dict[str, Any] | None = None,
+    registry: dict[str, Any] | None = None,
+    fail_closed: bool = False,
+) -> tuple[Prompt, dict[str, Any]]:
+    node_type = classify_node_type(beat_prompt=beat_prompt, beat_mode=beat_mode, node_type=node_type)
+    boundary = native_call_boundary or {
+        "source_file": "systems/PlotPilot/application/workflows/auto_novel_generation_workflow.py",
+        "source_function": "AutoNovelGenerationWorkflow._build_prompt",
+    }
+    trace: dict[str, Any] = {
+        "enhancement_mode": "pre_generation",
+        "node_type": node_type,
+        "selector_policy_id": f"PLOTPILOT-M4-{node_type.upper()}-DEFAULT-0001",
+        "selectable_statuses": sorted(DEFAULT_SELECTABLE_STATUSES),
+        "native_call_boundary": boundary,
+        "selected_assets": [],
+        "injected_blocks": [],
+        "sidecar_added_regeneration_count": 0,
+        "enhancement_applied": False,
+        "all_assets_resolved": False,
+        "runtime_pack_matches_selection": False,
+        "no_post_generation_rewrite": True,
+        "active_registry_writeback": False,
+    }
+
+    try:
+        selected_assets = select_research_assets(registry, node_type=node_type)
+        if not selected_assets:
+            raise ValueError("NO_SELECTABLE_RESEARCH_ASSETS")
+
+        block = _render_sidecar_block(
+            node_type=node_type,
+            native_call_boundary=boundary,
+            selected_assets=selected_assets,
+        )
+        enhanced_prompt = Prompt(system=prompt.system.rstrip() + "\n\n" + block, user=prompt.user)
+        trace["selected_assets"] = selected_assets
+        selected_asset_ids = [asset["asset_id"] for asset in selected_assets]
+        trace["selected_asset_ids"] = selected_asset_ids
+        trace["source_trace"] = {
+            "native_call_boundary": boundary,
+            "selected_asset_ids": selected_asset_ids,
+            "asset_versions": {
+                asset["asset_id"]: asset["version"]
+                for asset in selected_assets
+            },
+            "asset_sources": {
+                asset["asset_id"]: {
+                    "source": asset.get("source") or "",
+                    "source_anchor": asset.get("source_anchor") or "",
+                    "source_line": asset.get("source_line") or 0,
+                }
+                for asset in selected_assets
+            },
+        }
+        trace["injected_blocks"] = [
+            {
+                "block_id": "sidecar-m4-pre-generation",
+                "target": "system",
+                "position": "append",
+                "asset_ids": [asset["asset_id"] for asset in selected_assets],
+                "asset_count": len(selected_assets),
+                "token_estimate": max(120, 60 * len(selected_assets)),
+                "prompt_excerpt_hash": sha256(block.encode("utf-8")).hexdigest(),
+            }
+        ]
+        trace["enhancement_applied"] = True
+        trace["all_assets_resolved"] = True
+        trace["runtime_pack_matches_selection"] = True
+        return enhanced_prompt, trace
+    except Exception as exc:
+        trace["failure_reason"] = f"{type(exc).__name__}: {exc}"
+        if fail_closed:
+            raise
+        return prompt, trace

--- a/tests/unit/application/blueprint/services/test_beat_sheet_sidecar_m4.py
+++ b/tests/unit/application/blueprint/services/test_beat_sheet_sidecar_m4.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from application.blueprint.services.beat_sheet_service import BeatSheetService
+from domain.ai.value_objects.prompt import Prompt
+
+
+@pytest.mark.asyncio
+async def test_generate_beat_sheet_applies_m4_adapter_before_llm(monkeypatch):
+    import application.blueprint.services.beat_sheet_service as beat_sheet_module
+    import infrastructure.ai.prompt_utils as prompt_utils
+
+    captured_prompts = []
+    saved_sheets = []
+
+    service = BeatSheetService(
+        beat_sheet_repo=SimpleNamespace(save=AsyncMock(side_effect=saved_sheets.append)),
+        chapter_repo=Mock(),
+        storyline_repo=Mock(),
+        llm_service=SimpleNamespace(),
+        vector_store=None,
+    )
+    service._retrieve_relevant_context = AsyncMock(return_value={})
+
+    def fake_render_required_prompt(_node_key, _variables):
+        return Prompt(system="beat sheet system", user="beat sheet user")
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: beat_sheet",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    async def fake_generate(prompt, _config):
+        captured_prompts.append(prompt)
+        return SimpleNamespace(
+            content=(
+                '{"scenes": [{"title": "追车", "goal": "逼迫主角选择", '
+                '"pov_character": "阿澄", "estimated_words": 800}]}'
+            )
+        )
+
+    monkeypatch.setattr(prompt_utils, "render_required_prompt", fake_render_required_prompt)
+    monkeypatch.setattr(beat_sheet_module, "enhance_prompt_for_plotpilot_m4", fake_enhance, raising=False)
+    service.llm_service.generate = fake_generate
+
+    beat_sheet = await service.generate_beat_sheet("chapter-1", "主角追查线索。")
+
+    assert beat_sheet.get_scene_count() == 1
+    assert captured_prompts
+    assert "【Sidecar M4 pre-generation】" in captured_prompts[0].system

--- a/tests/unit/application/blueprint/services/test_setup_main_plot_suggestion_sidecar_m4.py
+++ b/tests/unit/application/blueprint/services/test_setup_main_plot_suggestion_sidecar_m4.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+import pytest
+
+from application.blueprint.services.setup_main_plot_suggestion_service import (
+    SetupMainPlotSuggestionService,
+)
+from domain.ai.services.llm_service import GenerationConfig
+from domain.ai.value_objects.prompt import Prompt
+
+
+@pytest.mark.asyncio
+async def test_suggest_options_applies_m4_adapter_before_llm(monkeypatch):
+    import application.blueprint.services.setup_main_plot_suggestion_service as main_plot_module
+
+    captured_prompts = []
+
+    class FakeLLM:
+        async def generate(self, prompt, _config):
+            captured_prompts.append(prompt)
+            return SimpleNamespace(
+                content="""
+                {
+                  "plot_options": [
+                    {"id": "option_a", "title": "A", "logline": "log", "core_conflict": "conflict", "starting_hook": "hook"},
+                    {"id": "option_b", "title": "B", "logline": "log", "core_conflict": "conflict", "starting_hook": "hook"},
+                    {"id": "option_c", "title": "C", "logline": "log", "core_conflict": "conflict", "starting_hook": "hook"}
+                  ]
+                }
+                """
+            )
+
+    service = SetupMainPlotSuggestionService.__new__(SetupMainPlotSuggestionService)
+    service._llm = FakeLLM()
+    service._build_prompt_and_config = lambda _novel_id: (
+        {"target_chapters": 60},
+        Prompt(system="main plot system", user="main plot user"),
+        GenerationConfig(),
+    )
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: main_plot",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    monkeypatch.setattr(main_plot_module, "enhance_prompt_for_plotpilot_m4", fake_enhance, raising=False)
+
+    options = await service.suggest_options("novel-1")
+
+    assert len(options) == 3
+    assert captured_prompts
+    assert "【Sidecar M4 pre-generation】" in captured_prompts[0].system

--- a/tests/unit/application/engine/dag/nodes/test_dag_sidecar_m4_nodes.py
+++ b/tests/unit/application/engine/dag/nodes/test_dag_sidecar_m4_nodes.py
@@ -1,0 +1,93 @@
+from application.engine.dag.models import NodeCategory, NodeMeta
+from application.engine.dag.registry import BaseNode
+from domain.ai.value_objects.prompt import Prompt
+
+
+class _WriterNodeForSidecarTest(BaseNode):
+    meta = NodeMeta(
+        node_type="exec_writer",
+        display_name="Writer",
+        category=NodeCategory.EXECUTION,
+    )
+
+    def get_effective_prompt(self):
+        return {
+            "system": "writer system {{outline}}",
+            "user_template": "writer user {{outline}}",
+            "source": "test",
+        }
+
+    async def execute(self, inputs, context):
+        raise NotImplementedError
+
+    def validate_inputs(self, inputs):
+        return True
+
+
+class _ValidationNodeForSidecarTest(BaseNode):
+    meta = NodeMeta(
+        node_type="val_style",
+        display_name="Style",
+        category=NodeCategory.VALIDATION,
+    )
+
+    def get_effective_prompt(self):
+        return {
+            "system": "validation system {{content}}",
+            "user_template": "validation user {{content}}",
+            "source": "test",
+        }
+
+    async def execute(self, inputs, context):
+        raise NotImplementedError
+
+    def validate_inputs(self, inputs):
+        return True
+
+
+def test_dag_exec_writer_resolve_prompt_applies_m4_adapter(monkeypatch):
+    import application.engine.dag.registry as registry_module
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: dag_exec_writer",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    monkeypatch.setattr(registry_module, "enhance_prompt_for_plotpilot_m4", fake_enhance, raising=False)
+
+    node = _WriterNodeForSidecarTest()
+    resolved = node.resolve_prompt({"outline": "章节大纲"})
+
+    assert "【Sidecar M4 pre-generation】" in resolved["system"]
+    assert resolved["sidecar_trace"]["node_type"] == "dag_exec_writer"
+    assert node._sidecar_traces[-1]["native_call_boundary"]["source_function"] == (
+        "BaseNode.resolve_prompt"
+    )
+
+
+def test_non_creative_dag_node_is_not_sidecar_enhanced(monkeypatch):
+    import application.engine.dag.registry as registry_module
+
+    calls = []
+
+    def fake_enhance(prompt, **kwargs):
+        calls.append((prompt, kwargs))
+        return prompt, {"enhancement_applied": True}
+
+    monkeypatch.setattr(registry_module, "enhance_prompt_for_plotpilot_m4", fake_enhance, raising=False)
+
+    node = _ValidationNodeForSidecarTest()
+    resolved = node.resolve_prompt({"content": "正文"})
+
+    assert calls == []
+    assert "【Sidecar M4 pre-generation】" not in resolved["system"]

--- a/tests/unit/application/engine/dag/plan/test_outline_beat_planner_sidecar_m4.py
+++ b/tests/unit/application/engine/dag/plan/test_outline_beat_planner_sidecar_m4.py
@@ -1,0 +1,86 @@
+import pytest
+
+from domain.ai.value_objects.prompt import Prompt
+
+
+class _FakeStreamLLM:
+    def __init__(self):
+        self.prompts = []
+
+    async def stream_generate(self, prompt, _config):
+        self.prompts.append(prompt)
+        yield '{"atoms": [{"id": "b1", "intent": "主角被迫作出选择", "weight": 1}]}'
+
+
+@pytest.mark.asyncio
+async def test_llm_decompose_outline_applies_m4_adapter_before_stream(monkeypatch):
+    import application.engine.dag.plan.outline_beat_planner as planner
+
+    llm = _FakeStreamLLM()
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: outline_partition",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    monkeypatch.setattr(planner, "enhance_prompt_for_plotpilot_m4", fake_enhance, raising=False)
+
+    atoms = await planner.llm_decompose_outline(
+        "主角进入废弃车站。",
+        1200,
+        system="partition system",
+        user="partition user",
+        llm_service=llm,
+    )
+
+    assert atoms
+    assert llm.prompts
+    assert "【Sidecar M4 pre-generation】" in llm.prompts[0].system
+
+
+@pytest.mark.asyncio
+async def test_build_chapter_execution_plan_keeps_outline_partition_sidecar_trace(monkeypatch):
+    import application.engine.dag.plan.outline_beat_planner as planner
+
+    llm = _FakeStreamLLM()
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: outline_partition",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    monkeypatch.setattr(planner, "enhance_prompt_for_plotpilot_m4", fake_enhance, raising=False)
+
+    plan = await planner.build_chapter_execution_plan_async(
+        "主角进入废弃车站。",
+        target_chapter_words=1200,
+        llm_system="partition system",
+        llm_user="partition user",
+        llm_service=llm,
+    )
+
+    assert plan.atoms
+    assert plan.provenance["sidecar_traces"][0]["node_type"] == "outline_partition"
+    assert plan.provenance["sidecar_traces"][0]["native_call_boundary"]["source_function"] == (
+        "outline_beat_planner.llm_decompose_outline"
+    )

--- a/tests/unit/application/workflows/test_plotpilot_sidecar_m4_adapter.py
+++ b/tests/unit/application/workflows/test_plotpilot_sidecar_m4_adapter.py
@@ -1,0 +1,130 @@
+from domain.ai.value_objects.prompt import Prompt
+
+
+def test_m4_adapter_appends_pre_generation_block_and_trace_with_active_assets():
+    from application.workflows.plotpilot_sidecar_m4_adapter import (
+        enhance_prompt_for_plotpilot_m4,
+    )
+
+    registry = {
+        "research_assets": [
+            {
+                "asset_type": "capability",
+                "asset_id": "CAP-ACTIVE",
+                "status": "active",
+                "version": "1.0",
+                "source": "cap.md",
+                "node_scope": ["beat_prose"],
+            },
+            {
+                "asset_type": "method_card",
+                "asset_id": "METHOD-ACTIVE",
+                "status": "active",
+                "version": "1.0",
+                "source": "method.md",
+                "node_scope": ["beat_scene"],
+            },
+            {
+                "asset_type": "failure_case",
+                "asset_id": "FAIL-ACTIVE",
+                "status": "active",
+                "version": "1.0",
+                "source": "fail.md",
+                "node_scope": ["chapter_prose"],
+            },
+            {
+                "asset_type": "capability",
+                "asset_id": "CAP-DRAFT",
+                "status": "draft",
+                "version": "1.0",
+                "source": "draft.md",
+                "node_scope": ["beat_prose"],
+            },
+        ]
+    }
+    prompt = Prompt(system="base system", user="base user")
+
+    enhanced, trace = enhance_prompt_for_plotpilot_m4(
+        prompt,
+        beat_prompt="beat focus",
+        beat_mode=True,
+        registry=registry,
+    )
+
+    assert enhanced.user == "base user"
+    assert "【Sidecar M4 pre-generation】" in enhanced.system
+    assert "node_type: beat_prose" in enhanced.system
+    assert "CAP-ACTIVE" in enhanced.system
+    assert "CAP-DRAFT" not in enhanced.system
+    assert trace["enhancement_mode"] == "pre_generation"
+    assert trace["node_type"] == "beat_prose"
+    assert trace["enhancement_applied"] is True
+    assert trace["sidecar_added_regeneration_count"] == 0
+    assert trace["no_post_generation_rewrite"] is True
+    assert trace["active_registry_writeback"] is False
+    assert [asset["asset_id"] for asset in trace["selected_assets"]] == [
+        "CAP-ACTIVE",
+        "METHOD-ACTIVE",
+        "FAIL-ACTIVE",
+    ]
+    assert trace["injected_blocks"][0]["target"] == "system"
+    assert trace["injected_blocks"][0]["asset_ids"] == [
+        "CAP-ACTIVE",
+        "METHOD-ACTIVE",
+        "FAIL-ACTIVE",
+    ]
+
+
+def test_m4_adapter_falls_back_with_trace_when_no_active_assets():
+    from application.workflows.plotpilot_sidecar_m4_adapter import (
+        enhance_prompt_for_plotpilot_m4,
+    )
+
+    prompt = Prompt(system="base system", user="base user")
+
+    enhanced, trace = enhance_prompt_for_plotpilot_m4(
+        prompt,
+        node_type="chapter_prose",
+        registry={"research_assets": []},
+    )
+
+    assert enhanced is prompt
+    assert trace["node_type"] == "chapter_prose"
+    assert trace["enhancement_applied"] is False
+    assert trace["sidecar_added_regeneration_count"] == 0
+    assert "NO_SELECTABLE_RESEARCH_ASSETS" in trace["failure_reason"]
+
+
+def test_m4_adapter_trace_exposes_audit_consumable_source_trace():
+    from application.workflows.plotpilot_sidecar_m4_adapter import (
+        enhance_prompt_for_plotpilot_m4,
+    )
+
+    registry = {
+        "research_assets": [
+            {
+                "asset_type": "method_card",
+                "asset_id": "METHOD-MAIN",
+                "status": "active",
+                "version": "2.1",
+                "source": "method.md",
+                "source_anchor": "主线候选方法",
+                "source_line": 12,
+                "node_scope": ["main_plot"],
+                "usage": "method_orchestration",
+            }
+        ]
+    }
+
+    _enhanced, trace = enhance_prompt_for_plotpilot_m4(
+        Prompt(system="base system", user="base user"),
+        node_type="main_plot",
+        registry=registry,
+    )
+
+    assert trace["selected_asset_ids"] == ["METHOD-MAIN"]
+    assert trace["selected_assets"][0]["source_anchor"] == "主线候选方法"
+    assert trace["selected_assets"][0]["source_line"] == 12
+    assert trace["source_trace"]["selected_asset_ids"] == ["METHOD-MAIN"]
+    assert trace["source_trace"]["asset_versions"] == {"METHOD-MAIN": "2.1"}
+    assert trace["source_trace"]["asset_sources"]["METHOD-MAIN"]["source_anchor"] == "主线候选方法"

--- a/tests/unit/application/workflows/test_plotpilot_sidecar_m4_workflow_boundary.py
+++ b/tests/unit/application/workflows/test_plotpilot_sidecar_m4_workflow_boundary.py
@@ -1,0 +1,203 @@
+from unittest.mock import Mock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from application.workflows.auto_novel_generation_workflow import AutoNovelGenerationWorkflow
+from domain.ai.value_objects.prompt import Prompt
+
+
+@pytest.fixture
+def workflow():
+    return AutoNovelGenerationWorkflow(
+        context_builder=Mock(),
+        consistency_checker=Mock(),
+        storyline_manager=Mock(),
+        plot_arc_repository=Mock(),
+        llm_service=Mock(),
+    )
+
+
+def test_build_prompt_applies_m4_adapter_before_return(workflow, monkeypatch):
+    import application.workflows.auto_novel_generation_workflow as workflow_module
+
+    calls = []
+
+    def fake_enhance(prompt, **kwargs):
+        calls.append(kwargs)
+        node_type = "beat_prose" if kwargs["beat_mode"] else "chapter_prose"
+        return (
+            Prompt(
+                system=prompt.system + f"\n\n【Sidecar M4 pre-generation】\nnode_type: {node_type}",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": node_type,
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    monkeypatch.setattr(
+        workflow_module,
+        "enhance_prompt_for_plotpilot_m4",
+        fake_enhance,
+    )
+
+    prompt = workflow._build_prompt(
+        context="CTX",
+        outline="OL",
+        beat_prompt="第 1 节拍：进入现场。",
+        beat_index=0,
+        total_beats=3,
+    )
+
+    assert calls
+    assert calls[0]["beat_mode"] is True
+    assert calls[0]["beat_prompt"] == "第 1 节拍：进入现场。"
+    assert calls[0]["native_call_boundary"]["source_function"] == (
+        "AutoNovelGenerationWorkflow._build_prompt"
+    )
+    assert "【Sidecar M4 pre-generation】" in prompt.system
+    assert "node_type: beat_prose" in prompt.system
+    assert "【Sidecar M4 pre-generation】" not in prompt.user
+    assert workflow._last_sidecar_trace["node_type"] == "beat_prose"
+    assert workflow._sidecar_traces[-1]["node_type"] == "beat_prose"
+
+
+@pytest.mark.asyncio
+async def test_suggest_outline_applies_m4_adapter_before_llm(workflow, monkeypatch):
+    import application.workflows.auto_novel_generation_workflow as workflow_module
+
+    captured_prompts = []
+    workflow.context_builder.build_context.return_value = "托管连写上下文"
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: chapter_outline",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    async def fake_generate(prompt, _config):
+        captured_prompts.append(prompt)
+        return SimpleNamespace(content="1. 主角收到线索\n2. 代价升级")
+
+    monkeypatch.setattr(workflow_module, "enhance_prompt_for_plotpilot_m4", fake_enhance)
+    workflow.llm_service.generate = AsyncMock(side_effect=fake_generate)
+
+    outline = await workflow.suggest_outline("novel-1", 4)
+
+    assert "主角收到线索" in outline
+    assert captured_prompts
+    assert "【Sidecar M4 pre-generation】" in captured_prompts[0].system
+    assert workflow._sidecar_traces[-1]["node_type"] == "chapter_outline"
+    assert workflow._sidecar_traces[-1]["native_call_boundary"]["source_function"] == (
+        "AutoNovelGenerationWorkflow.suggest_outline"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_prose_from_script_applies_m4_adapter_before_llm(workflow, monkeypatch):
+    import application.workflows.auto_novel_generation_workflow as workflow_module
+
+    captured_prompts = []
+
+    class FakeGateway:
+        def render(self, *_args, **_kwargs):
+            return SimpleNamespace(prompt=Prompt(system="prose system", user="prose user"))
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: chapter_prose",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    async def fake_generate(prompt, _config):
+        captured_prompts.append(prompt)
+        return SimpleNamespace(content="生成正文")
+
+    monkeypatch.setattr(workflow_module, "get_prompt_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(workflow_module, "enhance_prompt_for_plotpilot_m4", fake_enhance)
+    workflow.llm_service.generate = AsyncMock(side_effect=fake_generate)
+
+    prose = await workflow._generate_prose_from_script(
+        script="剧本",
+        outline="大纲",
+        target_words=1200,
+        context="上下文",
+    )
+
+    assert prose == "生成正文"
+    assert captured_prompts
+    assert "【Sidecar M4 pre-generation】" in captured_prompts[0].system
+    assert workflow._last_sidecar_trace["node_type"] == "chapter_prose"
+    assert workflow._sidecar_traces[-1]["native_call_boundary"]["source_function"] == (
+        "AutoNovelGenerationWorkflow._generate_prose_from_script"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_prose_from_script_records_output_evidence_on_sidecar_trace(
+    workflow, monkeypatch
+):
+    import application.workflows.auto_novel_generation_workflow as workflow_module
+
+    class FakeGateway:
+        def render(self, *_args, **_kwargs):
+            return SimpleNamespace(prompt=Prompt(system="prose system", user="prose user"))
+
+    def fake_enhance(prompt, **kwargs):
+        return (
+            Prompt(
+                system=prompt.system + "\n\n【Sidecar M4 pre-generation】\nnode_type: chapter_prose",
+                user=prompt.user,
+            ),
+            {
+                "enhancement_mode": "pre_generation",
+                "node_type": kwargs["node_type"],
+                "enhancement_applied": True,
+                "sidecar_added_regeneration_count": 0,
+                "native_call_boundary": kwargs["native_call_boundary"],
+            },
+        )
+
+    async def fake_generate(_prompt, _config):
+        return SimpleNamespace(content="窗外的雨线忽然停住，主角把钥匙攥进掌心。")
+
+    monkeypatch.setattr(workflow_module, "get_prompt_gateway", lambda: FakeGateway())
+    monkeypatch.setattr(workflow_module, "enhance_prompt_for_plotpilot_m4", fake_enhance)
+    workflow.llm_service.generate = AsyncMock(side_effect=fake_generate)
+
+    prose = await workflow._generate_prose_from_script(
+        script="剧本",
+        outline="大纲",
+        target_words=1200,
+    )
+
+    trace = workflow._sidecar_traces[-1]
+    assert prose == "窗外的雨线忽然停住，主角把钥匙攥进掌心。"
+    assert trace["enhancement_applied"] is True
+    assert trace["output_evidence"]["output_char_count"] == len(prose)
+    assert len(trace["output_evidence"]["output_excerpt_hash"]) == 64
+    assert trace["enhanced_before_native_call"] is True


### PR DESCRIPTION
## Summary
- Adds a Sidecar M4 pre-generation adapter that selects active writing research assets, injects them before native PlotPilot LLM calls, and records source trace metadata.
- Wires the adapter into chapter prose, beat prose, hosted outline, outline partition, beat sheet, main plot suggestions, and selected creative DAG prompt boundaries.
- Adds sidecar trace output on chapter generation results and targeted regression tests for workflow, blueprint, outline partition, and DAG boundaries.

## Problem
The M4 planning documents defined Sidecar as a default pre-generation enhancement layer, but runtime generation paths were still not consistently using the selected research assets before model calls. That meant the system could look documented while core generation nodes remained unenhanced or unauditable.

## Fix
This change keeps PlotPilot native generation calls intact and injects Sidecar context only before those calls. It records selected asset ids, versions, sources, injection trace hashes, output evidence hashes, and confirms `sidecar_added_regeneration_count == 0`. It also keeps DAG coverage scoped to creative/planning nodes so validation and unrelated review nodes are not polluted.

## Validation
- `.venv-py311/bin/python -m pytest tests/unit/application/workflows/test_auto_novel_generation_workflow.py tests/unit/application/workflows/test_plotpilot_sidecar_m4_adapter.py tests/unit/application/workflows/test_plotpilot_sidecar_m4_workflow_boundary.py tests/unit/application/dag/plan/test_outline_beat_planner_json.py tests/unit/application/engine/dag/plan/test_outline_beat_planner_sidecar_m4.py tests/unit/application/engine/dag/nodes/test_dag_sidecar_m4_nodes.py tests/unit/application/blueprint/services/test_beat_sheet_sidecar_m4.py tests/unit/application/blueprint/services/test_setup_main_plot_suggestion_sidecar_m4.py tests/unit/application/blueprint/test_setup_main_plot_suggestion_service.py tests/unit/application/services/test_setup_main_plot_suggestion_service.py tests/dag/test_registry.py tests/unit/application/engine/test_execution_beat_node_plan_contract.py -q`
- Result: 48 passed
- `.venv-py311/bin/python -m py_compile application/workflows/__init__.py application/workflows/plotpilot_sidecar_m4_adapter.py application/workflows/auto_novel_generation_workflow.py application/engine/dtos/generation_result.py application/engine/dag/plan/__init__.py application/engine/dag/plan/outline_beat_planner.py application/engine/dag/registry.py application/blueprint/services/beat_sheet_service.py application/blueprint/services/setup_main_plot_suggestion_service.py`
- Import smoke: `AutoNovelGenerationWorkflow`, `BaseNode`, and `select_research_assets(node_type="main_plot")`

## Risks
- The adapter is enabled on multiple generation boundaries, so prompt size can increase by the selected Sidecar block. Selection is capped and uses active assets only.
- Non-chapter traces are currently available through service/node state or plan provenance; this PR does not add a UI panel.
- Rollback is straightforward: revert this PR to remove the adapter wiring and tests.