### PR TITLE
fix: load knowledge in workbench context fallback

### DIFF
--- a/application/engine/services/query_service.py
+++ b/application/engine/services/query_service.py
@@ -31,7 +31,7 @@ from application.ai_invocation.autopilot.review_gate import (
 
 logger = logging.getLogger(__name__)
 
-_WORKBENCH_CONTEXT_BACKFILL_ATTEMPTED_KEY = "_workbench_context_backfill_attempted"
+_WORKBENCH_CONTEXT_BACKFILL_ATTEMPTED_KEY = "_workbench_context_backfill_v2_attempted"
 
 # 守护进程经 _update_shared_state 写入、/status 需透出的运行时字段（不在 NovelState 模型内）
 _RUNTIME_STATUS_KEYS: tuple[str, ...] = (
@@ -562,6 +562,7 @@ class QueryService:
         plot_arc = self._shared.get_plot_arc(novel_id)
         knowledge = self._shared.get_knowledge(novel_id)
         foreshadows = self._shared.get_foreshadows(novel_id)
+        triples = self._shared.get_triples(novel_id)
         chapters = self._shared.get_chapters(novel_id)
 
         # 如果共享内存中没有数据，降级到数据库查询
@@ -577,12 +578,20 @@ class QueryService:
             novel_id in self._workbench_context_backfill_attempted
             or bool(raw_state.get(_WORKBENCH_CONTEXT_BACKFILL_ATTEMPTED_KEY))
         )
-        needs_backfill = not chronicles or plot_arc is None or knowledge is None or not foreshadows
+        needs_backfill = (
+            not chronicles
+            or plot_arc is None
+            or knowledge is None
+            or not foreshadows
+            or not triples
+        )
         if needs_backfill and not backfill_attempted:
             try:
                 from application.engine.services.state_bootstrap import StateBootstrap
 
                 bootstrap = StateBootstrap()
+                if not triples:
+                    triples = bootstrap._load_triples(novel_id)
                 if not foreshadows:
                     foreshadows = bootstrap._load_foreshadows(novel_id)
                 if plot_arc is None:

--- a/application/engine/services/query_service.py
+++ b/application/engine/services/query_service.py
@@ -566,8 +566,31 @@ class QueryService:
             logger.debug(f"共享内存中没有小说 {novel_id} 的工作台数据，从数据库加载")
             return self._fallback_workbench_from_db(novel_id)
 
+        # 旧启动链路可能只预热了章节/故事线，导致作品基础、知识库、剧情弧光等为空。
+        # 这里对缺失面板做一次按需回填，避免 UI 看起来像“基础没有填”。
+        if not chronicles or plot_arc is None or knowledge is None or not foreshadows:
+            try:
+                from application.engine.services.state_bootstrap import StateBootstrap
+
+                bootstrap = StateBootstrap()
+                if not foreshadows:
+                    foreshadows = bootstrap._load_foreshadows(novel_id)
+                if plot_arc is None:
+                    plot_arc = bootstrap._load_plot_arc(novel_id)
+                if knowledge is None:
+                    knowledge = bootstrap._load_knowledge(novel_id)
+                if not chronicles:
+                    # 编年史依赖 Bible / snapshots / chapters，按需补齐依赖后再聚合。
+                    bootstrap._load_bible(novel_id)
+                    bootstrap._load_snapshots(novel_id)
+                    chapters = self._shared.get_chapters(novel_id) or chapters
+                    chronicles = bootstrap._load_chronicles(novel_id)
+            except Exception as e:
+                logger.debug("工作台上下文按需回填失败: novel=%s err=%s", novel_id, e)
+
         # 计算最大章节号
         max_ch = max((c.number for c in chapters), default=1)
+        knowledge_graph = self.get_knowledge_graph(novel_id)
 
         return WorkbenchContextResponse(
             novel_id=novel_id,
@@ -581,7 +604,7 @@ class QueryService:
             plot_arc=plot_arc,
             knowledge=knowledge,
             foreshadow_ledger=foreshadows,
-            knowledge_graph={"total_triples": 0, "by_source": {}},  # 需要单独处理
+            knowledge_graph=knowledge_graph,
             macro={"narrative_event_count": 0},  # 需要单独处理
             sandbox={"bible_character_count": 0},  # 需要单独处理
             chapters_digest=[c.to_dict() for c in chapters],
@@ -601,8 +624,18 @@ class QueryService:
             chapters_data = bootstrap._load_chapters(novel_id)
             foreshadows_data = bootstrap._load_foreshadows(novel_id)
             plot_arc_data = bootstrap._load_plot_arc(novel_id)
+            bootstrap._load_bible(novel_id)
+            triples_data = bootstrap._load_triples(novel_id)
+            bootstrap._load_snapshots(novel_id)
             knowledge_data = bootstrap._load_knowledge(novel_id)
             chronicles_data = bootstrap._load_chronicles(novel_id)
+            knowledge_graph = {
+                "total_triples": len(triples_data),
+                "by_source": {},
+            }
+            for t in triples_data:
+                src = t.get("source_type", "unknown")
+                knowledge_graph["by_source"][src] = knowledge_graph["by_source"].get(src, 0) + 1
 
             max_ch = max((c.number for c in chapters_data), default=1) if chapters_data else 1
 
@@ -618,7 +651,7 @@ class QueryService:
                 plot_arc=plot_arc_data,
                 knowledge=knowledge_data,
                 foreshadow_ledger=foreshadows_data,
-                knowledge_graph={"total_triples": 0, "by_source": {}},
+                knowledge_graph=knowledge_graph,
                 macro={"narrative_event_count": 0},
                 sandbox={"bible_character_count": 0},
                 chapters_digest=[c.to_dict() for c in chapters_data],

--- a/application/engine/services/query_service.py
+++ b/application/engine/services/query_service.py
@@ -31,6 +31,8 @@ from application.ai_invocation.autopilot.review_gate import (
 
 logger = logging.getLogger(__name__)
 
+_WORKBENCH_CONTEXT_BACKFILL_ATTEMPTED_KEY = "_workbench_context_backfill_attempted"
+
 # 守护进程经 _update_shared_state 写入、/status 需透出的运行时字段（不在 NovelState 模型内）
 _RUNTIME_STATUS_KEYS: tuple[str, ...] = (
     "writing_substep",
@@ -314,6 +316,7 @@ class QueryService:
 
     def __init__(self, shared_state: Optional[SharedStateRepository] = None):
         self._shared = shared_state or get_shared_state_repository()
+        self._workbench_context_backfill_attempted: set[str] = set()
 
     # ==================== 小说状态 ====================
 
@@ -566,9 +569,16 @@ class QueryService:
             logger.debug(f"共享内存中没有小说 {novel_id} 的工作台数据，从数据库加载")
             return self._fallback_workbench_from_db(novel_id)
 
-        # 旧启动链路可能只预热了章节/故事线，导致作品基础、知识库、剧情弧光等为空。
-        # 这里对缺失面板做一次按需回填，避免 UI 看起来像“基础没有填”。
-        if not chronicles or plot_arc is None or knowledge is None or not foreshadows:
+        # Backfill optional workbench panels once when an older bootstrap path only warmed
+        # chapters/storylines. Empty lists/None may also be a legitimate result for early
+        # novels, so cache the attempt and avoid hitting SQLite on every workbench request.
+        raw_state = self._shared.get_raw_state(novel_id) or {}
+        backfill_attempted = (
+            novel_id in self._workbench_context_backfill_attempted
+            or bool(raw_state.get(_WORKBENCH_CONTEXT_BACKFILL_ATTEMPTED_KEY))
+        )
+        needs_backfill = not chronicles or plot_arc is None or knowledge is None or not foreshadows
+        if needs_backfill and not backfill_attempted:
             try:
                 from application.engine.services.state_bootstrap import StateBootstrap
 
@@ -580,15 +590,21 @@ class QueryService:
                 if knowledge is None:
                     knowledge = bootstrap._load_knowledge(novel_id)
                 if not chronicles:
-                    # 编年史依赖 Bible / snapshots / chapters，按需补齐依赖后再聚合。
+                    # Chronicles depend on Bible / snapshots / chapters, so hydrate them first.
                     bootstrap._load_bible(novel_id)
                     bootstrap._load_snapshots(novel_id)
                     chapters = self._shared.get_chapters(novel_id) or chapters
                     chronicles = bootstrap._load_chronicles(novel_id)
             except Exception as e:
-                logger.debug("工作台上下文按需回填失败: novel=%s err=%s", novel_id, e)
+                logger.debug("Workbench context backfill failed: novel=%s err=%s", novel_id, e)
+            else:
+                self._workbench_context_backfill_attempted.add(novel_id)
+                self._shared.merge_raw_state(
+                    novel_id,
+                    **{_WORKBENCH_CONTEXT_BACKFILL_ATTEMPTED_KEY: True},
+                )
 
-        # 计算最大章节号
+        # Calculate max chapter number
         max_ch = max((c.number for c in chapters), default=1)
         knowledge_graph = self.get_knowledge_graph(novel_id)
 

--- a/application/engine/services/state_bootstrap.py
+++ b/application/engine/services/state_bootstrap.py
@@ -84,6 +84,9 @@ class StateBootstrap:
                     # 加载 Bible
                     self._load_bible(novel_id)
 
+                    # 加载叙事知识（premise lock / 章后摘要 / facts）
+                    self._load_knowledge(novel_id)
+
                     # 加载三元组
                     self._load_triples(novel_id)
 
@@ -134,6 +137,21 @@ class StateBootstrap:
 
             # 加载剧情弧光
             self._load_plot_arc(novel_id)
+
+            # 加载 Bible
+            self._load_bible(novel_id)
+
+            # 加载叙事知识
+            self._load_knowledge(novel_id)
+
+            # 加载三元组
+            self._load_triples(novel_id)
+
+            # 加载快照
+            self._load_snapshots(novel_id)
+
+            # 加载编年史
+            self._load_chronicles(novel_id)
 
             return True
 
@@ -293,6 +311,31 @@ class StateBootstrap:
                 self._shared.set_foreshadows(novel_id, entries)
                 return entries
 
+            rows = db.fetch_all(
+                """SELECT id, description, planted_chapter, due_chapter,
+                          resolved_chapter, status, importance, subtext_type
+                   FROM foreshadows
+                   WHERE novel_id = ?
+                   ORDER BY planted_chapter, importance DESC, id""",
+                (novel_id,),
+            )
+            entries = [
+                {
+                    "id": r["id"],
+                    "description": r["description"],
+                    "planted_chapter": r["planted_chapter"],
+                    "due_chapter": r["due_chapter"],
+                    "resolved_chapter": r["resolved_chapter"],
+                    "status": r["status"],
+                    "importance": r["importance"],
+                    "subtext_type": r["subtext_type"],
+                }
+                for r in rows
+            ]
+            if entries:
+                self._shared.set_foreshadows(novel_id, entries)
+                return entries
+
             return []
 
         except Exception as e:
@@ -423,6 +466,77 @@ class StateBootstrap:
 
         except Exception as e:
             logger.debug(f"加载 Bible 失败（可能不存在）: {novel_id}, {e}")
+            return None
+
+    def _load_knowledge(self, novel_id: str) -> Optional[Dict[str, Any]]:
+        """加载叙事知识到共享内存。
+
+        workbench-context 的 DB fallback 已经依赖该方法；缺失时会导致
+        “作品基础/知识库/章后摘要”在共享状态或降级读取中全部为空。
+        """
+        try:
+            from domain.novel.value_objects.novel_id import NovelId
+            from infrastructure.persistence.database.connection import get_database
+            from infrastructure.persistence.database.sqlite_knowledge_repository import (
+                SqliteKnowledgeRepository,
+            )
+
+            repo = SqliteKnowledgeRepository(get_database())
+            knowledge = repo.get_by_novel_id(NovelId(novel_id))
+
+            if not knowledge:
+                return None
+
+            chapters = [
+                {
+                    "chapter_id": ch.chapter_id,
+                    "summary": ch.summary,
+                    "key_events": ch.key_events,
+                    "open_threads": ch.open_threads,
+                    "consistency_note": ch.consistency_note,
+                    "beat_sections": list(ch.beat_sections or []),
+                    "micro_beats": list(ch.micro_beats or []),
+                    "sync_status": ch.sync_status,
+                }
+                for ch in (knowledge.chapters or [])
+            ]
+
+            facts = [
+                {
+                    "id": fact.id,
+                    "subject": fact.subject,
+                    "predicate": fact.predicate,
+                    "object": fact.object,
+                    "chapter_id": fact.chapter_id,
+                    "note": fact.note,
+                    "entity_type": fact.entity_type,
+                    "importance": fact.importance,
+                    "location_type": fact.location_type,
+                    "description": fact.description,
+                    "first_appearance": fact.first_appearance,
+                    "related_chapters": list(fact.related_chapters or []),
+                    "tags": list(fact.tags or []),
+                    "attributes": dict(fact.attributes or {}),
+                    "confidence": fact.confidence,
+                    "source_type": fact.source_type,
+                    "subject_entity_id": fact.subject_entity_id,
+                    "object_entity_id": fact.object_entity_id,
+                    "provenance": list(getattr(fact, "provenance", []) or []),
+                }
+                for fact in (knowledge.facts or [])
+            ]
+
+            knowledge_dict = {
+                "version": knowledge.version,
+                "premise_lock": knowledge.premise_lock,
+                "chapters": chapters,
+                "facts": facts,
+            }
+            self._shared.set_knowledge(novel_id, knowledge_dict)
+            return knowledge_dict
+
+        except Exception as e:
+            logger.debug(f"加载叙事知识失败（可能不存在）: {novel_id}, {e}")
             return None
 
     def _load_triples(self, novel_id: str) -> List[Dict[str, Any]]:
@@ -567,6 +681,13 @@ def refresh_narrative_contract_in_shared_state(novel_id: str) -> None:
     try:
         bootstrap = StateBootstrap()
         bootstrap._load_bible(novel_id)
+        bootstrap._load_chapters(novel_id)
+        bootstrap._load_foreshadows(novel_id)
         bootstrap._load_storylines(novel_id)
+        bootstrap._load_plot_arc(novel_id)
+        bootstrap._load_knowledge(novel_id)
+        bootstrap._load_triples(novel_id)
+        bootstrap._load_snapshots(novel_id)
+        bootstrap._load_chronicles(novel_id)
     except Exception as e:
         logger.debug("叙事契约共享状态刷新失败 novel=%s err=%s", novel_id, e)


### PR DESCRIPTION
## 变更类型

- [x] `fix` Bug 修复
- [ ] `feat` 新功能
- [ ] `refactor` 重构（不影响功能）
- [ ] `perf` 性能优化
- [ ] `docs` 文档

## Summary

Fixes a workbench context fallback failure where `QueryService._fallback_workbench_from_db()` calls `StateBootstrap._load_knowledge()`, but `StateBootstrap` did not implement that method.

## Changes

- Add `StateBootstrap._load_knowledge()` to load premise lock, chapter summaries, and knowledge facts into shared state.
- Preload Bible, knowledge, triples, snapshots, and chronicles when loading a single novel.
- Refresh the full narrative contract shared state after Bible/storyline updates.
- Add a foreshadow fallback from the `foreshadows` table when the registry row is absent.
- Return real knowledge graph counts in workbench context fallback.

## Why

Without this fix, `/api/v1/novels/{novel_id}/workbench-context` can return empty or failed fallback data even when knowledge and chapter summaries already exist in SQLite.

## Verification

- Ran Python syntax check with `py_compile` for:
  - `application/engine/services/state_bootstrap.py`
  - `application/engine/services/query_service.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workbench now performs an on-demand, one-time backfill when key narrative panels are missing, and returns a fully computed knowledge graph.
  * Shared-state initialization now loads per-novel narrative knowledge before graph triples.
  * Shared-state refresh now rehydrates a broader set of workbench elements to keep views synchronized.

* **Bug Fixes**
  * Improved consistency by computing knowledge graph details from graph triples (and source breakdowns) instead of placeholders.
  * Enhanced backfill behavior by safely handling missing data while still constructing a usable response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->